### PR TITLE
fix: can not record voice

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -39,6 +39,11 @@ build: |
     libvlc.so
     libffmpegthumbnailer.so
     libdeepin-event-log.so
+    gstreamer-1.0/libgstcoreelements.so
+    gstreamer-1.0/libgstlame.so
+    gstreamer-1.0/libgstpulseaudio.so
+    gstreamer-1.0/libgstaudioconvert.so
+    gstreamer-1.0/libgstaudioresample.so
   )
 
   # 生成.install 文件
@@ -48,6 +53,10 @@ sources:
   # linglong:gen_deb_source sources arm64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
   # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools, qt6-webengine-dev, qt6-5compat-dev
   # linglong:gen_deb_source install libsqlite3-dev, libglib2.0-dev, libvlc-dev, libvlccore-dev, libgstreamer-plugins-base1.0-dev, libgstreamer1.0-dev, libffmpegthumbnailer-dev, libdmr-dev
+  # linglong:gen_deb_source install gstreamer1.0-plugins-good, gstreamer1.0-pulseaudio
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/adduser/adduser_3.131-1deepin2_all.deb
+    digest: 7165c1918cafcb0e026649217b0ae58a77a143a6b39650313cdfc29fd1087492
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
     digest: db24bc67c73659376f0a1eae6d7c536aaa53eb75790e6bf51916a0cb2a630fbd
@@ -64,11 +73,38 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_arm64.deb
     digest: 5fc6a22a0ad720a1b8fc7f8ef83ddfbb0c59bfa43ad383c7052cf2adf9f3d0d7
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-bin_1.14.10-3_arm64.deb
+    digest: 1897c8dfbbbfba645cccc34762612e60903f62caa3aeaecaf4fead01105f2c15
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus-broker/dbus-broker_29-3_arm64.deb
+    digest: 85ea96ecd1c36047a88b101d796617cab7fa4158f08180e7d275c799fb1ad97a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-daemon_1.14.10-3_arm64.deb
+    digest: b4917aa3272909743d1888d1b5ac53cc5037d6bf087288754f363035c25ad7c6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-session-bus-common_1.14.10-3_all.deb
+    digest: 2f9dc2fb500df63edb46c3121e6540d838047e3a9e9c5ec0cbe05649b7da3f30
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-system-bus-common_1.14.10-3_all.deb
+    digest: 2768fa6a52a3a0162988d735bd2cc7af849d3984fa9567c50092176ca36f9aa8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-user-session_1.14.10-3_arm64.deb
+    digest: 448a91177e5a302d964b6dbef0239cb11dce94e2ba757368d075f18c670ea074
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/dconf-gsettings-backend_0.40.0-2_arm64.deb
+    digest: 39dc1d77a1606055e03659ead1f05eccf5dda6ba728897aa79b077828dbd6c5d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/dconf-service_0.40.0-2_arm64.deb
+    digest: 3519e252c6decf5d942303ec032d0c56e23fd4eaf83ab2806af343d205445f5f
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
     digest: 11a42f07b2feefb7669441c3a67176cc32dc857c7d21b3290c464795fc514448
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lvm2/dmsetup_1.02.196-1_arm64.deb
+    digest: 0a5f8f1eac90849665c9517b8560227c5ccd082de45824b169b5b569669a2ce9
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
     digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
@@ -121,14 +157,44 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_arm64.deb
     digest: 1afc84a191b5f3819a8bc441315d4ab876409ec711acf1af3eda81659f9e3abb
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
+    digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking-services_2.78.0-1_arm64.deb
+    digest: e77ac51b00d8e5571476315bdfe08e4dba8a739c7d184a5c0488a29990b2eca5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking_2.78.0-1_arm64.deb
+    digest: 71a35d0dcc2e793ab413991cf7fead4c725ff13a77e2d8502c6d21d28b01b40c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gsettings-desktop-schemas/gsettings-desktop-schemas_47.1-1_all.deb
+    digest: f87ebb3a3d4d6557f779dd83909a6aa79282e7085aacf756fcc828bae36526eb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-base1.0/gstreamer1.0-plugins-base_1.24.6-1_arm64.deb
+    digest: 3a41383edb74540f114a0807a94e11e408d1de950c9eccdb3780bb8f9ffd8610
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-good1.0/gstreamer1.0-plugins-good_1.24.6-1deepin1+rb1_arm64.deb
+    digest: 353eb4c40c7d0e0c88de245841ad4f3d605d5904509708d3dc4fceb9ffbb2a01
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-good1.0/gstreamer1.0-pulseaudio_1.24.6-1deepin1+rb1_arm64.deb
+    digest: 42b8e02fff58a5a6e8efbc5c2d90ceb24a22bfea68dc6b04cf6085ef702f9170
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
+    digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
     digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aalib/libaa1_1.4p5-50_arm64.deb
+    digest: a4300e9c78b6dceadac9e66aa1066cafebee5634fcec35bc201bcc9972c8b631
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_arm64.deb
     digest: 51808064361bdae539f985645eaee59b53c703b293174f761d996b27f2b8d860
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aom/libaom3_3.9.1-1_arm64.deb
     digest: 2ac174ee086466df9fc130a81c5f9aed2932b8de1b40ef60bd116a549d4af57f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/apparmor/libapparmor1_3.0.13-2_arm64.deb
+    digest: fa147fcfcd1479df1fd0247928de71372bb590a25bb2ba55ed11c8e20152282f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libarchive/libarchive13_3.7.2-1deepin1_arm64.deb
     digest: f8199c6a03fc0179dea25ac1a7b4c798ac8a286551bad4b31c5438222ce856c2
@@ -144,6 +210,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libasyncns/libasyncns0_0.8-deepin1_arm64.deb
     digest: 6752ef532df114ff1b95a8755893ba10430d8dc817d55e2a290f1dc786f5a491
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/audit/libaudit-common_3.1.2-2_all.deb
+    digest: 5fcb4f437655bbe179c280be56fdc879d317f6ea6f3a6b865c9fa01a314fc8ca
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/audit/libaudit1_3.1.2-2_arm64.deb
+    digest: 382d7a63e8cf7aeb39f54aa3657fcb2890ae7579f27f42dba84e66cd26688e45
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_arm64.deb
     digest: caef7cbebe662623b30149c2a4301d2ffeb03071e545f030bb0cff9ba881d2da
@@ -226,6 +298,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo2_1.18.0-1_arm64.deb
     digest: 419fb5f555309b00910e51c807295f6ddf931894df73e0de206d855740333042
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap-ng/libcap-ng0_0.8.4-2deepin1_arm64.deb
+    digest: 7dc863e432010eb9425dd5f5e69431cfe290f14ca93b4969111fbf96d3110eb2
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2-bin_2.66-5_arm64.deb
     digest: 50f7cde5dc2b83935b7f99fa9955ee18b4bd8f5ac87db50e2335445885d52c55
   - kind: file
@@ -243,6 +318,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcdio/libcdio19_2.1.0-4_arm64.deb
     digest: 4eea867e82111a8670343f0cb70c870a7ac5febd22d2495768344360e8a486c5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cdparanoia/libcdparanoia0_3.10.2+debian-14_arm64.deb
+    digest: 0f387f76baccda606b4c849cd7eb8b9e644ea09d864ab73de1ed6a0e1ef26a5a
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
     digest: 39486fac0b8bd52f8641e2586befaa00aeb6a03106f3b6c99e64039c8e7b4a6e
@@ -267,6 +345,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_arm64.deb
     digest: 037584e67001e5de6f78c0d3acabe70a7b2e7dc592252ae0d9397c263c41c9f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2_arm64.deb
+    digest: 323561981b604680b9e72c6ab1d36c51bb5d95795759b03e9705270ff7998a20
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin4_arm64.deb
     digest: ba46c758512962bd4c7ec4b8a7856417ea16fd6b8eb1687b446adcf6afb83f6b
@@ -301,6 +382,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdc1394/libdc1394-25_2.2.6-4_arm64.deb
     digest: d60fff5081a93426d063bcdee8ee640311fc81a881bcf9ceaff247172fcb0885
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/libdconf1_0.40.0-2_arm64.deb
+    digest: 57f0d64bf483877f4c8e4bec0eaec73227d30795dba37aa6ce726b6816c0abef
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdecor-0/libdecor-0-0_0.1.1-2deepin0_arm64.deb
     digest: 0e7a786cfe249c8784179530ab4c4e22ccda599eff8a52f326f9698223763fb4
   - kind: file
@@ -309,6 +393,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_arm64.deb
     digest: 044cb710b30d6019492308216ead89b7a7357e4e63a2574929a85a167967f515
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lvm2/libdevmapper1.02.1_1.02.196-1_arm64.deb
+    digest: c2c9cdc97ada4d7eab5c1639ecbc586596962bbcd8e7a7c041e55255386911c0
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-movie-reborn/libdmr-dev_6.0.10_arm64.deb
     digest: 74e99c80ceb793fc0733f8e0e92904c41c2f664a2d021ea65827cc66acf48622
