### PR TITLE
fix: 修复删除笔记后，再添加新笔记，会闪现一次删除前内容的问题

### DIFF
--- a/src/views/webrichtexteditor.cpp
+++ b/src/views/webrichtexteditor.cpp
@@ -686,6 +686,15 @@ void WebRichTextEditor::setData(VNoteItem *data, const QString &reg)
     }
 
     if (nullptr == data) {
+
+        // 清空js页面内容
+        emit JsContent::instance()->callJsSetHtml("");
+
+        // 开启100ms事件循环，保证js页面内容被刷新
+        QEventLoop eveLoop;
+        QTimer::singleShot(100, &eveLoop, SLOT(quit()));
+        eveLoop.exec();
+
         this->setVisible(false);
         //无数据时先保存之前数据
         updateNote();


### PR DESCRIPTION
    删除笔记时，清空js详情页内容，并开启100ms事件循环等待js页面刷新

Log: 修复删除笔记后，再添加新笔记，会闪现一次删除前内容的问题
Bug: https://pms.uniontech.com/bug-view-194163.html