### PR TITLE
chore: remove debian/files

### DIFF
--- a/debian/files
+++ b/debian/files
@@ -1,3 +1,0 @@
-deepin-voice-note-dbgsym_1.0_amd64.deb debug optional automatic=yes
-deepin-voice-note_1.0_amd64.buildinfo devel optional
-deepin-voice-note_1.0_amd64.deb devel optional


### PR DESCRIPTION
remove debian/files to fix obs build

Log: fix obs build
Task: linuxdeepin/developer-center#3530
Influence: none