### PR TITLE
chore: Bump version to 6.0.14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.0.14) unstable; urgency=medium
+
+  * Adjust the audio port available range.
+
+ -- renbin <renbin@uniontech.com>  Fri, 13 Oct 2023 16:08:18 +0800
+
 deepin-voice-note (6.0.13) unstable; urgency=medium
 
   * New version 6.0.13


### PR DESCRIPTION
Bump version to 6.0.14
PR:
* https://github.com/linuxdeepin/deepin-voice-note/pull/96

Log: Bump version to 6.0.14
Issue: Bump version