### PR TITLE
fix: 修复语音记事本删除语音文本后，新建文本时会闪现上一次删除的文本语音及一些日志打印

### DIFF
--- a/src/common/jscontent.cpp
+++ b/src/common/jscontent.cpp
@@ -95,27 +95,37 @@ bool JsContent::insertImages(const QImage &image)
 
 void JsContent::jsCallTxtChange()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     emit textChange();
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void JsContent::jsCallChannleFinish()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     emit getfontinfo();
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void JsContent::jsCallSummernoteInitFinish()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     emit loadFinsh();
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void JsContent::jsCallPopupMenu(int type, const QVariant &json)
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     emit popupMenu(type, json);
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void JsContent::jsCallPlayVoice(const QVariant &json, bool bIsSame)
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     emit playVoice(json, bIsSame);
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 QString JsContent::jsCallGetTranslation()
@@ -156,7 +166,9 @@ QVariant JsContent::callJsSynchronous(QWebEnginePage *page, const QString &funti
 
 void JsContent::jsCallSetDataFinsh()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     emit setDataFinsh();
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void JsContent::jsCallPaste(bool isVoicePaste)
@@ -171,7 +183,9 @@ void JsContent::jsCallViewPicture(const QString &imagePath)
 
 void JsContent::jsCallCreateNote()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     emit createNote();
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void JsContent::jsCallSetClipData(const QString &text, const QString &html)

--- a/src/views/leftview.cpp
+++ b/src/views/leftview.cpp
@@ -363,6 +363,7 @@ QModelIndex LeftView::setDefaultNotepadItem()
  */
 void LeftView::addFolder(VNoteFolder *folder)
 {
+    qInfo() << __LINE__ << __func__ << "正在添加记事本...";
     if (nullptr != folder) {
         QStandardItem *pItem = StandardItemCommon::createStandardItem(
             folder, StandardItemCommon::NOTEPADITEM);
@@ -373,6 +374,7 @@ void LeftView::addFolder(VNoteFolder *folder)
         setCurrentIndex(index);
     }
     this->scrollToTop();
+    qInfo() << __LINE__ << __func__ << "已添加记事本";
 }
 
 /**
@@ -411,6 +413,7 @@ bool LeftView::eventFilter(QObject *o, QEvent *e)
  */
 void LeftView::appendFolder(VNoteFolder *folder)
 {
+    qInfo() << __LINE__ << __func__ << "正在追加记事本...";
     if (nullptr != folder) {
         QStandardItem *pItem = StandardItemCommon::createStandardItem(
             folder, StandardItemCommon::NOTEPADITEM);
@@ -421,6 +424,7 @@ void LeftView::appendFolder(VNoteFolder *folder)
             root->appendRow(pItem);
         }
     }
+    qInfo() << __LINE__ << __func__ << "已追加记事本";
 }
 
 /**

--- a/src/views/vnotemainwindow.cpp
+++ b/src/views/vnotemainwindow.cpp
@@ -201,6 +201,7 @@ void VNoteMainWindow::initConnections()
 //刷新详情页显示
 void VNoteMainWindow::changeRightView(bool isMultiple)
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     m_multipleSelectWidget->setNoteNumber(m_middleView->getSelectedCount());
     if (isMultiple) {
         if (m_stackedRightMainWidget->currentWidget() == m_rightViewHolder) {
@@ -226,6 +227,7 @@ void VNoteMainWindow::changeRightView(bool isMultiple)
             m_imgInsert->setDisabled(false);
         }
     }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 /**
@@ -700,6 +702,7 @@ void VNoteMainWindow::onVNoteFoldersLoaded()
  */
 void VNoteMainWindow::onVNoteSearch()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     if (m_noteSearchEdit->lineEdit()->hasFocus()) {
         QString text = m_noteSearchEdit->text();
         if (!text.isEmpty()) {
@@ -719,6 +722,7 @@ void VNoteMainWindow::onVNoteSearch()
             setSpecialStatus(SearchEnd);
         }
     }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 /**
@@ -741,6 +745,7 @@ void VNoteMainWindow::onVNoteFolderChange(const QModelIndex &current, const QMod
 {
     Q_UNUSED(previous);
 
+    qInfo() << __LINE__ << __func__ << "start...";
     //记事本切换后刷新详情页
     changeRightView(false);
     VNoteFolder *data = static_cast<VNoteFolder *>(StandardItemCommon::getStandardItemData(current));
@@ -750,6 +755,7 @@ void VNoteMainWindow::onVNoteFolderChange(const QModelIndex &current, const QMod
         m_imgInsert->setDisabled(true);
         m_recordBar->setVisible(false);
     }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 /**
@@ -1136,6 +1142,7 @@ bool VNoteMainWindow::checkIfNeedExit()
 void VNoteMainWindow::onVNoteChange(const QModelIndex &previous)
 {
     Q_UNUSED(previous);
+    qInfo() << __LINE__ << __func__ << "start...";
 
     QModelIndex index = m_middleView->currentIndex();
     VNoteItem *data = static_cast<VNoteItem *>(StandardItemCommon::getStandardItemData(index));
@@ -1146,11 +1153,15 @@ void VNoteMainWindow::onVNoteChange(const QModelIndex &previous)
     }
     //多选笔记时不更新详情页内容
     if (!m_middleView->isMultipleSelected()) {
+        if(!m_richTextEdit->isVisible()){
+            m_richTextEdit->setVisible(true);
+        }
         m_richTextEdit->initData(data, m_searchKey, m_rightViewHasFouse);
     }
     //没有数据，插入图片按钮禁用
     m_imgInsert->setDisabled(nullptr == data);
     m_rightViewHasFouse = false;
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 /**
@@ -1332,6 +1343,7 @@ int VNoteMainWindow::loadNotepads()
  */
 void VNoteMainWindow::addNotepad()
 {
+    qInfo() << __LINE__ << __func__ << "正在新增记事本...";
     VNoteFolder itemData;
     VNoteFolderOper folderOper;
     itemData.name = folderOper.getDefaultFolderName();
@@ -1360,6 +1372,7 @@ void VNoteMainWindow::addNotepad()
 
         addNote();
     }
