### PR TITLE
fix:  修复无输入设备时插拔出输出设备录音图标处于高亮状态

### DIFF
--- a/src/views/vnoterecordbar.cpp
+++ b/src/views/vnoterecordbar.cpp
@@ -333,7 +333,7 @@ void VNoteRecordBar::onChangeTheme()
 void VNoteRecordBar::onDeviceEnableChanged(int mode, bool enabled)
 {
     qInfo() << "通过控制中心改变默认设备 "<< mode << "（输出设备:0 输入设备:1）使能状态！enalbed:" <<enabled;
-    if (m_currentMode == mode) {
+    if (1 == mode) {
         qInfo() << "录制按钮是否可点击？" << enabled;
         m_recordBtn->setEnabled(enabled);
     }


### PR DESCRIPTION
 无输入设备时，插入或拔出输出设备，录音图标处于高亮状态

Log:   修复无输入设备时插拔出输出设备录音图标处于高亮状态

Bug: https://pms.uniontech.com/bug-view-261835.html