@@ -391,6 +478,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkwidget/libdtkwidget5_5.7.5_arm64.deb
     digest: 0bb6d99f853f3c4b37f76c992d8482a950b4e32eb365e1283f41ffeb9092952a
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdv/libdv4_1.0.0-14_arm64.deb
+    digest: 3d3f0a948d21e0f9a0ef7f5deff1381caf13ee99070d1fb9c4b9b6409ef98ad8
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdvdnav/libdvdnav4_6.1.1-1_arm64.deb
     digest: f5e805b74f43e619521c8d270fd6cc234a231bb0bfd15d3c626dc5653b28fff6
   - kind: file
@@ -436,6 +526,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_arm64.deb
     digest: 2c66c6eb5bb8e1f8dbb6449e3948e3a75add01415561c10a89ac1b238a9a24b1
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libfdisk1_2.39.3-6deepin1_arm64.deb
+    digest: a835a38111345a0ad891fe5f438f6d428789f30562a20592866054aa54b18ea1
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
     digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
   - kind: file
@@ -447,6 +540,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_arm64.deb
     digest: 5417b1bd3affb161bac0dcfd46df7ff9f431030d084a23652b9f04ef51a8ccf4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flac/libflac8_1.3.3-2_arm64.deb
     digest: 8a6209363d55641f2e981b054bf9ade88af6c0de9b966107de96d1f6a1a792dd
@@ -568,6 +664,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_arm64.deb
     digest: e67f481218dd4fc506bb97ebccacbbd39e5420caca6c71ba011b1efcc0f1f5a0
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gpm/libgpm2_1.20.7-9_arm64.deb
+    digest: 5063da57f2c3e007d9dfd8da2858f9a6b58ef9605cb598ccd837a87405487f6f
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libgprofng0_2.41-6deepin4_arm64.deb
     digest: 24f98baf5394f7976a7f9f41b9acf40df8983090e1f24b35fa66a53a0d10e0a9
   - kind: file
@@ -667,6 +766,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_arm64.deb
     digest: 127ab1d74ddbf0f1620b8a2b907d9160a359079c49fdef8e07ee6ef795b502ff
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/json-c/libjson-c5_0.17-1_arm64.deb
+    digest: 66f2fb579734b89310287f3bebb415ee73f46401cfbf07486923e7b8cbb05713
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_arm64.deb
     digest: 05fee10e849eed1621ca9bdd41b4fca3f6dd342a477e05f2eaa182f57f8319a4
   - kind: file
@@ -675,6 +777,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_arm64.deb
     digest: 91223dc8480403e5770986e2fd73b8a92ce1e74b9f52b442616cc3ef0ff59dc7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/kmod/libkmod2_30+20230601-2.1_arm64.deb
+    digest: e2a560f5d202d9c49f7f823373f5d54db3ccb5d1b155ef5eb2b0db8e49ff974f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_arm64.deb
     digest: 32e10af6aefa67b71ea312c55b8f9a3f7c016d1edc6bd30907ed38ec27aef8d8
@@ -760,11 +865,17 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_arm64.deb
     digest: 7b334d29e8aba558029270b847e25a91ccab562bdfee82d09558225eefce2705
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncurses6_6.4-4_arm64.deb
+    digest: 189d7fd965c99ea204689c7a6993161f4b069fb3c7a4ca4527176fd47a3354a8
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_arm64.deb
     digest: 4919576b45fe077f2b0f1365cafa0abb0cd29232a6bb2ffa4016df8926c64ce0
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb
     digest: 94f6240b06e89b83e43b85f3ac482f57468f7b78b3a356f692a9a2508b4b62f2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_arm64.deb
+    digest: a4a4ad6f2f5e0bf234331c7e22f12e13b7b5f52f6ee93188517427f88cda3b8f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
     digest: 06f3609b64811a80941b259736bb1f71a58633df1300b979a4458fd92a3d634e
@@ -784,6 +895,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/numactl/libnuma1_2.0.14-3deepin1_arm64.deb
     digest: 975f33301315941ea6ff79bd2e9d561f4722cb27ea10138da991cf7c86b6fb8b
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libogg/libogg0_1.3.5-3_arm64.deb
     digest: f38444dd8eefeaff0d041a17e7bd024fb08e056753ffff220c13bf770a023191
   - kind: file
@@ -792,6 +906,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openal-soft/libopenal1_1.19.1-2_arm64.deb
     digest: f08db4bd3d80d68cfdc9a22608bd40f166fdc42636b75836bdb4f0fa3e77f546
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opencore-amr/libopencore-amrnb0_0.1.5-1_arm64.deb
+    digest: 3ff8a220b18d47c0da4ff5dbc4389d8a89e709b55f0982aec298b00ad95c5dc9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opencore-amr/libopencore-amrwb0_0.1.5-1_arm64.deb
+    digest: 0955d68da228007fd327835d5e49f46cf574fbb25267d181e1ebfc248f35352a
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_arm64.deb
     digest: 4183274244acfc897705999133091b52af3c9c1ec54ed4b67319e9b044281434
@@ -819,6 +939,21 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_arm64.deb
     digest: a8cf0f0f9be1f016846baa4b2d2012fbef8b560dfc3cfa920b3d8ebb920038a4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-modules-bin_1.5.3-7_arm64.deb
+    digest: 841cc4fe4e530801fec6dfe359e27744849584e673f8177f924caa3f353a9016
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-modules_1.5.3-7_arm64.deb
+    digest: 073cd57219ed98b9b067bf03b75c808c7fa83412ab91750410e6cd2a1c9b72b9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-runtime_1.5.3-7_all.deb
+    digest: 28a2789917401d06fff5c31991bf27fc808626c5c086219df63cfe1acf978b97
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libpam-systemd_255.2-4deepin3_arm64.deb
+    digest: e3f25c7beb017168b2297be7ae2b4bdce7d102ed6f9af8b12765918d56d878cd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam0g_1.5.3-7_arm64.deb
+    digest: 80c8d2cb574ad570bd4f32ec1b0782d12c60bc77a176cb81574e45b341c249fc
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_arm64.deb
     digest: e0e7f4dc1eec6896e186bf9eb6083a22471d09b5175c5e909400fdc6a84f5bea
@@ -882,6 +1017,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_arm64.deb
     digest: 641e0a94a253612ff4e7be672d7ee28f5a9c98e263a5f065d9e4cf47dfe00681
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpsl/libpsl5_0.21.0-1.2_arm64.deb
+    digest: 906e8192d44527cb25bcbfd2a90992b25acfc3698a6b0cc6536edc6e935d64e6
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
     digest: 3c2fef66a85ca8d8219283c1402eb66500b8587fa4f4495d327515e12b71e710
@@ -1084,11 +1222,20 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsdl2/libsdl2-2.0-0_2.30.0+dfsg-1_arm64.deb
     digest: 17eaae3a3634dca799d7c6c9a061c4b1336ed54a195d651c0c0f93a16cb9e791
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libseccomp/libseccomp2_2.5.4-2deepin1+rb1_arm64.deb
+    digest: 26e1bb15a35a3b4f948bd5f869c09bad65620a0898edda93b2639b7e3cdcfd3c
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_arm64.deb
     digest: 503a2e758120d6eb2225f02eb4f509ed636560c343e42a685b68a74345c7c11d
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_arm64.deb
     digest: 9a9a27dec46d935b4ae8318b26d91c347e2adf9d6e7904f4e465c0ccfed535bc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsemanage/libsemanage-common_3.5-1deepin1_all.deb
+    digest: c4fe4277d3df3d1bbf39083659701e5f4f9857e612ef7f1185e45eedc8f27047
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsemanage/libsemanage2_3.5-1deepin1_arm64.deb
+    digest: e04714392810b1ecee7e5d525eb7ba980f5df1005b58eba5aa14d8faa6e5d799
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
@@ -1117,6 +1264,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shine/libshine3_3.1.1-2_arm64.deb
     digest: d5007b42903e1000baa20e8d02043d58152f92ffbe50275c39ae6d62b020a860
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libshout/libshout3_2.4.5-1_arm64.deb
+    digest: 5791e28b749137dc25692781e03c931fe69b4ebab724bffca7037de2e9096253
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsixel/libsixel1_1.8.6-2_arm64.deb
     digest: cd12e82e6bbf0a97bf80fcdfd1ffa342cf3ca3d69e374a7c1e3afa99bf91d8b4
   - kind: file
@@ -1125,6 +1275,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_arm64.deb
     digest: 04dcd31830a75668f1114bff0dd08033af565b7f4f05cdb411d101ccff99d6e3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libsmartcols1_2.39.3-6deepin1_arm64.deb
+    digest: 45c097e5720e7ba97ec63005aab9db05ad5e3ddae74b8d537660ac90c34ec145
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/snappy/libsnappy1v5_1.2.1-1_arm64.deb
     digest: c99a4ed8067e624491b4e6b0062688fe835b06c1db21a901e8a29926caec9d90
@@ -1140,6 +1293,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_arm64.deb
     digest: ac1056d07a450cced3125de43a15682b7cdc7060781697be7349235eb4e18093
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoup3/libsoup-3.0-0_3.4.3-1_arm64.deb
+    digest: 63d38bb5bae8c88b4b15f0696363c264c56fd409931268b8815f25c40793a928
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoup3/libsoup-3.0-common_3.4.3-1_all.deb
+    digest: 1591543d840396ea47f24a2b3287dabc0a50eeb085e07f0807cd99a4ca992f13
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoxr/libsoxr0_0.1.3-4_arm64.deb
     digest: 57472a0be9bd78ef65aa7f486c6b1236c956798c2af1152d7fd71bcc71d73bd4
