### PR TITLE
fix: Add functionality to get default microphone from pactl

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     voice note for deepin os

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.22) unstable; urgency=medium
+
+  * Update version to 6.5.22 
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 30 May 2025 14:24:23 +0800
+
 deepin-voice-note (6.5.21) unstable; urgency=medium
 
   * chore: New version 6.5.21.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     voice note for deepin os

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     voice note for deepin os

--- a/src/handler/voice_recoder_handler.h
+++ b/src/handler/voice_recoder_handler.h
@@ -47,7 +47,9 @@ private:
     void initAudioWatcher();
 
     bool checkVolume();
-
+    QString tryGetMicNameFromPactl() const;
+    QString getDefaultMicDeviceName() const;
+    
 private slots:
     void onAudioDeviceChange(int mode);
     void onAudioBufferProbed(const QAudioBuffer &buffer);


### PR DESCRIPTION
- Implemented the feature to obtain default audio source input information via the pactl command, and this source is used only when the noise reduction feature is active.

bug: https://pms.uniontech.com/bug-view-309299.html