### PR TITLE
fix: 修复编辑区由宽变窄时，气泡工具栏存在折行显示的问题

### DIFF
--- a/assets/web/index.js
+++ b/assets/web/index.js
@@ -82,6 +82,8 @@ var scrollHideFont = null  //字体滚动条定时
 var isUlOrOl = false
 const airPopoverHeight = 44  //悬浮工具栏高度
 const airPopoverWidth = 385  //悬浮工具栏宽度
+const airPopoverLeftMargin = 20 //悬浮工具栏距离编辑区左侧边距
+const airPopoverRightMargin = 15 //悬浮工具栏距离编辑区右侧边距
 
 // 翻译列表
 var tooltipContent = {
@@ -219,6 +221,30 @@ function changeContent(we, contents, $editable) {
             }
         }
         webobj.jsCallTxtChange();
+    }
+}
+
+/**
+ * 处理编辑页面大小改变事件
+ * @date 2023-05-30
+ * @param {any}
+ * @returns {any}
+ */
+window.onresize = function(){
+    updateAirPopoverPos()
+}
+
+/**
+ * 处理air-popover位置更新
+ * @date 2023-05-30
+ * @param {any} 
+ * @returns {any}
+ */
+function updateAirPopoverPos() {
+    if (!$('.note-air-popover').is(':hidden')) {
+        if (getSelectedRange().innerHTML != "") {
+            $('#summernote').summernote('airPopover.update')
+        }
     }
 }
 

--- a/assets/web/js/summernote_v9_2.js
+++ b/assets/web/js/summernote_v9_2.js
@@ -493,7 +493,7 @@
     /**
      * returns true if all of the values in the array pass the predicate truth test.
      * 通过条件返回true
-     * 
+     *
      */
     function all(array, pred) {
         for (var idx = 0, len = array.length; idx < len; idx++) {
@@ -1418,7 +1418,7 @@
     function splitNode(point, options) {
         var isSkipPaddingBlankHTML = options && options.isSkipPaddingBlankHTML;
         var isNotSplitEdgePoint = options && options.isNotSplitEdgePoint;
-        // edge case 
+        // edge case
         if (isEdgePoint(point) && (isText(point.node) || isNotSplitEdgePoint)) {
             if (isLeftEdgePoint(point)) {
                 return point.node;
@@ -7154,9 +7154,20 @@
                     let left = Math.max(bnd.left + bnd.width / 2 - 150, 0);
                     let top = bnd.top - airPopoverHeight;
                     // 左边距判断,显示区域宽度-距离左边距离<工具栏宽度
-                    if (winWidth - left < airPopoverWidth + 10) {
-                        left = winWidth - airPopoverWidth - 10
+                    if (winWidth - left < airPopoverWidth + airPopoverRightMargin) {
+                        left = winWidth - airPopoverWidth - airPopoverRightMargin
                     }
+
+                    // 根据UX意见，左边距最少20px
+                    if (left <= airPopoverLeftMargin) {
+                        // 当气泡工具栏显示不全时，让其紧贴编辑区左侧显示，
+                        // 以便能完整显示气泡工具栏内容
+                        if (left < -5)
+                            left = -5
+                        else
+                            left = airPopoverLeftMargin
+                    }
+
                     // 上边距判断，工具栏上边距不小于34（tip高度，避免遮挡）
                     if (top < 34) {
                         top = bnd.top + bnd.height + 14


### PR DESCRIPTION
  1.气泡工具栏跟随选中区域移动
  2.选中文字区域时，气泡工具栏显示位置调整：
    若编辑区较宽，显示位置与文字区域左对齐或右对齐
    若足够宽，则在选中区域附近显示气泡工具栏
    若处于最小尺寸，则紧贴编辑区左侧显示

Log: 修复编辑区由宽变窄时，气泡工具栏存在折行显示的问题
Bug: https://pms.uniontech.com/bug-view-152359.html