@@ -1192,11 +1351,23 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd-shared_255.2-4deepin3_arm64.deb
+    digest: aa751308df49917781abd8787524b1fe1ab11e046e60fddb8569ca89869c510b
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_arm64.deb
     digest: b30e099836df2bc77e96a03c45fffdd484de29c357009cccdf95b692259f046b
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_arm64.deb
+    digest: 287d31cf9321b19b5c7d104e8e1be43c0e6c4536cd64eab2b6c9813ebe1772b5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/taglib/libtag1v5_1.12-1deepin0_arm64.deb
+    digest: b39662c030536a2562c91ab82dbfb6c876062b277fb0a0bed667030e8b288872
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_arm64.deb
     digest: a193d7e19d36227ab39cc199ed2601bd6bbb91baddaa26dad3a2530288a57cab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
     digest: 3a87af58b0b3becac7062da11264d083cd68190e7dd421c2cbd00da8841cfa25
@@ -1261,6 +1432,12 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_arm64.deb
     digest: f085d875204b2c41158ad83c96da354d4ce53c724106857b861cca425170ed2f
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/v4l-utils/libv4l-0_1.26.1-3deepin0_arm64.deb
+    digest: c342dc7093265fdea1df305d37d616cb207c64d02d366c2ac81c1baebaa6f605
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/v4l-utils/libv4lconvert0_1.26.1-3deepin0_arm64.deb
+    digest: 68f101563a5b4d73cb4083c41cd5539a9b203d063ec8cfd51f78c2f5b1cadc49
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-drm2_2.20.0-2_arm64.deb
     digest: 9a61323993ee5414465bffd67342d3f96932516459f43434b16fb82bd75508b8
   - kind: file
@@ -1278,6 +1455,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_arm64.deb
     digest: 20d3e9a821dca4e8837a2f4802b2d503fe6471b3c1767dd251786bc75701568c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvisual/libvisual-0.4-0_0.4.0-17_arm64.deb
+    digest: 00e1bd8f874d6db70d74353098cf3b2d8fd9bdad95c2a1f5c87e7038ebc34e2f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vlc/libvlc-dev_3.0.21-2_arm64.deb
     digest: 2930b0a9286a4ffdf9c9b65f3d7971e05ba7001416250bcbfcc3992279564599
@@ -1317,6 +1497,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
     digest: c07692f2fda707855dbdd2f4586f8f1acf5b9cfc9618db7c08bf3442e4b7af3a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wavpack/libwavpack1_5.4.0-1_arm64.deb
+    digest: 70141b786ff16b81fcc97a4a0a9d1717943ae760228f1617eeaef49c2acd35e0
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-bin_1.23.0-1_arm64.deb
     digest: 4713f0794701ee1f2f869473778683d66617976d58093f5a68264d11526ca4e6
@@ -1555,11 +1738,17 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/mount_2.39.3-6deepin1_arm64.deb
+    digest: c6f0b8d5d106b00a134b9927c63045da6cb5c6c219c9e442405068b912e3b0b1
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_arm64.deb
     digest: 2411c1cc39eb107516938b83b1eb50c29e9a6deb232723d65e17cbf592df8609
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shadow/passwd_4.14+dfsg1-0deepin4_arm64.deb
+    digest: 8beaef7b29607cc41c2e45a0888d3b91cee2a8e756ea0022ab5dcb8d0c5c3b36
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_arm64.deb
     digest: d69d6e60753f09647125fa0991f7bda438f75c33708a9ca01dd6f1b6b87a3bd7
@@ -1693,11 +1882,23 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shared-mime-info/shared-mime-info_2.2-1_arm64.deb
     digest: e026d478f271cdce55bcc623fea311ee9605e39bf17ee3919b2502221d0e86e0
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd-dev_255.2-4deepin3_all.deb
+    digest: 04adbe93c28391ba986f20b138a0396c74f0c8be52f59141e0a64d375a27ed43
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd-sysv_255.2-4deepin3_arm64.deb
+    digest: b98e5d9f6d97dc36ef5a2da3e830155a355facab1a5082e2547b6b89cc58e7b4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd_255.2-4deepin3_arm64.deb
+    digest: bf0a560184f620d6b4eab6d5a0ae05d50650417e0c93496be1853b830f771d2b
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb
     digest: 9e736851d33ca49a6e7ae4b188c480ea0929cb8e322da77174570c64a1037175
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/usrmerge/usrmerge_38_all.deb
+    digest: fdc636985788b18a04cd15941a111fb2a73d3b56cf58c689b918345e6f003161
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_arm64.deb
     digest: 7094c9e4b23c9651ba3bb49b5c13883ff2bcd12cd4f30d291a2c29cc4fd34d52

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -39,6 +39,11 @@ build: |
     libvlc.so
     libffmpegthumbnailer.so
     libdeepin-event-log.so
+    gstreamer-1.0/libgstcoreelements.so
+    gstreamer-1.0/libgstlame.so
+    gstreamer-1.0/libgstpulseaudio.so
+    gstreamer-1.0/libgstaudioconvert.so
+    gstreamer-1.0/libgstaudioresample.so
   )
 
   # 生成.install 文件
@@ -48,6 +53,10 @@ sources:
   # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
   # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools, qt6-webengine-dev, qt6-5compat-dev
   # linglong:gen_deb_source install libsqlite3-dev, libglib2.0-dev, libvlc-dev, libvlccore-dev, libgstreamer-plugins-base1.0-dev, libgstreamer1.0-dev, libffmpegthumbnailer-dev, libdmr-dev
+  # linglong:gen_deb_source install gstreamer1.0-plugins-good, gstreamer1.0-pulseaudio
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/adduser/adduser_3.131-1deepin2_all.deb
+    digest: 7165c1918cafcb0e026649217b0ae58a77a143a6b39650313cdfc29fd1087492
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
     digest: b6175963d3e4cf00d76fe431e75e52450bad93604945040d706d97b65cd8623d
@@ -64,11 +73,38 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_amd64.deb
     digest: a67b553f354a824475090fcd7a1b6fe237598a1445158526027f2970aa976def
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-bin_1.14.10-3_amd64.deb
+    digest: 703c756370944c7e301d5c855350dd66b8df46bdae735399138afb9dc3fffa55
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus-broker/dbus-broker_29-3_amd64.deb
+    digest: 68ff1baedb2f4ced1ff5d2f9c3e59bd21e741b7710931e0539c89ef5951df8ba
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-daemon_1.14.10-3_amd64.deb
+    digest: 85212b9f616638ca22db78bcd022e90b640aad659a6c520b178d368947599e7d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-session-bus-common_1.14.10-3_all.deb
+    digest: 2f9dc2fb500df63edb46c3121e6540d838047e3a9e9c5ec0cbe05649b7da3f30
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-system-bus-common_1.14.10-3_all.deb
+    digest: 2768fa6a52a3a0162988d735bd2cc7af849d3984fa9567c50092176ca36f9aa8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-user-session_1.14.10-3_amd64.deb
+    digest: 98dc33fb51b8eb00ad61f7dd199d3431d021c67fcdbd7e047b640a6d3fe4a636
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/dconf-gsettings-backend_0.40.0-2_amd64.deb
+    digest: 3d80cdcf5a1430426c402bfd90745303d879a7b860ef4d6f6e2df116ee4a386b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/dconf-service_0.40.0-2_amd64.deb
+    digest: e0191ee7e4fac0aa946ee39591ccf6137ac7d9fa7251c7a7abc1740cea2146ff
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
     digest: f0e1fe7a35fc386fb5944eb9bc4325c4e2d8913f43639ab6791ed3ea6084f584
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lvm2/dmsetup_1.02.196-1_amd64.deb
+    digest: 665562c1473529846f741f2fc9de4dbb799ffc4f217dee4429f8c91f507498d6
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
     digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
@@ -121,17 +157,47 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_amd64.deb
     digest: 3cbcb69c6edaebc428fc9f7c19a4a4e7a057bb980ab6b6f754561e3aee3ea011
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
+    digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking-services_2.78.0-1_amd64.deb
+    digest: 1b12a72f80bd0a62d22b922ab3c8b90bdc11ac4bf819f955cccae09853755c21
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking_2.78.0-1_amd64.deb
+    digest: 3becf1edd62d0fec815062fb84cf821dea5801f946e5191bab534e5d28f8d1d3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gsettings-desktop-schemas/gsettings-desktop-schemas_47.1-1_all.deb
+    digest: f87ebb3a3d4d6557f779dd83909a6aa79282e7085aacf756fcc828bae36526eb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-base1.0/gstreamer1.0-plugins-base_1.24.6-1_amd64.deb
+    digest: 3a15070887e53d04d0866eded24713e905f78309ead3da0bf4710654406a082f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-good1.0/gstreamer1.0-plugins-good_1.24.6-1deepin1+rb1_amd64.deb
+    digest: 7cf975e4a6a3408354939c982a922698d22c9c59f9e9cb6a044b7e2257f121e8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-good1.0/gstreamer1.0-pulseaudio_1.24.6-1deepin1+rb1_amd64.deb
+    digest: 39295c73beb8d473ab5e7ddca1f75e15e0488b55804f20648982d31531744897
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
+    digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/isa-support/isa-support_20_amd64.deb
     digest: f0b6359b69792c0a22c0e5c7b93a1fcda184bea1fa671c961af09438e1c4811a
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
     digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aalib/libaa1_1.4p5-50_amd64.deb
