### PR TITLE
Fix the issue of audio continuing to play after exit

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -14,6 +14,7 @@
 #include "globaldef.h"
 #include "actionmanager.h"
 #include "utils.h"
+#include "vtextspeechandtrmanager.h"
 #include "handler/web_engine_handler.h"
 #include "handler/vnote_message_dialog_handler.h"
 #include "handler/voice_recoder_handler.h"
@@ -880,6 +881,13 @@ void VNoteMainManager::resumeVoicePlayer()
 
 void VNoteMainManager::forceExit()
 {
+    VTextSpeechAndTrManager::instance()->onStopTextToSpeech();
     QApplication::exit(0);
     _Exit(0);
+}
+
+bool VNoteMainManager::isVoiceToText()
+{
+    bool aa = OpsStateInterface::instance()->isVoice2Text();
+    return aa;
 }

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -54,6 +54,7 @@ public:
     Q_INVOKABLE void showPrivacy();
     Q_INVOKABLE void resumeVoicePlayer();
     Q_INVOKABLE void forceExit();
+    Q_INVOKABLE bool isVoiceToText();
 
 signals:
     void finishedFolderLoad(const QList<QVariantMap> &foldersData);

--- a/src/common/vnotea2tmanager.cpp
+++ b/src/common/vnotea2tmanager.cpp
@@ -55,7 +55,7 @@ int VNoteA2TManager::initSession()
 
     timer = new QTimer;
     timer->setSingleShot(true);
