### PR TITLE
fix: 不参与合成器崩溃重连

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,9 @@ DWIDGET_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
+    // Task 326583 不参与合成器崩溃重连
+    unsetenv("QT_WAYLAND_RECONNECT");
+
     PerformanceMonitor::initializeAppStart();
     if (!QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin")) {
         setenv("XDG_CURRENT_DESKTOP", "Deepin", 1);


### PR DESCRIPTION
应用涉及 GPU 加速，目前合成器重连暂未完整支持，
移除 QT_WAYLAND_RECONNECT 环境变量，不参与合成
器崩溃重连。

Log: 规避部分已知问题
Bug: https://pms.uniontech.com/bug-view-248535.html