+    digest: 7a3de1da3ffd08698978bfab35bb32d959fa479ccf8b30d35fc9f0723fd7e973
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_amd64.deb
     digest: f06e936eb913b8e9271c17e6d8b94d9e4f0aa558d7debdc324c9484908ee8dc8
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aom/libaom3_3.9.1-1_amd64.deb
     digest: 6cfd746dd55a96fca3e058faf82c7400ddf50017bff6f7cfed6ad1f6ee637ad0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/apparmor/libapparmor1_3.0.13-2_amd64.deb
+    digest: 03d19b350ee32c5462bced7877432a39a60c71f0cdfe945ec2a63a1ea948b573
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libarchive/libarchive13_3.7.2-1deepin1_amd64.deb
     digest: 053c50d26080b3ca76dd008a365799077541208bfb23e6b1cdd67d6be0079618
@@ -147,6 +213,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libasyncns/libasyncns0_0.8-deepin1_amd64.deb
     digest: fd200e6260ccf2169de1a42591f730bfda6ff0e64a80c8eb4bc167e875cc9fcd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/audit/libaudit-common_3.1.2-2_all.deb
+    digest: 5fcb4f437655bbe179c280be56fdc879d317f6ea6f3a6b865c9fa01a314fc8ca
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/audit/libaudit1_3.1.2-2_amd64.deb
+    digest: 32e957d5e55d9bf6ea272c17c843feee2d92ad95c82cd81a8477c4c87dd65e5a
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_amd64.deb
     digest: 28bdf7a8c0529f6397921fe59358e8d94cf3d3f1e498f09e9b4035254ee15baf
@@ -229,6 +301,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo2_1.18.0-1_amd64.deb
     digest: cbf026997021678131d706318414a498b8054291185be3fa095fe8ea9fe162fc
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap-ng/libcap-ng0_0.8.4-2deepin1_amd64.deb
+    digest: 7efab9f53195e096021a501e1de215169c3be182d2a2cbdda8d561e68584860e
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2-bin_2.66-5_amd64.deb
     digest: 61428561e0fdf5ac64fb66b788f1bcf25bb8c2fd513688c27de843cc1ca2b80a
   - kind: file
@@ -246,6 +321,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcdio/libcdio19_2.1.0-4_amd64.deb
     digest: 37825fb31649756dea8c90861669a0cc84f5a02fe35cfad4b4a3f6a13e1f8f10
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cdparanoia/libcdparanoia0_3.10.2+debian-14_amd64.deb
+    digest: bf47490b840a1f50b2a98f453dc3ec61c3f52913e8ca6f74533100c8bd48ac2b
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
     digest: 1ee2dbafa2c331d58cf10cdf546c760d7a734c5d9fab1b16d2e04e51f6e38623
@@ -270,6 +348,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_amd64.deb
     digest: a7af8c9a2b767781d83f60fa32553f6a713569a0f7c4666e68dab41c46feaf1c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2_amd64.deb
+    digest: 432092c0719b0112362642094336cd4ff98a18c7ae9576ef9f113d7e1f54a21c
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin5_amd64.deb
     digest: c5320294cbb1a5a19f7eb0de0a2669a613f576db2612037a766a5bf44f766191
@@ -304,6 +385,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdc1394/libdc1394-25_2.2.6-4_amd64.deb
     digest: 6c06c202fd9c218273314883074f55ab3a3b942ff75319af502de00d65ecf252
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/libdconf1_0.40.0-2_amd64.deb
+    digest: 80248ca6b6f089cbf601cf9f5fe5f65f875a291c8413e1c93067dea6ae746f79
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdecor-0/libdecor-0-0_0.1.1-2deepin0_amd64.deb
     digest: f18e3ff04317d306f1f02e968393310456a7ca1cc4c1c5c18ebb462e78ee4d73
   - kind: file
@@ -312,6 +396,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_amd64.deb
     digest: 1b411007d982c5f2f2a6d1e2d0af7a85cbc274770e533fbd895fc54956a995ba
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lvm2/libdevmapper1.02.1_1.02.196-1_amd64.deb
+    digest: 60dc1a57537fa9ba5431e38c8573c3bb37a5a5762fcf45f02666cd2744a6a675
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-movie-reborn/libdmr-dev_6.0.10_amd64.deb
     digest: e5e9fa214b7e04fc90f19661a3fcc630818802822526bb8631190e47d5a9f331
@@ -388,6 +475,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkwidget/libdtkwidget5_5.7.5_amd64.deb
     digest: 9ac99a10cfd4fc06154fa2839f863ba0a88c795a87ae6a3872f466b1c7744111
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdv/libdv4_1.0.0-14_amd64.deb
+    digest: 4bc16faa05512b3a581c8364f8469be8532c8cb561b76dfb9712b3f68e23f1fe
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdvdnav/libdvdnav4_6.1.1-1_amd64.deb
     digest: df4c7720a1876aa6b21c9f4909e031e005553fa0010f8aef6bc62090775ee2ff
   - kind: file
@@ -433,6 +523,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_amd64.deb
     digest: 5be8be254b82a58e77549b1784520f1f7ebb395b57982f87524533e1f061f75a
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libfdisk1_2.39.3-6deepin1_amd64.deb
+    digest: 3ae1fd2b3592bb37f30d0c96082091589bfb83f50ccba23c3692ffd114213254
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
     digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
   - kind: file
@@ -444,6 +537,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_amd64.deb
     digest: 0f6db203dd26d4eebe637a1e0a50a75c99a2fb34bb81222660307ee6c0a1a9b9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flac/libflac8_1.3.3-2_amd64.deb
     digest: 176363ec9b23f4b24a1bf8f8d0523eab3a34bd5b5d995c7efa2575f5371f749b
@@ -565,6 +661,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_amd64.deb
     digest: c7c00dbad22e7c549a25c147e3d471fae76d0c22d479c0de61aac4cf60e97f36
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gpm/libgpm2_1.20.7-9_amd64.deb
+    digest: c00c715e31122bef570e1ffc5fbb122e4f0fc54f717b40dd1866aa577ca69339
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libgprofng0_2.41-6deepin5_amd64.deb
     digest: 0d8d6027c510e0e063e26a85eed097089887027ff8cdbb29cac437cba43e4675
   - kind: file
@@ -664,6 +763,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_amd64.deb
     digest: 664abd1a931622f6d14cced9ea87f3b4f201adf9616e6ef2daf1b044903f699f
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/json-c/libjson-c5_0.17-1_amd64.deb
+    digest: 4d8d2274f87aa27a15c420fabe43f7ce1c1ad16180fddba704ed107447db45ad
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_amd64.deb
     digest: e050a7e05c09e76575d85e0f909aa23ed84e2e80918a601ca753df79f5aba566
   - kind: file
@@ -672,6 +774,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_amd64.deb
     digest: 784e45679941a3e3de3d747f94f215a6fd4b3767aa0b92c4e66a43cc5d628d33
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/kmod/libkmod2_30+20230601-2.1_amd64.deb
+    digest: 74372a4857d86e72f473bb48ef74e28aa2ce59909d7f10d756bfc060b735c454
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_amd64.deb
     digest: ae4f1183b97f1f376f8caac13b739865aba4b4b77bcfec8d9dd86c85e6977411
@@ -757,11 +862,17 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_amd64.deb
     digest: 1c6cdb1193c443eb151333e709047eaaab206e22e48430fa59d298a0d7f37bb0
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncurses6_6.4-4_amd64.deb
+    digest: c77179c2998bbc269c69339d73dbfa850063deda170ddacd8c4ae422af9c9a2c
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_amd64.deb
     digest: 9993f7cfcc8cf37e6474d7b570faf1d5a19187af8a820f38cd5315461c765f2f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb
     digest: d19dd4ebabccc00232223b414732c26b63d4ee67f4147ad5a105795f4514382a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_amd64.deb
+    digest: 9221a35b50f8c23ddb78e93ea4cc66ffaf96586d38503ce4b8b61f6995739847
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
     digest: 5b552cdd40095bd94c6276021dfc5360f2a6289aa94f155ab3ab3daaef341c1d
@@ -781,6 +892,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/numactl/libnuma1_2.0.14-3deepin1_amd64.deb
     digest: 865f9d820329453a390a1c21375d7d7db3c6c68b36924eb6ac81a56cecd09874
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libogg/libogg0_1.3.5-3_amd64.deb
     digest: 6de429751d24e788ebc92ecb3e4c24c49f6aca67e0a9584f999d387bc4cefd7b
   - kind: file
@@ -789,6 +903,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openal-soft/libopenal1_1.19.1-2_amd64.deb
     digest: 6519188f969234cbdc9e3cb8346d86339b1f766db083e2519cfdc68b917e00ae
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opencore-amr/libopencore-amrnb0_0.1.5-1_amd64.deb
+    digest: ed16bb492bba32dfcc90bbc65c77903c27354c907fcdbe96d86b35e3b3e836a2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opencore-amr/libopencore-amrwb0_0.1.5-1_amd64.deb
+    digest: 0edde1c02bf7dc2c1f7cc4c44996e7e7ac73bd89e457ccec2d0a29d66ab0dbf1
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_amd64.deb
     digest: b91f22b0ab692fa36eff6fe2acc7e5878ab99d56177f3983cec1db54bd9c7f72
