### PR TITLE
fix: 修复双孔耳机插入录音时，概率性出现提示输入音量过低

### DIFF
--- a/src/common/audiowatcher.cpp
+++ b/src/common/audiowatcher.cpp
@@ -311,7 +311,8 @@ void AudioWatcher::onDBusAudioPropertyChanged(QDBusMessage msg)
             if (prop == QStringLiteral("Volume")) {
                 //默认输入源音量改变
                 double inAudioPortVolume = qvariant_cast<double>(changedProps[prop]);
-                if (abs(m_inAudioPortVolume - inAudioPortVolume) <= 0.000001) {
+                qDebug() << "当前音量: " << inAudioPortVolume << "，上一次音量: " << m_inAudioPortVolume;
+                if (abs(m_inAudioPortVolume - inAudioPortVolume) >= 0.000001) {
                     qInfo() << "默认输入源音量改变:" <<  m_inAudioPortVolume << " To " << inAudioPortVolume;
                     onSourceVolumeChanged(inAudioPortVolume);
                 }
@@ -343,7 +344,7 @@ void AudioWatcher::onDBusAudioPropertyChanged(QDBusMessage msg)
             if (prop == QStringLiteral("Volume")) {
                 //默认输出源音量改变
                 double outAudioPortVolume = qvariant_cast<double>(changedProps[prop]);
-                if (abs(m_outAudioPortVolume - outAudioPortVolume) <= 0.000001) {
+                if (abs(m_outAudioPortVolume - outAudioPortVolume) >= 0.000001) {
                     qInfo() << "默认输出源音量改变:" <<  m_outAudioPortVolume << " To " << outAudioPortVolume;
                     onSourceVolumeChanged(outAudioPortVolume);
                 }

--- a/src/common/metadataparser.h
+++ b/src/common/metadataparser.h
@@ -13,6 +13,9 @@
 #include <QMap>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 
 /*
 Eg: meta-data format


### PR DESCRIPTION
Description: 由于当前音量与上次音量对比出现异常导致

Log: 修复双孔耳机插入录音时，概率性出现提示输入音量过低

Bug: https://pms.uniontech.com/bug-view-214553.html