-    timer->setInterval(10000);
+    timer->setInterval(100000);
     connect(timer, &QTimer::timeout, [=](){
         emit asrError(AudioOther);
         OpsStateInterface::instance()->operState(OpsStateInterface::StateVoice2Text, false);

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -35,6 +35,10 @@ Item {
     signal mulChoices(int choices)
     signal noteItemChanged(int index)
 
+    function changeCurrentIndex(index) {
+        itemListView.currentIndex = index;
+    }
+
     function onDeleteNote() {
         messageDialogLoader.messageData = selectedNoteItem.length;
         if (messageDialogLoader.active) {

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -53,6 +53,7 @@ ApplicationWindow {
         y = Screen.height / 2 - height / 2;
     }
     onClosing: {
+        webEngineView.stopTTS();
         if (isRecording) {
             close.accepted = false;
             messageDialogLoader.showDialog(VNoteMessageDialogHandler.AbortRecord, ret => {

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -211,6 +211,7 @@ ApplicationWindow {
             });
             itemListView.selectedNoteItem = [topSize];
             itemListView.selectSize = 1;
+            itemListView.changeCurrentIndex(topSize);
             folderListView.addNote(1);
             itemListView.forceActiveFocus();
         }
@@ -285,6 +286,7 @@ ApplicationWindow {
             handleUpdateNoteList(notesData);
             itemListView.selectedNoteItem = [selectIndex];
             itemListView.selectSize = 1;
+            itemListView.changeCurrentIndex(selectIndex);
         }
     }
 

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -53,7 +53,7 @@ ApplicationWindow {
         y = Screen.height / 2 - height / 2;
     }
     onClosing: {
-        webEngineView.stopTTS();
+        close.accepted = false;
         if (isRecording) {
             close.accepted = false;
             messageDialogLoader.showDialog(VNoteMessageDialogHandler.AbortRecord, ret => {
@@ -63,7 +63,14 @@ ApplicationWindow {
                 }
             });
         } else {
-            VNoteMainManager.forceExit();
+            if (VNoteMainManager.isVoiceToText()) {
+                messageDialogLoader.showDialog(VNoteMessageDialogHandler.AborteAsr, ret => {
+                    if (ret) {
+                        VNoteMainManager.forceExit();
+                    }
+                });
+            } else
+                VNoteMainManager.forceExit();
         }
     }
     onWidthChanged: {

--- a/src/gui/mainwindow/VNoteRightMenu.qml
+++ b/src/gui/mainwindow/VNoteRightMenu.qml
@@ -23,9 +23,9 @@ Menu {
         }
         var actionText = ActionManager.actionText(actionId);
         var menu = menuCreator.createObject(parent, {
-                menuId: actionId,
-                title: actionText
-            });
+            menuId: actionId,
+            title: actionText
+        });
         parent.addMenu(menu);
         ActionManager.setActionObject(actionId, menu);
 
@@ -40,9 +40,9 @@ Menu {
     function addCustomMenuItem(actionId, parent) {
         var actionText = ActionManager.actionText(actionId);
         var menuItem = menuItemCreator.createObject(parent, {
-                menuId: actionId,
-                text: actionText
-            });
+            menuId: actionId,
+            text: actionText
+        });
         parent.addItem(menuItem);
         ActionManager.setActionObject(actionId, menuItem);
     }
@@ -53,8 +53,8 @@ Menu {
             return;
         }
         var menuSeparator = menuSeparatorCreator.createObject(parent, {
-                menuId: actionId
-            });
+            menuId: actionId
+        });
         parent.addItem(menuSeparator);
         ActionManager.setActionObject(actionId, menuSeparator);
     }

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -47,6 +47,10 @@ Item {
         recorderViewLoader.item.stop();
     }
 
+    function stopTTS() {
+        ActionManager.actionTriggerFromQuick(37);
+    }
+
     function toggleMultCho(choices) {
         if (choices > 1) {
             webVisible = false;
@@ -137,7 +141,7 @@ Item {
                     handler.onContextMenuRequested(req);
 
                     // prevent a default context menu from showing up
-                    req.accepted = true
+                    req.accepted = true;
                 }
                 onJavaScriptConsoleMessage: {
                     // 调试使用，打印控制台输出

--- a/src/handler/vnote_message_dialog_handler.cpp
+++ b/src/handler/vnote_message_dialog_handler.cpp
@@ -125,6 +125,8 @@ QString VNoteMessageDialogHandler::initMainMessage() const
             return QApplication::translate("VNoteMessageDialogHandler", "You do not have permission to save files there");
         case VoicePathNoAvail:
             return QApplication::translate("VNoteMessageDialogHandler", "The voice note has been deleted");
+        case NoNetwork:
+            return QApplication::translate("VNoteMessageDialogHandler", "The voice conversion failed due to the poor network connection, please have a check");
         default:
             break;
     }

--- a/src/handler/vnote_message_dialog_handler.h
+++ b/src/handler/vnote_message_dialog_handler.h
@@ -31,6 +31,7 @@ public:
         SaveFailed,        // 保存失败
         NoPermission,      // 无权限
         VoicePathNoAvail,  // 语音路径无效
+        NoNetwork,
     };
     Q_ENUM(MessageType)
 

--- a/src/handler/voice_to_text_handler.h
+++ b/src/handler/voice_to_text_handler.h
@@ -20,9 +20,11 @@ public:
     void setAudioToText(const QSharedPointer<VNVoiceBlock> &voiceBlock);
 
     Q_SIGNAL void audioLengthLimit();
+    Q_SIGNAL void noNetworkConnection();
 
 private:
     void onA2TStart();
+    bool checkNetworkState();
     Q_SLOT void onA2TError(int error);
     Q_SLOT void onA2TSuccess(const QString &text);
 

--- a/src/handler/web_engine_handler.cpp
+++ b/src/handler/web_engine_handler.cpp
@@ -66,6 +66,9 @@ WebEngineHandler::WebEngineHandler(QObject *parent)
     connect(m_voiceToTextHandler, &VoiceToTextHandler::audioLengthLimit, this, [this]() {
         Q_EMIT requestMessageDialog(VNoteMessageDialogHandler::AsrTimeLimit);
     });
+    connect(m_voiceToTextHandler, &VoiceToTextHandler::noNetworkConnection, this, [this]() {
+            Q_EMIT requestMessageDialog(VNoteMessageDialogHandler::NoNetwork);
+    });
     connect(m_voicePlayerHandler, &VoicePlayerHandler::playStatusChanged, this, [=](VoicePlayerHandler::PlayState state){
         if (state == VoicePlayerHandler::PlayState::End) {
             Q_EMIT playingVoice(false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
     ImageProvider *imageProvider = ImageProvider::instance();
 
     app->loadTranslator();
-
+    app->setApplicationDisplayName(QObject::tr("deepin-voice-note"));
     QQmlApplicationEngine engine;
     const QUrl url(QStringLiteral("qrc:/main.qml"));
     engine.addImageProvider("Provider", imageProvider);

--- a/translations/deepin-voice-note.ts
+++ b/translations/deepin-voice-note.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="466"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="474"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="492"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="681"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="371"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="516"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -304,18 +304,24 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="244"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="246"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="248"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
         <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -368,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -466,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -593,12 +599,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -619,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="454"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -627,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="57"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="97"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="97"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="116"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_az.ts
+++ b/translations/deepin-voice-note_az.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Adını dəyişdirmək</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Silmək</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Qeyd yaratmaq</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Axtarış nəticəsi yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Yuxarı yapışdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Yapışqan Qeydlər</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Qeyd yaratmaq</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Axtarış</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Yeni qeyd</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Qeyd saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Kəsmək</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Yerləşdirmək</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Silmək</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Ayarlar</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Səs qeydi silindi</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Silmək</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_bo.ts
+++ b/translations/deepin-voice-note_bo.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation>མིང་བསྐྱར་དུ་བཏགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation>འབྲི་དེབ་གསར་བཟོ།</translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation>ཟིན་བྲིས་གསར་པ་བཏོད་རྗེས་ཁྱེད་ཀྱིས་སྐད་བརྡ་དང་ཡིག་སྙོར་ཕབ་ལེན་བྱེད་འགོ་བརྩམས་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation>གསར་གཏོད་བྱ་དགོས།ཟིན་དེབ།</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation>གནས་སྤོ་བ། </translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation> ཟིན་བྲིས་རེ་རེ་བཞིན་དུ་འགོད་དགོས།:</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation> ཟིན་བྲིས་སུ་བཀོད་པ།:</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation>ཟིན་བྲིས་ཉར་ཚགས།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation>འཚོལ་ཞིབ་བྱས་འབྲས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation>གཏན་འཇགས་མེད་པར་བཟོ་དགོས།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation>སྟེང་དུ་འཇོག</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation>སྟེང་དུ་བཞག་ཟིན།</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation>གསར་གཏོད་བྱ་དགོས།ཟིན་དེབ།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation>འཚོལ་ཞིབ།</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation>གསར་དུ་བཀོད་པའི་མ་ཡིག</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation>མིང་རྟགས་འགོད་པའི་རྩ་བ་བསྐྱར་དུ་བཏགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation>ཟིན་བྲིས་འགོད་དེབ་བསུབ་དགོས།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation>འབྲི་དེབ་གསར་བཟོ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation>ཟིན་བྲིས་ལ་མིང་བཏགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation>ཟིན་བྲིས་སུབ་དགོས།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation>ཁྱབ་གཏོང་བཅས་བྱ་དགོས།/གནས་སྐབས་མཚམས་འཇོག་དགོས།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation>སྒྲ་ཕབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation>ཟིན་བྲིས་ཉར་ཚགས།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation>སྐད་གདངས་ཉར་ཚགས་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation>ཡོངས་རྫོགས་འདེམས་བསྐོ་བྱ་དགོས</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation>དྲས་གཏུབ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation>སྦྱར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation>ཕྱིར་འཐེན་བྱ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation>བསྐྱར་དུ་བསྒྲུབ་དགོས།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation>རོགས་རམ་བྱེད་དགོས།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation>མགྱོགས་མྱུར་གྱི་མཐེབ་བཀྱག་མངོན་པ།</translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation>ཟིན་དེབ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation>ཟིན་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation>རྩོམ་སྒྲིག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation>སྒྲིག་འགོད།</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation>སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation>གསང་དོན་སྲིད་ཇུས།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation>སྐད་ཆའི་ཟིན་ཐོ་ནི་ཚད་ཡང་བའི་བརྗེད་ཐོའི་ཡོ་བྱད་ཅིག་ཡིན་པ་དང་། རྩོམ་ཡིག་གི་ཟིན་བྲིས་དང་སྒྲ་ཕབ་བཟོ་བར་སྤྱོད་དགོས།.</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation>སྒྲའི་ཟིན་དེབ།</translation>
     </message>
@@ -575,12 +599,17 @@
         <translation>སྒྲའི་ཟིན་ཐོ་འདི་སུབ་ཚར།</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation>དེའི་ནང་གི་ཟིན་བྲིས་ཚང་མ་བསུབ་རྒྱུ་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation>སུབ་པ།</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation>གཞན་ཞིག་MP3དུ་ཉར་ཚགས་བྱས་ཡོད།</translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation>གསར་གཏོད་བྱ་དགོས།ཟིན་དེབ།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation>སྒྲ་ཕབ་བྱེད་འགོ་ཚུགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation>སྒྲ་ཕབ་སྒྲིག་ཆས་ལ་ཞིབ་དཔྱད་ཚད་ལེན་མ་བྱས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation>པར་རིས་ནང་འཇུག་པ།</translation>
     </message>

--- a/translations/deepin-voice-note_ca.ts
+++ b/translations/deepin-voice-note_ca.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Canvia&apos;n el nom</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Crea un quadern</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">No hi ha cap resultat de la cerca.</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Les adhesives a dalt</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Notes adhesives</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Crea un quadern</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Cerca</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nota nova</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Desa la nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Retalla</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Enganxa</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Paràmetres</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Paràmetres</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">S&apos;ha eliminat la nota de veu.</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_cs.ts
+++ b/translations/deepin-voice-note_cs.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Přejmenovat</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Vytvořit zápisník</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Nic nenalezeno</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Zůstává na začátku</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Lepítka s poznámkami</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Vytvořit zápisník</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Hledat</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nová poznámka</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Uložit poznámku</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopírovat</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Vyjmout</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Nastavení</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Hlasová poznámka byla smazána</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_de.ts
+++ b/translations/deepin-voice-note_de.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Umbenennen</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Notizbuch erstellen</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Keine Suchergebnisse</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Oben anhaftend</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Haftnotizen</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Notizbuch erstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Suchen</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Neue Notiz</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Notiz speichern</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Einstellungen</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Die Sprachnotiz wurde gelöscht</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_en.ts
+++ b/translations/deepin-voice-note_en.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Rename</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Create Notebook</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">No search results</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Sticky on Top</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Sticky Notes</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Create Notebook</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Search</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">New note</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Save note</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copy</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Paste</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Settings</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Settings</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">The voice note has been deleted</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_es.ts
+++ b/translations/deepin-voice-note_es.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Renombrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Borrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Crear cuaderno</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">No hay resultados de búsqueda</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Fijar arriba</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Notas fijadas</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Crear cuaderno</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Buscar</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nueva nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Guardar nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copiar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Cortar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Pegar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Borrar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Ajustes</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">La nota de voz fue borrada</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Borrar</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_fi.ts
+++ b/translations/deepin-voice-note_fi.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Nimeä</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Luo muistikirja</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Ei hakutuloksia</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Päälimmäinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Muistilaput</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Luo muistikirja</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Etsi</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Uusi muistiinpano</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Tallenna muistiinpano</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Leikkaa</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Liitä</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Asetukset</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Puhemuistio on poistettu</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_fr.ts
+++ b/translations/deepin-voice-note_fr.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Renommer</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Créer un carnet de notes</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Aucun résultat trouvé</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Collant sur le dessus</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Notes autocollantes</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Créer un carnet de notes</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Rechercher</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nouvelle note</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Enregistrer la note</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copier</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Couper</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Coller</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Paramètres</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Le mémo vocal a été supprimé</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_gl_ES.ts
+++ b/translations/deepin-voice-note_gl_ES.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Renomear</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished"></translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Sen resultados para a busca</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Fixar enrriba</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Notas pegañentas</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Buscar</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nova nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copiar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Cortar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Pegar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Axustes</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Axustes</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Eliminouse a nota de voz</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_hi_IN.ts
+++ b/translations/deepin-voice-note_hi_IN.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">नाम बदलें</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">नोटबुक बनाएँ</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">खोजने पर कोई परिणाम नहीं मिला</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">शीर्ष पर तारांकित</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">तारांकित नोट्स</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">नोटबुक बनाएँ</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">खोजें</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">नया नोट</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">नोट संचित करें</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">कॉपी करेें</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">कट करें</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">पेस्ट करें</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">सेटिंग्स</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">वाणी नोट हटा दिया गया</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">हटाएँ</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_hu.ts
+++ b/translations/deepin-voice-note_hu.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Átnevezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Törlés</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Jegyzettömb létrehozása</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Nincs keresési eredmény</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Ragasztás a tetejére</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Ragadós Cetlik</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Jegyzettömb létrehozása</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Keresés</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Új jegyzet</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Jegyzet mentése</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Másolás</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Kivágás</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Beillesztés</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Törlés</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Beállítások</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">A hangjegyzet törölve</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Törlés</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_it.ts
+++ b/translations/deepin-voice-note_it.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Rinomina</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Crea un Taccuino</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Nessun risultato</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Note adesive in alto</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Note adesive</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Crea un Taccuino</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Cerca</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nuova nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Salva nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Taglia</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Impostazioni</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">La nota vocale è stata eliminata</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_ms.ts
+++ b/translations/deepin-voice-note_ms.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Nama Semula</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Padam</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Cipta Buku Nota</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Tiada keputusan gelintar</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Lekat paling Atas</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Nota Lekat</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Cipta Buku Nota</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Gelintar</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nota baharu</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Simpan nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Salin</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Potong</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Tampal</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Padam</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Tetapan</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Nota suara telah dipadamkan</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Padam</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_nl.ts
+++ b/translations/deepin-voice-note_nl.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Notitieboek maken</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Geen zoekresultaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Vastzetten aan bovenkant</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Vastgezette memo&apos;s</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Notitieboek maken</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Zoeken</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nieuwe memo</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Memo opslaan</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Knippen</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Plakken</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Instellingen</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">De memo is verwijderd</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Verwijderen</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_pl.ts
+++ b/translations/deepin-voice-note_pl.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Zmień nazwę</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Usuń</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Utwórz notatnik</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Brak wyników wyszukiwania</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Przypnij na górze</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Przyczepione notatki</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Utwórz notatnik</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Szukaj</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nowa notatka</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Zapisz notatkę</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Wytnij</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Wklej</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Usuń</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Ustawienia</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Notatka głosowa została usunięta</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Usuń</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_pt.ts
+++ b/translations/deepin-voice-note_pt.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Renomear</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Criar bloco de notas</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Nenhum resultado encontrado</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Afixar por cima</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Notas de Afixar</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Criar bloco de notas</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Pesquisar</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nova nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Guardar nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copiar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Cortar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Colar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Definições</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Definições</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">A nota de voz foi eliminada</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_pt_BR.ts
+++ b/translations/deepin-voice-note_pt_BR.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Renomear</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Criar Bloco de Notas</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Nenhum resultado encontrado</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Adesivar no Topo</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Notas Adesivas</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Criar Bloco de Notas</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Pesquisar</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nova nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Salvar nota</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copiar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Recortar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Colar</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Configurações</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Configurações</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">A nota de voz foi excluída</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_ro.ts
+++ b/translations/deepin-voice-note_ro.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Creare agendă</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Căutare nu a dat nici-un rezultat</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Lipire sus</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Notițe lipicioase</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Creare agendă</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Căutare</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Înregistrare nouă </translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Copiere</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Decupare</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Lipire</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Setări</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Setări</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Înregistrare voce a fost ștearsă</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_ru.ts
+++ b/translations/deepin-voice-note_ru.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Переименовать</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Создать Записную книжку</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Поиск не дал результатов</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Прикрепить сверху</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Заметки</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Создать Записную книжку</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Поиск</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Новая запись</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Сохранить заметку</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Копировать</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Вырезать</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Настройки</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Настройки</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Голосовая запись удалена</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_sl.ts
+++ b/translations/deepin-voice-note_sl.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Preimenuj</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Ustvari beležnico</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Ni rezultatov iskanj</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Prilepi na vrh</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Lepljivi listki</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Ustvari beležnico</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Iskanje</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Nova beležka</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Shrani beležko</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">zreži</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Prilepi</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Nastavitve</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Nastavitve</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Glasovna beleža je bila zbrisana</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Izbriši</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_sq.ts
+++ b/translations/deepin-voice-note_sq.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Riemërtojeni</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Fshije</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Krijoni Bllok Shënimesh</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">S’ka përfundime kërkimi</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Ngjite në Krye</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Shënime Ngjitëse</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Krijoni Bllok Shënimesh</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Kërko</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Shënim i ri</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Ruani shënim</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Prije</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Ngjite</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Fshije</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Rregullime</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Rregullime</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Shënimi zanor u fshi</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Fshije</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_sr.ts
+++ b/translations/deepin-voice-note_sr.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Преименуј</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Обриши</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Направи бележницу</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Нема разултата претраге</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Лепљиво на врху</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Лепљива бележница</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Направи бележницу</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Претражи</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Нова белешка</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Сачувај белешку</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Копирај</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Исеци</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Убаци</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Обриши</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Подешавања</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Подешавања</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Гласовна белешка је обрисана</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Обриши</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_tr.ts
+++ b/translations/deepin-voice-note_tr.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Adlandır</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Sil</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Not Defteri Oluştur</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Arama sonucu bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Yapışkan Üstte</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Yapışkan Notlar</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Not Defteri Oluştur</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Ara</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Yeni not</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Notu kaydet</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Kes</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Yapıştır</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Sil</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Ayarlar</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Sesli not silinidi</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Sil</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_ug.ts
+++ b/translations/deepin-voice-note_ug.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation>نام قويۇش</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation>يېڭى خاتىرە قۇرۇش</translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation>يېڭى خاتىرە دەپتىرى قۇرغاندىن كېيىن، ئاۋاز ۋە تېكىستلەرنى خاتىرىلەشنى باشلىسىڭىز بولىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation>خاتىرە دەپتەر قۇرۇش</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation>كۆچمە خەۋەرلىشىش </translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation> خاتىرە قالدۇرماق:</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation> خاتىرە قالدۇرۇش:</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation>خاتىرىنى ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation>ئىزدەش نەتىجىسى يوق</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation>قىستۇرۇشنى يېشىش</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation>چوققىلاش</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation>چوققىلاندى</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation>خاتىرە دەپتەر قۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation>ئىزدەش</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation>نيۇنورتبۇك</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation>رېنامنوتبۇك</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation>درايتنوتبۇك</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation>يېڭى خاتىرە قۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation>رېنامنوت</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation>دىلېتنوت</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation>قويۇش/ۋاقتىنچە توختىتىش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation>ئۈن ئېلىش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation>خاتىرىنى ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation>ئۈننى ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation>ھەممىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation>كېسىش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation>چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation>قايتا قىلماق</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation>ياردەم</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation>تېز كۇنۇپكىنى كۆرسىتىش</translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation>خاتىرە دەپتەر</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation>نوت</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation>تەھرىر</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation>شەخسىيەت سىياسىيتى</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation>ئاۋازلىق ئىزاھاتلار تېكىست خاتىرە ۋە ئاۋاز ئېلىش ئۈچۈن ئىشلىتىلىدىغان يېنىك خاتىرە قورالى.</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation>ئاۋازلىق خاتىرە</translation>
     </message>
@@ -575,12 +599,17 @@
         <translation>ئاۋاز خاتىرىسى ئۆچۈرۈلدى</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation>ئۇنىڭدىكى بارلىق ئىزاھاتلار ئۆچۈرۈلىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation>ئۆچۈرۈش</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation>MP3 شەكلىدە ساقلاش</translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation>خاتىرە دەپتەر قۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation>ئۈن ئېلىشقا باشلىدى</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation>ئۈن ئېلىش ئۈسكۈنىسى بايقالمىدى</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation>رەسىم قىستۇرماق</translation>
     </message>

--- a/translations/deepin-voice-note_uk.ts
+++ b/translations/deepin-voice-note_uk.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="454"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation type="unfinished">Перейменувати</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="462"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation type="unfinished">Вилучити</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="480"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,12 +48,12 @@
 <context>
     <name>InitialInterface</name>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="60"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="66"/>
         <source>After creating a new notepad, you can start recording voice and text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="67"/>
+        <location filename="../src/gui/mainwindow/InitialInterface.qml" line="73"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Створити теку</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation type="unfinished">Немає результатів</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation type="unfinished">Приліпити згори</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="663"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation type="unfinished">Липкі нотатки</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="366"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation type="unfinished">Створити теку</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="515"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation type="unfinished">Пошук</translation>
     </message>
@@ -302,6 +302,30 @@
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Setting</name>
     <message>
         <location filename="../src/common/setting.cpp" line="24"/>
@@ -350,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation type="unfinished">Нова нотатка</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation type="unfinished">Зберегти нотатку</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation type="unfinished">Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation type="unfinished">Вирізати</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation type="unfinished">Вставити</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation type="unfinished">Вилучити</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation type="unfinished">Параметри</translation>
     </message>
@@ -471,22 +495,22 @@
 <context>
     <name>TitleBarMenu</name>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="15"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="16"/>
         <source>Settings</source>
         <translation type="unfinished">Параметри</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="28"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="30"/>
         <source>Privacy Policy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="51"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
         <source>Voice Notes is a lightweight memo tool to make text notes and voice recordings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="53"/>
+        <location filename="../src/gui/mainwindow/TitleBarMenu.qml" line="55"/>
         <source>Voice Note</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +599,17 @@
         <translation type="unfinished">Голосове нагадування вилучено</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation type="unfinished">Вилучити</translation>
     </message>
@@ -601,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="456"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -609,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="64"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="104"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="123"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-voice-note_zh_CN.ts
+++ b/translations/deepin-voice-note_zh_CN.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="466"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="474"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="492"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation>新建笔记</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation>移动 </translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation> 个笔记到：</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation> 笔记到：</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation>保存笔记</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation>无搜索结果</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation>取消置顶</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation>置顶</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="681"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation>已置顶</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="371"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation>新建记事本</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="516"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
@@ -304,19 +304,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="244"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>请前往应用商店安装“UOS AI”后再使用</translation>
     </message>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="246"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>未检测到音频输入设备，请检查后重试</translation>
     </message>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="248"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>未检测到音频输出设备，请检查后重试</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation>语音记事本</translation>
     </message>
 </context>
 <context>
@@ -368,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation>新建记事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation>重命名记事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation>删除记事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation>新建笔记</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation>重命名笔记</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation>删除笔记</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation>播放/暂停</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation>录音</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation>保存笔记</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation>保存语音</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation>撤销</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
@@ -466,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation>记事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation>笔记</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
@@ -593,12 +599,17 @@
         <translation>该语音笔记已被删除</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
-        <source>All notes in it will be deleted</source>
-        <translation>此本基本中的所有笔记都将移至回收站</translation>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation>当前网络状态差，语音转写失败，请确保网络畅通</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
+        <source>All notes in it will be deleted</source>
+        <translation>包含的所有笔记将被删除</translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
@@ -619,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="454"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation>保存为MP3</translation>
     </message>
@@ -627,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="57"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation>新建笔记</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="97"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation>开始录音</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="97"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation>未检测到录音设备</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="116"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation>插入图片</translation>
     </message>

--- a/translations/deepin-voice-note_zh_HK.ts
+++ b/translations/deepin-voice-note_zh_HK.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="466"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="474"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="492"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation>新建筆記</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation>郁 </translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation> 個筆記至：</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation> 筆記至：</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation>保存筆記</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation>無搜索結果</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation>攞消置頂</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation>置頂</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="681"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation>已置頂</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="371"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation>新建記事本</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="516"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
@@ -304,19 +304,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="244"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>請前往應用商店安裝“UOS AI”後再使用</translation>
     </message>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="246"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>未檢測到音頻輸入設備，請檢查後重試</translation>
     </message>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="248"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>未檢測到音頻輸出設備，請檢查後重試</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -368,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation>新建記事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation>重命名記事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation>刪除記事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation>新建筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation>重命名筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation>删除筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation>播放/暫停</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation>錄音</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation>保存筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation>保存語音</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation>黏貼</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation>撤銷</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
@@ -466,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation>記事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation>筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
@@ -593,12 +599,17 @@
         <translation>該語音筆記已被刪除</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation>此本基本中嘅所有筆記都將移至回收站</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -619,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="454"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation>保存為mp3</translation>
     </message>
@@ -627,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="57"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation>新建筆記</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="97"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation>開始錄音</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="97"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation>未檢測到錄音設備</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="116"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation>插入圖片</translation>
     </message>

--- a/translations/deepin-voice-note_zh_TW.ts
+++ b/translations/deepin-voice-note_zh_TW.ts
@@ -30,17 +30,17 @@
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="466"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="517"/>
         <source>Rename</source>
         <translation>重新命名</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="474"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="526"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/FolderListView.qml" line="492"/>
+        <location filename="../src/gui/mainwindow/FolderListView.qml" line="545"/>
         <source>New Note</source>
         <translation>建立筆記</translation>
     </message>
@@ -61,44 +61,44 @@
 <context>
     <name>ItemListView</name>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source>move </source>
         <translation>移動 </translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="73"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="78"/>
         <source> notes to :</source>
         <translation> 個筆記至:</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="75"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="80"/>
         <source> note to :</source>
         <translation> 筆記至:</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="158"/>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="185"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="163"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="190"/>
         <source>Save As</source>
         <translation>保存筆記</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="222"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="228"/>
         <source>No search results</source>
         <translation>無搜尋結果</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Unpin</source>
         <translation>取消置頂</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="238"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="244"/>
         <source>Sticky on Top</source>
         <translation>置頂</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/ItemListView.qml" line="681"/>
+        <location filename="../src/gui/mainwindow/ItemListView.qml" line="690"/>
         <source>Sticky Notes</source>
         <translation>已置頂</translation>
     </message>
@@ -106,12 +106,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="371"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="381"/>
         <source>Create Notebook</source>
         <translation>建立記事本</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/MainWindow.qml" line="516"/>
+        <location filename="../src/gui/mainwindow/MainWindow.qml" line="534"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
@@ -304,19 +304,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="244"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="230"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>請前往應用商店安裝“UOS AI”後再使用</translation>
     </message>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="246"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="232"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>未檢測到音頻輸入設備，請檢查後重試</translation>
     </message>
     <message>
-        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="248"/>
+        <location filename="../src/common/vtextspeechandtrmanager.cpp" line="234"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>未檢測到音頻輸出設備，請檢查後重試</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="56"/>
+        <location filename="../src/main.cpp" line="57"/>
+        <source>deepin-voice-note</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -368,97 +374,97 @@
 <context>
     <name>Shortcuts</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="740"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
         <source>New notebook</source>
         <translation>建立記事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="741"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="743"/>
         <source>Rename notebook</source>
         <translation>重命名記事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="742"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="744"/>
         <source>Delete notebook</source>
         <translation>删除記事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="764"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
         <source>New note</source>
         <translation>建立筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="765"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
         <source>Rename note</source>
         <translation>重命名筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="766"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
         <source>Delete note</source>
         <translation>删除筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="767"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
         <source>Play/Pause</source>
         <translation>播放/暫停</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="768"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
         <source>Record voice</source>
         <translation>錄音</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="769"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="771"/>
         <source>Save note</source>
         <translation>儲存筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="770"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="772"/>
         <source>Save recordings</source>
         <translation>儲存語音</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="790"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="791"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="792"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
         <source>Cut</source>
         <translation>剪下</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="793"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="794"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
         <source>Undo</source>
         <translation>撤銷</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="795"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="797"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="796"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="798"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="819"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="821"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="820"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="822"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
@@ -466,22 +472,22 @@
 <context>
     <name>ShortcutsGroups</name>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="746"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="748"/>
         <source>Notebooks</source>
         <translation>記事本</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="774"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="776"/>
         <source>Notes</source>
         <translation>筆記</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="800"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="802"/>
         <source>Edit</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="../src/common/VNoteMainManager.cpp" line="824"/>
+        <location filename="../src/common/VNoteMainManager.cpp" line="826"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
@@ -593,12 +599,17 @@
         <translation>該語音筆記已被刪除</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="139"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="129"/>
+        <source>The voice conversion failed due to the poor network connection, please have a check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="141"/>
         <source>All notes in it will be deleted</source>
         <translation>此記事本的所有筆記都將移至回收站</translation>
     </message>
     <message>
-        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="152"/>
+        <location filename="../src/handler/vnote_message_dialog_handler.cpp" line="154"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -619,7 +630,7 @@
 <context>
     <name>WebEngineHandler</name>
     <message>
-        <location filename="../src/handler/web_engine_handler.cpp" line="454"/>
+        <location filename="../src/handler/web_engine_handler.cpp" line="483"/>
         <source>save as MP3</source>
         <translation>儲存為mp3</translation>
     </message>
@@ -627,22 +638,22 @@
 <context>
     <name>WindowTitleBar</name>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="57"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="60"/>
         <source>Create Note</source>
         <translation>建立筆記</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="97"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>Start recording</source>
         <translation>開始錄音</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="97"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="100"/>
         <source>No recording device detected</source>
         <translation>未檢測到錄製設備</translation>
     </message>
     <message>
-        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="116"/>
+        <location filename="../src/gui/mainwindow/WindowTitleBar.qml" line="119"/>
         <source>Insert picture</source>
         <translation>插入圖片</translation>
     </message>


### PR DESCRIPTION
[fix: 修复列表索引错误问题]

修复列表索引错误问题

Bug: https://pms.uniontech.com/zentao/bug-view-284531.html
Log: 修复列表索引错误问题
[fix: Fix the issue of audio continuing to play after exit]

Fix the issue of audio continuing to play after exit.

Bug: https://pms.uniontech.com/zentao/bug-view-302477.html
Log: Fix the issue of audio continuing to play after exit
[fix: Fixed the issue that no prompt was displayed when exiting]

Fixed the issue that no prompt was displayed when exiting

Bug: https://pms.uniontech.com/zentao/bug-view-297735.html
Log: Fixed the issue that no prompt was displayed when exiting

[fix: Add a disconnection notification]

Add a disconnection notification

Bug: https://pms.uniontech.com/zentao/bug-view-291561.html
Log: Add a disconnection notification

[fix: Fixed the issue that the display name was not translated]

Fixed the issue that the display name was not translated

Bug: https://pms.uniontech.com/zentao/bug-view-303029.html
Log: Fixed the issue that the display name was not translated