@@ -816,6 +936,21 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_amd64.deb
     digest: 3aae0a4770a313f4092d89d9603472fe9dbc0bfc9e69230868c168b3b30f860a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-modules-bin_1.5.3-7_amd64.deb
+    digest: 99795f56f472c634ed363a5640756161fd68f39e9ad617943f802dabc4bb84f9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-modules_1.5.3-7_amd64.deb
+    digest: ad17b289619f3c370515da12ea9302faba965168f6ced08cd68ecb2e207985b7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-runtime_1.5.3-7_all.deb
+    digest: 28a2789917401d06fff5c31991bf27fc808626c5c086219df63cfe1acf978b97
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libpam-systemd_255.2-4deepin3_amd64.deb
+    digest: cb88f03525ee38b0024ee53bcbe844d005a4b802be5ae307e27b4da49ccbc289
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam0g_1.5.3-7_amd64.deb
+    digest: 8d6d9dad048874967ea0b2d95f7370b737916ca94cf72f08d4ca2cd376e83f80
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_amd64.deb
     digest: 578da94d3d5cdecfa7206866fa668e3d34ab338366395dc4665501e61d1b7a23
@@ -879,6 +1014,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_amd64.deb
     digest: 01182c680d643f335f63ae38016fef3d5f097ab718789f9aef79de42f00517d9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpsl/libpsl5_0.21.0-1.2_amd64.deb
+    digest: 7a00b4f3ca191e7a887cbfc6b0ed619493bf5344b85c8e823577b115ec34f738
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
     digest: 8be922fba920a96d098288da4fa5f1d5dfb778b362d7a26ed738014305aa3787
@@ -1081,11 +1219,20 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsdl2/libsdl2-2.0-0_2.30.0+dfsg-1_amd64.deb
     digest: 35803e0e71d3e5ba55c48ca81f5c88d9e51e9f5b17c3acc7692027eadb282197
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libseccomp/libseccomp2_2.5.4-2deepin1+rb1_amd64.deb
+    digest: 8521b2d3819cab1ca6c752bfff3a35a7e57cd57f5acb0680b8dcef583723c54f
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_amd64.deb
     digest: ccc4c248f64dbef5e3b9711491fc93a903e4fa15d1616f5ee1bfa0a5cd82c73b
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_amd64.deb
     digest: 6702f261991679f2b5fb4643acf010396a12d3994e26dd568628f433e6f0f129
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsemanage/libsemanage-common_3.5-1deepin1_all.deb
+    digest: c4fe4277d3df3d1bbf39083659701e5f4f9857e612ef7f1185e45eedc8f27047
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsemanage/libsemanage2_3.5-1deepin1_amd64.deb
+    digest: 6f69d2a20ebe5bb06552ccc0e9c9e71d3d16bb936271ff1c1526a9a8ef35c253
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
@@ -1114,6 +1261,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shine/libshine3_3.1.1-2_amd64.deb
     digest: 6b983449633db36212a3484471299d546ef79dca6bfea56866da050aaf260b5e
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libshout/libshout3_2.4.5-1_amd64.deb
+    digest: b7d0c8f00e6353ddecc9429a2687cf123f251b5a0500336a328b65a4ce5d4042
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsixel/libsixel1_1.8.6-2_amd64.deb
     digest: c6daf227a4341eb7bc63b184834e2c5578bd366510bcefa11c6cbcba254f13e4
   - kind: file
@@ -1122,6 +1272,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_amd64.deb
     digest: d8a6d0abf65a6fe4c5edcb5fa37b115477736e60c31118df74b701a468b49cab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libsmartcols1_2.39.3-6deepin1_amd64.deb
+    digest: ea04242d62ab7a29ba1ddfdc3efbc985e416c14e6a64b608a0608743dbaf5ab3
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/snappy/libsnappy1v5_1.2.1-1_amd64.deb
     digest: f125795c50fefab5431647aad7d9de630554c254af61837893feb3fe0960efd5
@@ -1137,6 +1290,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_amd64.deb
     digest: 10dcd94952de8e379983b3ac597802fccf58aa0f11b23dbe03f406a71e08135e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoup3/libsoup-3.0-0_3.4.3-1_amd64.deb
+    digest: 9888c53cf0e3cedfe9c8f06e3e08d225b063843874a74f9d74518cb25fc182e6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoup3/libsoup-3.0-common_3.4.3-1_all.deb
+    digest: 1591543d840396ea47f24a2b3287dabc0a50eeb085e07f0807cd99a4ca992f13
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoxr/libsoxr0_0.1.3-4_amd64.deb
     digest: 9736df9018121b8368b482278a533284a82da09650baa3cb3541fa58cfbc09cd
@@ -1189,11 +1348,23 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd-shared_255.2-4deepin3_amd64.deb
+    digest: 0c8b3dab78fd0ab8e33ee5775b86edac0dbc68b2c581b7f0c011a0c0d62f2124
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_amd64.deb
     digest: 2d65df5f46dba24e2cd25605b715ea7bf4b1a23ccf2fb789f50e4a1d9c0586f4
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_amd64.deb
+    digest: 4fdd6319d141f7950b7a0581b38a34f9a2e63f35a8ff38b2ed13a7a77e80e90e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/taglib/libtag1v5_1.12-1deepin0_amd64.deb
+    digest: 6981b6a6a11c8e04e81c0e149166261c159f4860055f0dd25e3ed3cdffd14fa7
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
     digest: 3f24f7a181f374bd6623bfdc7781e2cee5d948361a456d2f6216aa4ba5c44a2e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
     digest: 3a87af58b0b3becac7062da11264d083cd68190e7dd421c2cbd00da8841cfa25
@@ -1258,6 +1429,12 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_amd64.deb
     digest: 8cc7e43d37649c4ee3595f33589716d7eea70ea4ccde666039b2b1d01a4f8413
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/v4l-utils/libv4l-0_1.26.1-3deepin0_amd64.deb
+    digest: aa9439fb952fd1ff2027164d4c6c91d6fda3aa6aab8e798b6ca93d9ab08eb257
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/v4l-utils/libv4lconvert0_1.26.1-3deepin0_amd64.deb
+    digest: 2d492ea2d77af93beaed3bdc2d24475379bd21ff9a8fad13835a626ce7f1edf4
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-drm2_2.20.0-2_amd64.deb
     digest: 3c519c4dafb6a654f92945151f133ecc09263a62a030ceef6c5357e0dd3dc731
   - kind: file
@@ -1275,6 +1452,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_amd64.deb
     digest: 1e15072d6b706e885046073d7acc1e2d792c16df0957f08d8dc1f2ae15955700
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvisual/libvisual-0.4-0_0.4.0-17_amd64.deb
+    digest: d8d2635755c1d7f682572b1e440495f0234dbaa87c003431e3e5177d7679e7af
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vlc/libvlc-dev_3.0.21-2_amd64.deb
     digest: 0fe7b6359a135699478c6dbf89daff01aba77f370468c4561f626f05853aa66f
@@ -1317,6 +1497,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
     digest: 2e0eb22e108ff3de178a570dcd21ab3d6cc16f6baf94bec37595008786789280
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wavpack/libwavpack1_5.4.0-1_amd64.deb
+    digest: 4ac1acbfdd1a76a3e42bc193729cb09e7daab9e076223aed2400817b652877f4
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-bin_1.23.0-1_amd64.deb
     digest: b0cf8f0211ca5e4a3a199f2ba2603c7b9ad9ca773d6926462c2fe75a9506b871
@@ -1555,11 +1738,17 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/mount_2.39.3-6deepin1_amd64.deb
+    digest: 1bf6ba7c9a55cd2793d59059bf1d241dd298ea1c17aa3a5495a217201492b69b
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_amd64.deb
     digest: 752849bcf3692f005746425ed4307477b665ce980135c7815538a2053e4cbfdf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shadow/passwd_4.14+dfsg1-0deepin4_amd64.deb
+    digest: 66fad35a6acb896c7243ad5d1570cef3d4d27bbcefd7318b5667fc11447a9a8a
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_amd64.deb
     digest: 4bf340095bbde164d3ca33360e3b9d89a2f92bb1912cf2b4fb21a266c2ca250c
@@ -1696,11 +1885,23 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/isa-support/sse3-support_20_amd64.deb
     digest: d3d15b6d1efd83ac8be75321a1ae64c9257a13ca6c49852253eb52d92c040d24
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd-dev_255.2-4deepin3_all.deb
+    digest: 04adbe93c28391ba986f20b138a0396c74f0c8be52f59141e0a64d375a27ed43
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd-sysv_255.2-4deepin3_amd64.deb
+    digest: 135e67bd005cfb79ae3499d5b98b7cb0b79417d5e72b33a4f0a2f1b150b400a0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd_255.2-4deepin3_amd64.deb
+    digest: 2a63852367f6adba6f2cfb2fa0a6e9a469605c5d2f5d13211a071e9807e7e8a5
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
     digest: ee27ac0010bb1525067edda7b6b86110a00550232fb154f87491dbc3a3a2c8ff
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/usrmerge/usrmerge_38_all.deb
+    digest: fdc636985788b18a04cd15941a111fb2a73d3b56cf58c689b918345e6f003161
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_amd64.deb
     digest: 0ab4e3eb8b8b386bfb3718ba57f67acd57f07ee2f1ceade1beda197c0ab4af03

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -39,6 +39,11 @@ build: |
     libvlc.so
     libffmpegthumbnailer.so
     libdeepin-event-log.so