+    qInfo() << __LINE__ << __func__ << "已新增记事本";
 }
 
 /**
@@ -1405,6 +1418,7 @@ void VNoteMainWindow::editNotepad()
  */
 void VNoteMainWindow::addNote()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     m_middleView->clearSelection();
 
     qint64 id = m_middleView->getCurrentId();
@@ -1427,6 +1441,7 @@ void VNoteMainWindow::addNote()
         m_richTextEdit->unboundCurrentNoteData();
         m_middleView->addRowAtHead(newNote);
     }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 /**
@@ -1443,6 +1458,7 @@ void VNoteMainWindow::editNote()
  */
 void VNoteMainWindow::delNote()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     m_stackedRightMainWidget->setCurrentWidget(m_rightViewHolder);
     //记录移除前位置
     m_middleView->setNextSelection();
@@ -1452,9 +1468,18 @@ void VNoteMainWindow::delNote()
     if (noteDataList.size()) {
         //删除笔记之前先解除详情页绑定的笔记数据
         m_richTextEdit->unboundCurrentNoteData();
+        qint32 noteId = 0;
+        qint64 folderId = 0;
         for (auto noteData : noteDataList) {
             VNoteItemOper noteOper(noteData);
-            noteOper.deleteNote();
+            noteId = noteData->noteId;
+            folderId = noteData->folderId;
+            m_richTextEdit->unboundCurrentNoteData(noteData);
+            if(noteOper.deleteNote()){
+                qInfo() << "删除成功！" << folderId << noteId;
+            }else{
+                qInfo() << "删除失败！";
+            }
         }
         //Refresh the middle view
         if (m_middleView->rowCount() <= 0 && stateOperation->isSearching()) {
@@ -1466,6 +1491,7 @@ void VNoteMainWindow::delNote()
     }
     //设置移除后选中
     m_middleView->selectAfterRemoved();
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 /**
@@ -1505,6 +1531,7 @@ int VNoteMainWindow::loadNotes(VNoteFolder *folder)
  */
 int VNoteMainWindow::loadSearchNotes(const QString &key)
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     m_middleView->clearAll();
     m_middleView->setSearchKey(key);
     VNOTE_ALL_NOTES_MAP *noteAll = VNoteDataManager::instance()->getAllNotesInFolder();
@@ -1532,6 +1559,7 @@ int VNoteMainWindow::loadSearchNotes(const QString &key)
         //刷新详情页-切换至当前笔记
         m_stackedRightMainWidget->setCurrentWidget(m_rightViewHolder);
     }
+    qInfo() << __LINE__ << __func__ << "end";
     return m_middleView->rowCount();
 }
 
@@ -1576,6 +1604,7 @@ void VNoteMainWindow::onPlayPlugVoiceStop(VNVoiceBlock *voiceData)
  */
 void VNoteMainWindow::onNewNotebook()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     static struct timeval curret = {0, 0};
     static struct timeval lastPress = {0, 0};
 
@@ -1589,6 +1618,7 @@ void VNoteMainWindow::onNewNotebook()
 
         UPT(lastPress, curret);
     }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 /**
@@ -1596,6 +1626,7 @@ void VNoteMainWindow::onNewNotebook()
  */
 void VNoteMainWindow::onNewNote()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     static struct timeval curret = {0, 0};
     static struct timeval lastPress = {0, 0};
 
