### PR TITLE
Fix missing include QJsonDocument

### DIFF
--- a/src/common/vnotea2tmanager.cpp
+++ b/src/common/vnotea2tmanager.cpp
@@ -17,6 +17,8 @@
 #include <QApplication>
 #include <QDebug>
 
+#include <QJsonDocument>
+
 DCORE_USE_NAMESPACE
 
 /**


### PR DESCRIPTION
Fixes build error:

```text
/build/deepin-voice-note/src/deepin-voice-note/src/common/vnotea2tmanager.cpp: In member function ‘void VNoteA2TManager::asrJsonParser(const QString&, asrMsg&)’:
/build/deepin-voice-note/src/deepin-voice-note/src/common/vnotea2tmanager.cpp:153:19: error: variable ‘QJsonDocument doc’ has initializer but incomplete type
  153 |     QJsonDocument doc = QJsonDocument::fromJson(msg.toUtf8(), &error);
      |                   ^~~
/build/deepin-voice-note/src/deepin-voice-note/src/common/vnotea2tmanager.cpp:153:40: error: incomplete type ‘QJsonDocument’ used in nested name specifier
  153 |   
```