+    gstreamer-1.0/libgstcoreelements.so
+    gstreamer-1.0/libgstlame.so
+    gstreamer-1.0/libgstpulseaudio.so
+    gstreamer-1.0/libgstaudioconvert.so
+    gstreamer-1.0/libgstaudioresample.so
   )
 
   # 生成.install 文件
@@ -48,6 +53,10 @@ sources:
   # linglong:gen_deb_source sources loong64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
   # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools, qt6-webengine-dev, qt6-5compat-dev
   # linglong:gen_deb_source install libsqlite3-dev, libglib2.0-dev, libvlc-dev, libvlccore-dev, libgstreamer-plugins-base1.0-dev, libgstreamer1.0-dev, libffmpegthumbnailer-dev, libdmr-dev
+  # linglong:gen_deb_source install gstreamer1.0-plugins-good, gstreamer1.0-pulseaudio
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/adduser/adduser_3.131-1deepin2_all.deb
+    digest: 7165c1918cafcb0e026649217b0ae58a77a143a6b39650313cdfc29fd1087492
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
     digest: f6ff5fd88f299cfe07c0c808da8795d6ba4a6add35435dde5be1a64a4403de0d
@@ -64,11 +73,38 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_loong64.deb
     digest: 08d9f48f571bc206fe4e30a27e535a3a086b9dedba4a5f5055e898ff0dbea7a6
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-bin_1.14.10-3_loong64.deb
+    digest: ce3e9d3d45cdbf7b95c18d4a5f897ee5394e658b06f2f2f489b1305d675b0781
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus-broker/dbus-broker_29-3_loong64.deb
+    digest: c32fa99bec894b1be78e1a8a8c5ac0206a3962b750aa9338387297e240b9db71
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-daemon_1.14.10-3_loong64.deb
+    digest: d45f96544cf9704e415fed35a36c1ed4ba2693f76ab464f71e8ef0370b5ca749
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-session-bus-common_1.14.10-3_all.deb
+    digest: 2f9dc2fb500df63edb46c3121e6540d838047e3a9e9c5ec0cbe05649b7da3f30
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-system-bus-common_1.14.10-3_all.deb
+    digest: 2768fa6a52a3a0162988d735bd2cc7af849d3984fa9567c50092176ca36f9aa8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/dbus-user-session_1.14.10-3_loong64.deb
+    digest: 4c9515d14bdb22c1064e839e35c5235b56ca0c06253e95fbd36032e361e7f841
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/dconf-gsettings-backend_0.40.0-2_loong64.deb
+    digest: 9a60bb442283f963ee7067aabd5591d7a100003ca4b01f19130509d4e4b1145f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/dconf-service_0.40.0-2_loong64.deb
+    digest: b363f4660223cc03a32118194cb895f40bf489d20bbfe2cf165cf44fff0f9240
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
     digest: eab43bf5b5365d2839d6c319aa489eb239a581d8fadc3132920645bf20948a70
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lvm2/dmsetup_1.02.196-1_loong64.deb
+    digest: 792f98739028972db9cc4b178abeb01f1ca2e267713313eedcc1d8fce01ffd46
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
     digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
@@ -121,14 +157,44 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_loong64.deb
     digest: df1346b7d3f97770fe21c1d05024d3d9583cfd1d4dd3da3036f8a306419eb1a1
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
+    digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking-services_2.78.0-1_loong64.deb
+    digest: cac2038581c8e79e1d77222b2bc658572c5bda68ec2a84f2850928534d7a899c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib-networking/glib-networking_2.78.0-1_loong64.deb
+    digest: 388e3237a15d2e4b1e7a685f569dcbc4583f0f271650262ecae55508308ee0f6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gsettings-desktop-schemas/gsettings-desktop-schemas_47.1-1_all.deb
+    digest: f87ebb3a3d4d6557f779dd83909a6aa79282e7085aacf756fcc828bae36526eb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-base1.0/gstreamer1.0-plugins-base_1.24.6-1_loong64.deb
+    digest: b2947d22f29389df7a80459fe217a3520482ceacec395be445ce33f6ffaeaa24
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-good1.0/gstreamer1.0-plugins-good_1.24.6-1deepin1+rb1_loong64.deb
+    digest: 2cc1604714f1bbd30f6e7fb01d10c83791050e25e65efb05d18ec1b20f854431
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gst-plugins-good1.0/gstreamer1.0-pulseaudio_1.24.6-1deepin1+rb1_loong64.deb
+    digest: 431ad6c4d1abbb6bead765827777538cdca01964ee25ec6441b5b6195caa61f5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
+    digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
     digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aalib/libaa1_1.4p5-50_loong64.deb
+    digest: 1cd24d52494e8ea394cb0f232b3ddc5a0eaa02f2a9db7dbe3b254de2c98ebf3e
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_loong64.deb
     digest: 6a5d883c7ca1fb96e88290e5f80f2310b83e190d02133676ef19fcce44b5fc39
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aom/libaom3_3.9.1-1_loong64.deb
     digest: 22bc30a8ead069539d5cad4100b0141198b3871fdcd5253189c5bfcffd14cced
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/apparmor/libapparmor1_3.0.13-2_loong64.deb
+    digest: e36a3df3b4edc54926271c4efb8cd9070de991d40ba4b23a7462ab1296148e91
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libarchive/libarchive13_3.7.2-1deepin1_loong64.deb
     digest: c24133d467efd52fca411565f9b1cba091f07b54bdbf835dd4322aae952d0c8f
@@ -150,6 +216,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/attr/libattr1_2.5.1-1_loong64.deb
     digest: 405e34b981984b1e6d04b5093fdaa36013459af4687c62c3a7dbdd0b42766ecb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/audit/libaudit-common_3.1.2-2_all.deb
+    digest: 5fcb4f437655bbe179c280be56fdc879d317f6ea6f3a6b865c9fa01a314fc8ca
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/audit/libaudit1_3.1.2-2_loong64.deb
+    digest: 542edb61c1447f4154b176659618cf97ca7aa6799a2dd5322ba20e32336e368e
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_loong64.deb
     digest: 9ccbd93fc9d06c9ddf2b4fa7a399f4695576f80624ce1742ecce86de1b31006e
@@ -232,6 +304,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo2_1.18.0-1_loong64.deb
     digest: 79927555f9e79d6b0f2e4b533853b67fea7cabb9f3fece9ff7a87684508222f1
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap-ng/libcap-ng0_0.8.4-2deepin1_loong64.deb
+    digest: 8273873be5fb356e98e3200f0666ebc6a4568e46f6457f0e14acbf9d844d1a82
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2-bin_2.66-5_loong64.deb
     digest: 0e334137263dbb4c2bbaa2aa6cab9bff8ad40125f2f7ed1dd562c6e4e6ec0ebc
   - kind: file
@@ -246,6 +321,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcdio/libcdio19_2.1.0-4_loong64.deb
     digest: 4f1824f239de11b4c4cdf184fcb467f4d6ab34acea25d26a92c79a9b26a4e873
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cdparanoia/libcdparanoia0_3.10.2+debian-14_loong64.deb
+    digest: 071fa98d030e6fde5e8be3dd95cff2bc719e017aa94f8ae9d3d4b2c4f59aac2e
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
     digest: 23c1612c4842c5ea3315b25e15d859301a5f925f439fc377b3b989d1473d142c
@@ -270,6 +348,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_loong64.deb
     digest: a9dcd576d5cd80ada64381a1727a3116545e93cf447f59c7414d1777e2993fec
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2_loong64.deb
+    digest: e1336bb3d22c37afc57bab108791e409f30c5333bdc7e01f2ac0f6d37735f2df
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin4_loong64.deb
     digest: 2865f6e5b84a2b879e3a28a2a9596658be420fe428903b5a99426a299d5d75f3
@@ -304,6 +385,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdc1394/libdc1394-25_2.2.6-4_loong64.deb
     digest: 49187cc551a3bb2bacad56903348d9863a799b4df8dec284f35f18c18bc8f8ec
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dconf/libdconf1_0.40.0-2_loong64.deb
+    digest: cc045f5e127c57d0e051177ce11347f3c46f20c345786f2082f6cf11ec00ff31
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdecor-0/libdecor-0-0_0.1.1-2deepin0_loong64.deb
     digest: a55bfbfa4b51851b1cd6ae396f889a63a931a78eaaecc540bc42abcca03dbaf3
   - kind: file
@@ -312,6 +396,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_loong64.deb
     digest: 1b60dc1dbbef61987759b5254d408edbd7d653e28b94f857de22578b0ca62dae
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lvm2/libdevmapper1.02.1_1.02.196-1_loong64.deb
+    digest: 9ec120245c4830c0eb000d2047b58e5efd04c42c538a8f76d441e25abff57ab8
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-movie-reborn/libdmr-dev_6.0.10_loong64.deb
     digest: 865e5ec867d50230baef60b177943986f715f115ce7add5b2f679435df334f1e
