### PR TITLE
fix: 修复Ctrl+B加粗文本时，又新建文本笔记的问题

### DIFF
--- a/src/views/vnotemainwindow.cpp
+++ b/src/views/vnotemainwindow.cpp
@@ -2240,6 +2240,11 @@ void VNoteMainWindow::onReNameNotepadShortcut()
 
 void VNoteMainWindow::onAddNoteShortcut()
 {
+    // 焦点若在文本编辑区域，仅执行文本加粗操作，不新建文本笔记.
+    QWidget* focusWidget = this->focusWidget();
+    if (focusWidget && m_richTextEdit == focusWidget->parentWidget())
+        return;
+
     if (canDoShortcutAction()
             && !(stateOperation->isRecording()
                  || stateOperation->isPlaying()


### PR DESCRIPTION
   与产品确认：焦点在文本区域时，Ctrl+B仅执行文本加粗操作，不新建文本笔记

Log: 修复Ctrl+B加粗文本时，又新建文本笔记的问题
Bug: https://pms.uniontech.com/bug-view-151155.html