### PR TITLE
fix: cannot launch copilot page on first start

### DIFF
--- a/src/common/vtextspeechandtrmanager.cpp
+++ b/src/common/vtextspeechandtrmanager.cpp
@@ -17,8 +17,17 @@
 #include <QStandardPaths>
 
 static const QString kUosAiBin = "uos-ai-assistant";
+static const QString kCopilotService = "com.deepin.copilot";
+static const QString kCopilotPath = "/com/deepin/copilot";
+static const QString kCopilotInterface = "com.deepin.copilot";
+static const QString kFlytekService = "com.iflytek.aiassistant";
 
-VTextSpeechAndTrManager::VTextSpeechAndTrManager(QObject *parent) {}
+VTextSpeechAndTrManager::VTextSpeechAndTrManager(QObject *parent)
+    : QObject(parent)
+    , m_copilot{new QDBusInterface(kCopilotService, kCopilotPath, kCopilotInterface)}
+{
+    m_copilot->setTimeout(2000);
+}
 
 VTextSpeechAndTrManager *VTextSpeechAndTrManager::instance()
 {
@@ -31,37 +40,14 @@ void VTextSpeechAndTrManager::checkUosAiExists()
     static std::once_flag kAiFlag;
     std::call_once(kAiFlag, [this]() {
         auto initFunc = []() {
-            QDBusConnection connection = QDBusConnection::sessionBus();
-            QDBusConnectionInterface *bus = connection.interface();
-            Status status = Disable;
-
-            if (bus->isServiceRegistered("com.iflytek.aiassistant")) {
-                status = Enable;
+            // If call dbus interface success, the uos-ai backend process started.
+            auto copilot = QSharedPointer<QDBusInterface>::create(kCopilotService, kCopilotPath, kCopilotInterface);
+            Status status = copilotInstalled(copilot);
+            if (Enable == status) {
+                status = isCopilotEnabled(copilot);
             }
 
-            if (Enable != status) {
-                // Check if install uos-ai
-                if (QStandardPaths::findExecutable(kUosAiBin).isEmpty()) {
-                    status = NotInstalled;
-                }
-
-                // Try to start uos-ai
-                if (NotInstalled != status) {
-                    QProcess process;
-                    process.setProgram(kUosAiBin);
-                    qint64 pid = 0;
-                    if (process.startDetached(&pid)) {
-                        status = Enable;
-                    }
-
-                    qInfo() << QString("Ai service not register, try to start %1, ret: %2, pid: %3")
-                                   .arg(kUosAiBin)
-                                   .arg(Enable == status)
-                                   .arg(pid);
-                } else {
-                    qInfo() << QString("Ai service not register, not found %1").arg(kUosAiBin);
-                }
-            }
+            qInfo() << QString("backend uos-ai status: %1(%2)").arg(Enable == status).arg(status);
 
             // call on non-gui thread, so queued connection.
             auto ins = VTextSpeechAndTrManager::instance();
@@ -81,8 +67,8 @@ void VTextSpeechAndTrManager::checkUosAiExists()
 bool VTextSpeechAndTrManager::isTextToSpeechInWorking()
 {
     if (m_isSpeeching) {
-        QDBusMessage stopReadingMsg = QDBusMessage::createMethodCall(
-            "com.iflytek.aiassistant", "/aiassistant/tts", "com.iflytek.aiassistant.tts", "isTTSInWorking");
+        QDBusMessage stopReadingMsg =
+            QDBusMessage::createMethodCall(kCopilotService, "/aiassistant/tts", "com.iflytek.aiassistant.tts", "isTTSInWorking");
 
         QDBusReply<bool> stopReadingStateRet = QDBusConnection::sessionBus().call(stopReadingMsg, QDBus::BlockWithGui);
         if (stopReadingStateRet.isValid()) {
@@ -101,8 +87,8 @@ bool VTextSpeechAndTrManager::isTextToSpeechInWorking()
  */
 bool VTextSpeechAndTrManager::getTextToSpeechEnable()
 {
-    QDBusMessage voiceReadingMsg = QDBusMessage::createMethodCall(
-        "com.iflytek.aiassistant", "/aiassistant/tts", "com.iflytek.aiassistant.tts", "getTTSEnable");
+    QDBusMessage voiceReadingMsg =
+        QDBusMessage::createMethodCall(kCopilotService, "/aiassistant/tts", "com.iflytek.aiassistant.tts", "getTTSEnable");
 
     QDBusReply<bool> voiceReadingStateRet = QDBusConnection::sessionBus().call(voiceReadingMsg, QDBus::BlockWithGui);
     if (voiceReadingStateRet.isValid()) {
@@ -118,8 +104,8 @@ bool VTextSpeechAndTrManager::getTextToSpeechEnable()
  */
 bool VTextSpeechAndTrManager::getSpeechToTextEnable()
 {
-    QDBusMessage dictationMsg = QDBusMessage::createMethodCall(
-        "com.iflytek.aiassistant", "/aiassistant/iat", "com.iflytek.aiassistant.iat", "getIatEnable");
+    QDBusMessage dictationMsg =
+        QDBusMessage::createMethodCall(kCopilotService, "/aiassistant/iat", "com.iflytek.aiassistant.iat", "getIatEnable");
 
     QDBusReply<bool> dictationStateRet = QDBusConnection::sessionBus().call(dictationMsg, QDBus::BlockWithGui);
     if (dictationStateRet.isValid()) {
@@ -135,8 +121,8 @@ bool VTextSpeechAndTrManager::getSpeechToTextEnable()
  */
 bool VTextSpeechAndTrManager::getTransEnable()
 {
-    QDBusMessage translateReadingMsg = QDBusMessage::createMethodCall(
-        "com.iflytek.aiassistant", "/aiassistant/trans", "com.iflytek.aiassistant.trans", "getTransEnable");
+    QDBusMessage translateReadingMsg =
+        QDBusMessage::createMethodCall(kCopilotService, "/aiassistant/trans", "com.iflytek.aiassistant.trans", "getTransEnable");
 
     QDBusReply<bool> translateStateRet = QDBusConnection::sessionBus().call(translateReadingMsg, QDBus::BlockWithGui);
     if (translateStateRet.isValid()) {
@@ -151,7 +137,7 @@ bool VTextSpeechAndTrManager::getTransEnable()
  */
 VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::onTextToSpeech()
 {
-    if (Enable != status()) {
+    if (Enable != checkValid()) {
         return status();
     }
 
@@ -159,7 +145,7 @@ VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::onTextToSpeech()
         return NoOutputDevice;
     }
 
-    QDBusInterface interface("com.iflytek.aiassistant", "/aiassistant/deepinmain", "com.iflytek.aiassistant.mainWindow");
+    QDBusInterface interface(kCopilotService, "/aiassistant/deepinmain", "com.iflytek.aiassistant.mainWindow");
     if (!interface.isValid()) {
         return Failed;
     }
@@ -184,7 +170,7 @@ VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::onStopTextToSpeech()
     }
 
     if (m_isSpeeching) {
-        QDBusInterface interface("com.iflytek.aiassistant", "/aiassistant/tts", "com.iflytek.aiassistant.tts");
+        QDBusInterface interface(kCopilotService, "/aiassistant/tts", "com.iflytek.aiassistant.tts");
         if (!interface.isValid()) {
             return Failed;
         }
@@ -201,7 +187,7 @@ VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::onStopTextToSpeech()
  */
 VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::onSpeechToText()
 {
-    if (Enable != status()) {
+    if (Enable != checkValid()) {
         return status();
     }
 
@@ -209,7 +195,7 @@ VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::onSpeechToText()
         return NoInputDevice;
     }
 
-    QDBusInterface interface("com.iflytek.aiassistant", "/aiassistant/deepinmain", "com.iflytek.aiassistant.mainWindow");
+    QDBusInterface interface(kCopilotService, "/aiassistant/deepinmain", "com.iflytek.aiassistant.mainWindow");
     if (!interface.isValid()) {
         return Failed;
     }
@@ -223,7 +209,7 @@ VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::onSpeechToText()
  */
 VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::onTextTranslate()
 {
-    if (Enable != status()) {
+    if (Enable != checkValid()) {
         return status();
     }
 
@@ -247,6 +233,66 @@ QString VTextSpeechAndTrManager::errorString(Status status)
         case NoOutputDevice:
             return QObject::tr("No audio output device detected. Please check and try again");
         default:
-            return "Unknown error";
+            // Unknown error
+            return {};
     }
+}
+
+VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::checkValid()
+{
+    switch (m_status) {
+        case NotInstalled:
+            m_status = copilotInstalled(m_copilot);
+            if (Enable != m_status) {
+                break;
+            }
+            // If uos-ai is installed, it detects whether the user agrees to the user agreement.
+            Q_FALLTHROUGH();
+        case NoUserAgreement: {
+            // Detect current state every call
+            m_status = isCopilotEnabled(m_copilot);
+            if (NoUserAgreement == m_status) {
+                launchCopilotChat(m_copilot);
+            }
+        } break;
+        default:
+            break;
+    }
+
+    return m_status;
+}
+
+VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::copilotInstalled(const QSharedPointer<QDBusInterface> &copilot)
+{
+    QDBusReply<QString> version = copilot->call("version");
+    if (version.isValid()) {
+        qInfo() << "Installed uos-ai, current version:" << version.value();
+        return Enable;
+    }
+
+    qWarning() << "Query uos-ai installed faild! Maybe need install" << version.error().message();
+    return NotInstalled;
+}
+
+VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::isCopilotEnabled(const QSharedPointer<QDBusInterface> &copilot)
+{
+    QDBusReply<bool> state = copilot->call("isCopilotEnabled");
+    if (state.isValid()) {
+        return state.value() ? Enable : NoUserAgreement;
+    }
+
+    // NOTE: Adapt old version, if dbus interface not valid, assume the user agreement agreed.
+    qWarning() << "Query uos-ai user exp state failed!" << state.error().message();
+    return Enable;
+}
+
+VTextSpeechAndTrManager::Status VTextSpeechAndTrManager::launchCopilotChat(const QSharedPointer<QDBusInterface> &copilot)
+{
+    QDBusMessage message = copilot->call("launchChatPage");
+    if (!message.errorMessage().isEmpty()) {
+        qWarning() << "Launch uos-ai chat page failed!" << message.errorMessage();
+        return Disable;
+    }
+
+    return Enable;
 }

--- a/src/common/vtextspeechandtrmanager.h
+++ b/src/common/vtextspeechandtrmanager.h
@@ -6,6 +6,9 @@
 #define VTEXTSPEECHANDTRMANAGER_H
 
 #include <QObject>
+#include <QSharedPointer>
+
+class QDBusInterface;
 
 class VTextSpeechAndTrManager : public QObject
 {
@@ -19,6 +22,7 @@ public:
         Enable,
 
         NotInstalled,
+        NoUserAgreement,    // whether the user agrees to the user agreement.
         NoInputDevice,
         NoOutputDevice,
 
@@ -54,8 +58,15 @@ private:
     // 检测文本翻译开关是否打开
     bool getTransEnable();
 
+    Status checkValid();
+
+    static Status copilotInstalled(const QSharedPointer<QDBusInterface> &copilot);
+    static Status isCopilotEnabled(const QSharedPointer<QDBusInterface> &copilot);
+    static Status launchCopilotChat(const QSharedPointer<QDBusInterface> &copilot);
+
     bool m_isSpeeching{false};
     Status m_status{NotInstalled};
+    QSharedPointer<QDBusInterface> m_copilot;
 };
 
 #endif  // VTEXTSPEECHANDTRMANAGER_H

--- a/src/handler/web_engine_handler.cpp
+++ b/src/handler/web_engine_handler.cpp
@@ -307,21 +307,30 @@ void WebEngineHandler::onMenuClicked(ActionManager::ActionKind kind)
         case ActionManager::TxtSpeech: {
             auto status = VTextSpeechAndTrManager::instance()->onTextToSpeech();
             if (VTextSpeechAndTrManager::Success != status) {
-                Q_EMIT popupToast(VTextSpeechAndTrManager::instance()->errorString(status), status);
+                QString errString = VTextSpeechAndTrManager::instance()->errorString(status);
+                if (!errString.isEmpty()) {
+                    Q_EMIT popupToast(errString, status);
+                }
             }
             break;
         }
         case ActionManager::TxtStopreading: {
             auto status = VTextSpeechAndTrManager::instance()->onStopTextToSpeech();
             if (VTextSpeechAndTrManager::Success != status) {
-                Q_EMIT popupToast(VTextSpeechAndTrManager::instance()->errorString(status), status);
+                QString errString = VTextSpeechAndTrManager::instance()->errorString(status);
+                if (!errString.isEmpty()) {
+                    Q_EMIT popupToast(errString, status);
+                }
             }
             break;
         }
         case ActionManager::TxtDictation: {
             auto status = VTextSpeechAndTrManager::instance()->onSpeechToText();
             if (VTextSpeechAndTrManager::Success != status) {
-                Q_EMIT popupToast(VTextSpeechAndTrManager::instance()->errorString(status), status);
+                QString errString = VTextSpeechAndTrManager::instance()->errorString(status);
+                if (!errString.isEmpty()) {
+                    Q_EMIT popupToast(errString, status);
+                }
             }
             break;
         }


### PR DESCRIPTION
As title. Show the Copilot page, inform users that they need to agree to the User Agreement.
Use QDBusInterface instead of QProcess to start uos-ai.

Log: Launch copilot page on first start.
Bug: https://pms.uniontech.com/bug-view-300535.html