@@ -385,6 +472,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkwidget/libdtkwidget5_5.7.5_loong64.deb
     digest: c1bfd6954fa4498712c1299080e0610646452a3ee8d215c1b9a824efa7274e33
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdv/libdv4_1.0.0-14_loong64.deb
+    digest: 4dd720fa2ac6f19a13001f815186fbf55e002caca8d1b25ee7ec2959b732630d
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdvdnav/libdvdnav4_6.1.1-1_loong64.deb
     digest: 34fadb59f4bd3cb13ecee20d70f5b9882d21e2416a9ddf27135373fb6437c1e2
   - kind: file
@@ -421,6 +511,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_loong64.deb
     digest: 845317fb7d0fdc029f3aa98c870826391b9bdb530c6aee296fd1671ed5dd8429
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libfdisk1_2.39.3-6deepin1_loong64.deb
+    digest: 90cdc402705bd60eceee7c4f3063f5e962ce62732f2e980f71767c6b6d55ad0d
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
     digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
   - kind: file
@@ -432,6 +525,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_loong64.deb
     digest: a7db6ba0bdb19eba45a01ffee174164abf3daeb95b51ab4d800f1128e9f88782
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flac/libflac8_1.3.3-2_loong64.deb
     digest: 88b83d3414a7170f0e4ed2ba671b9cc45e5b376f3481a8154b094148a75f2fb3
@@ -553,6 +649,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_loong64.deb
     digest: 432b4819ad1edb46e6d8116596212dbc3a82d0d34c93c3574ded8db352188c8c
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gpm/libgpm2_1.20.7-9_loong64.deb
+    digest: d6e713e40df887e5b6608bbfc747d3355e4c46669974bc7cf11198429f19b90d
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
     digest: 3fc95b46c6dc87a3991386255c381d00c68a6ae6bfb4390ccb05f8cc61949331
   - kind: file
@@ -649,6 +748,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_loong64.deb
     digest: 47df0f4474b4722b6a741b7c8b33057f38f58245efa92c176abd489665e92c1f
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/json-c/libjson-c5_0.17-1_loong64.deb
+    digest: 2978e7ce51b13758c61ad11b5961c50b91ba6c779edf08a0c4fbb56b5c2aa99a
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_loong64.deb
     digest: ff74443d44dd44adb4aba8829d58bb89ad9bc7bcb934b5bd7f7b578fc86b9f73
   - kind: file
@@ -657,6 +759,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_loong64.deb
     digest: 0f7646fd6ba7bcf29756eac9b72ce2b03ad5de6d90e131ce0ab97e51f1da29ab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/kmod/libkmod2_30+20230601-2.1_loong64.deb
+    digest: 500ef5f0d6bfa0ee386b8300bf8f4daf6ca984e2d3866e16c91affc006d82f31
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_loong64.deb
     digest: 071d32ffb73b3feca3d9135ec6109730728b20f40dc194abb24d3f4506c964ef
@@ -742,11 +847,17 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_loong64.deb
     digest: af51c3ea198343b87345b6699d46a0610d20bc9d6064d15ef51125edc5972d08
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncurses6_6.4-4_loong64.deb
+    digest: 97027cacc48e63b806ca0903d726499afd5e05d1f07e5dde9c27a26d543ba277
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_loong64.deb
     digest: 4db1ea7ab75ab8e38d6ea0e9c408766dd8328c84ded9e53aae7f6bba29e8e7e7
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_loong64.deb
     digest: b49e593029d91c73f2240ffb5f129e3a47f613aadbf8ab5f50d592b2a5abdc98
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_loong64.deb
+    digest: 73c2009828b2dbd6d42c3d6f2c48f38b6c0ba6887c71bf4bf10e997d4072ca08
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
     digest: b8ccd5bf943ded55cccdc92d59c8abb35a1fb65fc3425ebe35670d37b7bdad6f
@@ -763,6 +874,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nss/libnss3_3.105-2_loong64.deb
     digest: 4b1bd5b0e058d5ca0741f52307ff0d09404d1ff98770b3b1eecdc55c576c65d8
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libogg/libogg0_1.3.5-3_loong64.deb
     digest: 45f908be81e813e6326426acd4c5675adac085383a93bf5b87bee2942a2152bd
   - kind: file
@@ -771,6 +885,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openal-soft/libopenal1_1.19.1-2_loong64.deb
     digest: 7ac233c2f743368fa3db292a6c04a824dbf1bc4817cb40f49fd457b96d51f33e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opencore-amr/libopencore-amrnb0_0.1.5-1_loong64.deb
+    digest: 34cd9ed4991403b3d7bfbb65d4ffae68964f8b6f748a87dac9e0489164f8ae61
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opencore-amr/libopencore-amrwb0_0.1.5-1_loong64.deb
+    digest: 44ed8e5eb2ce6ee9c56af00c27ce64a2985ae1311de35dc9417b9fc30faa6ccc
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_loong64.deb
     digest: 72259f4ed0b1127c554e3747b8763fc18659dc5178fc2fe32ada313357c1802a
@@ -798,6 +918,21 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_loong64.deb
     digest: 75dc180effd2912fd0a127952cc27c52ff0e900d7c8b79f3bb4b0d1ac1a120e3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-modules-bin_1.5.3-7_loong64.deb
+    digest: 5dc50dd145785e30648e42fb91db3f31b806735e7b10a968c48d7d7375847715
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-modules_1.5.3-7_loong64.deb
+    digest: cf7355e65a3df43639cdbed9d796ad620f979f24e6050fab418d48e604a91f76
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam-runtime_1.5.3-7_all.deb
+    digest: 28a2789917401d06fff5c31991bf27fc808626c5c086219df63cfe1acf978b97
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libpam-systemd_255.2-4deepin3_loong64.deb
+    digest: 903e7f690c7704363c521d1958327375f364bdac0acb00c988bb04d27226c656
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pam/libpam0g_1.5.3-7_loong64.deb
+    digest: 2bd2b109cdeda454a9d61ee61d06e9c39a1ef0296d891f40549c44dfcb0573ca
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_loong64.deb
     digest: c1e53075721790fad6dadb0f0c6f85da39b2e127374424a63ac010d4d7972f74
@@ -864,6 +999,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_loong64.deb
     digest: 8c5d37ea50aeb08f936ee1e57b5f295cbc5d76690d92c265b26fbf0e14e687c6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpsl/libpsl5_0.21.0-1.2_loong64.deb
+    digest: 48076d0b45bdee001ab7b435296ab05853ab64402092af005e07437dcc838640
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
     digest: 9d68b88d2e9de4c313b75ec6ebd8df51105856bf8998470dc7faf770308ddc40
@@ -1078,6 +1216,12 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_loong64.deb
     digest: a19a49923398b268c9f2f8e45bca89a70779d5b1b788f9f295e428e731868fe6
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsemanage/libsemanage-common_3.5-1deepin1_all.deb
+    digest: c4fe4277d3df3d1bbf39083659701e5f4f9857e612ef7f1185e45eedc8f27047
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsemanage/libsemanage2_3.5-1deepin1_loong64.deb
+    digest: 606d01201a53c510d39f94b0ad8b6c13b4feb636a5686168693734c0e4ac4d23
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
   - kind: file
@@ -1105,6 +1249,9 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shine/libshine3_3.1.1-2_loong64.deb
     digest: 83ec46f7ce2381f484401aa33d7540cfd954f5064ab2c3372ba55f67c9204b8a
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libshout/libshout3_2.4.5-1_loong64.deb
+    digest: ddebd087753d10be88c37df1728fe46ef5fb4c95489dee75908f14ecbf039961
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsixel/libsixel1_1.8.6-2_loong64.deb
     digest: 13880034d44ecaedf746798b519ef820249667f5c7ecf9f55a5215ba1e54d008
   - kind: file
@@ -1113,6 +1260,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_loong64.deb
     digest: 9af2780f0816a5e2c10bbbe3abb974ba236ecf0beef15a49040433889c678847
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libsmartcols1_2.39.3-6deepin1_loong64.deb
+    digest: 969dc944c0756c7947ed13d8e8f658d3fc2fb7d98e4120f871a0dccfbead211d
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/snappy/libsnappy1v5_1.2.1-1_loong64.deb
     digest: 037f2de80f65e4491772282c5c45bc286cca8a804f4141f55bd146b1dba20ccc
@@ -1128,6 +1278,12 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_loong64.deb
     digest: 0ffa187ef4755909e7306c416ef177f3bb28b70c2509a558b9dee95f9e6c62f2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoup3/libsoup-3.0-0_3.4.3-1_loong64.deb
+    digest: df3d8356aabb2cf1c24733e9e3410babc7948e3bbfa71a79269523d5502131c4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoup3/libsoup-3.0-common_3.4.3-1_all.deb
+    digest: 1591543d840396ea47f24a2b3287dabc0a50eeb085e07f0807cd99a4ca992f13
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoxr/libsoxr0_0.1.3-4_loong64.deb
     digest: bb803883ea5a502ae59c3ee986680ce3612863406469d327009684d7377b27cc
