### PR TITLE
fix: build failures due to missing includes

### DIFF
--- a/src/views/middleview.cpp
+++ b/src/views/middleview.cpp
@@ -28,6 +28,8 @@
 #include <QScrollBar>
 #include <QDrag>
 #include <QMimeData>
+#include <QThreadPool>
+#include <QStandardPaths>
 
 /**
  * @brief MiddleView::MiddleView


### PR DESCRIPTION
Fixes the following build failure:
```
/home/felix/projects/deepin/deepin-voice-note/src/views/middleview.cpp: In member function ‘void MiddleView::saveAs(SaveAsType)’:
/home/felix/projects/deepin/deepin-voice-note/src/views/middleview.cpp:283:22: error: ‘QStandardPaths’ has not been declared
  283 |         historyDir = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
      |                      ^~~~~~~~~~~~~~
/home/felix/projects/deepin/deepin-voice-note/src/views/middleview.cpp:283:55: error: ‘QStandardPaths’ has not been declared
  283 |         historyDir = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
      |                                                       ^~~~~~~~~~~~~~
/home/felix/projects/deepin/deepin-voice-note/src/views/middleview.cpp:354:5: error: ‘QThreadPool’ has not been declared
  354 |     QThreadPool::globalInstance()->start(exportWorker);
      |     ^~~~~~~~~~~
```