### PR TITLE
fix: text color incorrect after load

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -140,7 +140,7 @@ var isShowAir = true
 var nowClickVoice = null
 var global_activeColor = ''
 var global_disableColor = ''
-var global_theme = 1
+var global_theme = 1    // theme type 1:light 2:dark
 var global_themeColor = 'transparent'  //主题色
 var scrollHide = null  //滚动条隐藏定时器
 var scrollHideFont = null  //字体滚动条定时
@@ -852,6 +852,9 @@ function setHtml(html) {
     webobj.jsCallSetDataFinsh();
     resetScroll()
     $('#summernote').summernote('editor.resetRecord')
+
+    // We need call once at init, ensure the foreground color / background color is correct.
+    switchTextColor(global_theme == 2)
 }
 
 /**


### PR DESCRIPTION
The theme may changed after save the html file,
we need to call switchTextColor() after setHtml()
to ensure the text color is correct.

Log: Fix text color incorrect after load.
Bug: https://pms.uniontech.com/bug-view-277373.html
Influence: richtext