@@ -1177,11 +1333,23 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_loong64.deb
     digest: 0dea4074d37171a31a99d1f773b67f88ed06d6027597da7c5cebae6352d8b478
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd-shared_255.2-4deepin3_loong64.deb
+    digest: 462f4ee8d24e0b29122f2c1760e170514e029bac843ce39286922ba38a96d331
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_loong64.deb
     digest: 00df4db71c335976879e8d9dbe2ec14f1fd13a7cfce8973e6b22e6a3a7cc2fc8
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_loong64.deb
+    digest: d2688537a91f78d0b816045d583542bd5bb41bf4ef6e10d49672f4bbcf639997
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/taglib/libtag1v5_1.12-1deepin0_loong64.deb
+    digest: 68acfd7d231bdd51d3e2f0e37c54710572b6685e153f11434ab9024f20ae3492
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_loong64.deb
     digest: 75dde4d8be25c4d18dcf4e27dffff588fabf9c2b365b3c22b2cbd12af97d90b3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
     digest: 3a87af58b0b3becac7062da11264d083cd68190e7dd421c2cbd00da8841cfa25
@@ -1240,6 +1408,12 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_loong64.deb
     digest: 48c616dfb3a357311ea0507bf7c43740e66a2eb1f85027c116a3f7f20067f4e8
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/v4l-utils/libv4l-0_1.26.1-3deepin0_loong64.deb
+    digest: 68d52092e2d82cd186685595f9e3c86f90a66d19663f947689d5075c9201ab66
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/v4l-utils/libv4lconvert0_1.26.1-3deepin0_loong64.deb
+    digest: ad4e08b6ff92f3606f862af7bfa8c95212c6a9edede97cea053ca8e26d63ad40
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-drm2_2.20.0-2_loong64.deb
     digest: bbbdab85f21232ec1d4f1522042a0870fbdc5561814169b40702b4652b65816b
   - kind: file
@@ -1257,6 +1431,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_loong64.deb
     digest: 2426d25458a68233bce71e89668c2a8a521388f606e526e85188c562760249b6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvisual/libvisual-0.4-0_0.4.0-17_loong64.deb
+    digest: 97007ac71560cc816fdd320dc72c46d3c28ae760a5f00d84740c811fa2b48daf
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vlc/libvlc-dev_3.0.21-2_loong64.deb
     digest: c365e788813bad597aa9bbd07c2eba472c7f5b4ef3421da41ac003c0a9c03caa
@@ -1296,6 +1473,9 @@ sources:
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
     digest: 87c13b7db15b7c19111c5af081825d48550cd48c351e3c5ddfac976939bd67b1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wavpack/libwavpack1_5.4.0-1_loong64.deb
+    digest: ed3e1e06ecb13233f836c2c7796f75f5f539ee428554dcc167f1aff10dcb3a7c
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-bin_1.23.0-1_loong64.deb
     digest: 7cbb3b24e28e53fdffc09dbb235c88a5fdd550fc08e590479674d1ef91b5dc09
@@ -1540,11 +1720,17 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/mount_2.39.3-6deepin1_loong64.deb
+    digest: 6f3233bf2f3c875d3b13a34fcd085bb3841267cba0454b98a259a23dde204a27
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_loong64.deb
     digest: 8569bcf5afca194968c0e49c3a71fbf106bdb5f6281db535142a5b8ea1a46e18
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shadow/passwd_4.14+dfsg1-0deepin4_loong64.deb
+    digest: 0c6ae6318d0dbae5474e029a0c8e24bb168ef12fc34a5152c68eed0d32eff7f5
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_loong64.deb
     digest: 713a6fe43f8c66f410ed5eca4b57361868d6da0f05e2ef9f7300f7fe524ee2e5
@@ -1675,11 +1861,23 @@ sources:
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shared-mime-info/shared-mime-info_2.2-1_loong64.deb
     digest: a0cd2345f1c869975ba98b8ead9048f32746d72966162472ce531ae48ecb0e9e
   - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd-dev_255.2-4deepin3_all.deb
+    digest: 04adbe93c28391ba986f20b138a0396c74f0c8be52f59141e0a64d375a27ed43
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd-sysv_255.2-4deepin3_loong64.deb
+    digest: 991f7697219f6f9d1c68c364627b591b7bf0f783aff6dc96b22311484bfac9b6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/systemd_255.2-4deepin3_loong64.deb
+    digest: c9e7d02158da5760c03bf749ce2d7bc53702ac296f19d4d3d2af2310e5b3adfb
+  - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_loong64.deb
     digest: 48cc0cc32829c68c7b58e74f141fe552f9a3f5c9e6da77ad54184530debc0cff
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/usrmerge/usrmerge_38_all.deb
+    digest: fdc636985788b18a04cd15941a111fb2a73d3b56cf58c689b918345e6f003161
   - kind: file
     url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_loong64.deb
     digest: 54727a76b166231d74f5116fc6732bf97ac9aa2ee8f8b49bbf0ee5b8358c5483

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,9 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions(-DQT_QML_DEBUG_NO_WARNING)
 endif()
 
+# using for linglnog
+add_definitions(-DINSTALL_LIB_PATH="${CMAKE_INSTALL_LIBDIR}")
+
 list(APPEND RESOURCES ${CMAKE_PROJECT_NAME}.qrc deepin-voice-note-web.qrc)
 
 find_package(Qt6 6.6 REQUIRED COMPONENTS Core Widgets Quick DBus Sql WebEngineQuick Multimedia)

--- a/src/audio/gstreamrecorder.cpp
+++ b/src/audio/gstreamrecorder.cpp
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "gstreamrecorder.h"
+#include "common/utils.h"
+
 #include <DLog>
 
 static const QString mp3Encoder = "capsfilter caps=audio/x-raw,rate=44100,channels=2 ! lamemp3enc name=enc target=1 cbr=true bitrate=192";
@@ -46,7 +48,7 @@ GstreamRecorder::GstreamRecorder(QObject *parent)
     : QObject(parent)
 {
     // check if current in linglong, update GST_PLUGIN_PATH
-    if (!qgetenv("LINGLONG_APPID").isEmpty()) {
+    if (Utils::inLinglongEnv()) {
         qputenv("GST_PLUGIN_PATH", QByteArray(INSTALL_LIB_PATH) + QByteArray("/gstreamer-1.0"));
     }
 

--- a/src/audio/gstreamrecorder.cpp
+++ b/src/audio/gstreamrecorder.cpp
@@ -45,6 +45,11 @@ gboolean GstBusMessageCb(GstBus *bus, GstMessage *msg, void *userdata)
 GstreamRecorder::GstreamRecorder(QObject *parent)
     : QObject(parent)
 {
+    // check if current in linglong, update GST_PLUGIN_PATH
+    if (!qgetenv("LINGLONG_APPID").isEmpty()) {
+        qputenv("GST_PLUGIN_PATH", QByteArray(INSTALL_LIB_PATH) + QByteArray("/gstreamer-1.0"));
+    }
+
     gst_init(nullptr, nullptr);
 }
 

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -353,3 +353,8 @@ QString Utils::createRichText(const QString &title, const QString &key)
     QString newText = editTitle.replace(key, highLightText);
     return newText;
 }
+
+bool Utils::inLinglongEnv()
+{
+    return !qgetenv("LINGLONG_APPID").isEmpty();
+}

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -50,4 +50,6 @@ public:
     static bool isWayland();
     //搜索结果标题处理
     static QString createRichText(const QString &title, const QString &key);
+    // Check if current in linglong environment
+    static bool inLinglongEnv();
 };

--- a/src/handler/voice_player_handler.cpp
+++ b/src/handler/voice_player_handler.cpp
@@ -15,6 +15,7 @@
 #include "common/qtplayer.h"
 #include "common/metadataparser.h"
 #include "common/jscontent.h"
+#include "common/utils.h"
 #include "opsstateinterface.h"
 
 // 进度条刻度，按秒进位
@@ -86,14 +87,19 @@ void VoicePlayerHandler::playVoiceImpl(bool bIsSame)
 
 void VoicePlayerHandler::initPlayer()
 {
-    QString strlib = "libvlc.so";
-    QDir dir;
-    QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
-    dir.setPath(path);
-    QStringList list = dir.entryList(QStringList() << (strlib + "*"), QDir::NoDotAndDotDot | QDir::Files); //filter name with strlib
+    bool found = false;
+    // Using Qt player in linglong environment
+    if (!Utils::inLinglongEnv()) {
+        QString strlib = "libvlc.so";
+        QDir dir;
+        QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
+        dir.setPath(path);
+        QStringList list = dir.entryList(QStringList() << (strlib + "*"), QDir::NoDotAndDotDot | QDir::Files); //filter name with strlib
 
-    QLibrary library("libvlc.so.5");
-    bool found = list.contains(strlib) || library.load();
+        QLibrary library("libvlc.so.5");
+        found = list.contains(strlib) || library.load();
+    }
+
     if (found) {
         m_player = new VlcPlayer(this);
         bool successed = static_cast<VlcPlayer*>(m_player)->initVlcPlayer();


### PR DESCRIPTION
[fix: can not record voice](https://github.com/linuxdeepin/deepin-voice-note/commit/705d9982785dab9d10e3337f6788b00a520aff42) 

Gstreamer can not find pulse plugin,
move .so plugin and set plugin path manually.

Log: fix can not record voice.
Bug: https://pms.uniontech.com/bug-view-305495.html

[fix: crash on play voice](https://github.com/linuxdeepin/deepin-voice-note/commit/3c06ecddd89199f14f4ff9e2c331bdb2cdc27107) 

VLC requires plugins in the Linglong environment;
otherwise, it may crash.
Switched to Qtplayer temporarily while waiting for
the correct VLC plugins to be copied.

Log: fix crash on play voice.