@@ -1606,6 +1637,7 @@ void VNoteMainWindow::onNewNote()
 
         UPT(lastPress, curret);
     }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 /**

--- a/src/views/vnotemainwindow.h
+++ b/src/views/vnotemainwindow.h
@@ -290,8 +290,8 @@ private:
     MiddleView *m_middleView {nullptr};
     WebRichTextEditor *m_richTextEdit {nullptr};
 
-    DPushButton *m_addNotepadBtn {nullptr};
-    DFloatingButton *m_addNoteBtn {nullptr};
+    DPushButton *m_addNotepadBtn {nullptr}; //新增记事本
+    DFloatingButton *m_addNoteBtn {nullptr};//新增笔记
     DAnchorsBase *m_buttonAnchor {nullptr};
 
     VNoteRecordBar *m_recordBar {nullptr};

--- a/src/views/webrichtexteditor.cpp
+++ b/src/views/webrichtexteditor.cpp
@@ -49,6 +49,7 @@ void WebRichTextEditor::initWebView()
 {
     QWebChannel *channel = new QWebChannel(this);
     JsContent *content = JsContent::instance();
+    //将js 注册到QWebChannel
     channel->registerObject("webobj", content);
     page()->setWebChannel(channel);
     QFileInfo info(webPage);
@@ -141,7 +142,9 @@ void WebRichTextEditor::initData(VNoteItem *data, const QString &reg, bool focus
     m_setFocus = focus;
     //富文本设置异步操作，解决笔记列表不实时刷新
     QTimer::singleShot(0, this, [=] {
+        qInfo() << __LINE__ << __func__ << "start...";
         setData(data, reg);
+        qInfo() << __LINE__ << __func__ << "end";
     });
 }
 
@@ -169,6 +172,7 @@ void WebRichTextEditor::insertVoiceItem(const QString &voicePath, qint64 voiceSi
 
 void WebRichTextEditor::updateNote()
 {
+    //qInfo() << __LINE__ << __func__ << "start...";
     if (m_noteData) {
         if (m_textChange) {
             QVariant result = JsContent::instance()->callJsSynchronous(page(), QString("getHtml()"));
@@ -182,6 +186,7 @@ void WebRichTextEditor::updateNote()
             m_textChange = false;
         }
     }
+    //qInfo() << __LINE__ << __func__ << "end";
 }
 
 void WebRichTextEditor::searchText(const QString &searchKey)
@@ -195,12 +200,27 @@ void WebRichTextEditor::searchText(const QString &searchKey)
 
 void WebRichTextEditor::unboundCurrentNoteData()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     //停止更新定时器
     m_updateTimer->stop();
     //手动更新
     updateNote();
     //绑定数据设置为空
     m_noteData = nullptr;
+    qInfo() << __LINE__ << __func__ << "end";
+}
+
+void WebRichTextEditor::unboundCurrentNoteData(VNoteItem *data)
+{
+    qInfo() << __LINE__ << __func__ << "start...";
+
+    if(data){
+        data->htmlCode = "<p><br></p>";
+        //将网页数据变成空白
+        JsContent::instance()->callJsSetHtml(data->htmlCode);
+
+    }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void WebRichTextEditor::onTextChange()
@@ -223,6 +243,7 @@ void WebRichTextEditor::saveMenuParam(int type, const QVariant &json)
 
 void WebRichTextEditor::onSetDataFinsh()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     //清除选中
     page()->triggerAction(QWebEnginePage::Unselect);
     //数据加载完成,需要设置焦点时需要先清除焦点再重新设置，解决编辑器无光标问题
@@ -234,6 +255,7 @@ void WebRichTextEditor::onSetDataFinsh()
     if (!m_searchKey.isEmpty()) {
         findText(m_searchKey);
     }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void WebRichTextEditor::showTxtMenu(const QPoint &pos)
@@ -647,6 +669,7 @@ void WebRichTextEditor::onHideEditToolbar()
  */
 void WebRichTextEditor::onLoadFinsh()
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     //再次设置笔记内容
     if (m_noteData && !m_loadFinshSign) {
         if (m_noteData->htmlCode.isEmpty()) {
@@ -656,10 +679,12 @@ void WebRichTextEditor::onLoadFinsh()
         }
     }
     m_loadFinshSign = true;
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 void WebRichTextEditor::setData(VNoteItem *data, const QString &reg)
 {
+    qInfo() << __LINE__ << __func__ << "start...";
     //有焦点先隐藏编辑工具栏
     if (hasFocus()) {
         emit JsContent::instance()->callJsHideEditToolbar();
@@ -692,6 +717,7 @@ void WebRichTextEditor::setData(VNoteItem *data, const QString &reg)
     } else { //笔记相同时执行搜索
         findText(reg);
     }
+    qInfo() << __LINE__ << __func__ << "end";
 }
 
 bool WebRichTextEditor::isVoicePaste()

--- a/src/views/webrichtexteditor.h
+++ b/src/views/webrichtexteditor.h
@@ -69,6 +69,11 @@ public:
     void unboundCurrentNoteData();
 
     /**
+     * @brief 解除绑定的笔记数据
+     */
+    void unboundCurrentNoteData(VNoteItem* data);
+
+    /**
      * @brief 快捷键触发右键菜单
      */
     void shortcutPopupMenu();


### PR DESCRIPTION
Description: 修复语音记事本删除语音文本后，新建文本时会闪现上一次删除的文本语音

Log: 修复语音记事本删除语音文本后，新建文本时会闪现上一次删除的文本语音

Bug: https://pms.uniontech.com/bug-view-194163.html