### PR TITLE
    fix: Update MIPS architecture dependencies in debian/control     

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.28.1
+  version: 6.5.29.1
   kind: app
   description: |
     voice note for deepin os

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.29) unstable; urgency=medium
+
+  * fix: Update MIPS architecture dependencies in debian/control
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Sat, 21 Jun 2025 19:51:34 +0800
+
 deepin-voice-note (6.5.28) unstable; urgency=medium
 
   * fix: Update lrelease command detection for Qt6 compatibility

--- a/debian/control
+++ b/debian/control
@@ -56,7 +56,9 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
  qml6-module-qt-labs-platform [!mipsel !mips64el] | qml-module-qt-labs-platform [mipsel mips64el],
 # qml6-module-qtgraphicaleffects [!mipsel !mips64el] | qml-module-qtgraphicaleffects [mipsel mips64el],
  qml6-module-qtwebchannel [!mipsel !mips64el] | qml-module-qtwebchannel [mipsel mips64el],
- qml6-module-qtwebengine [!mipsel !mips64el] | qml-module-qtwebengine [mipsel mips64el]
+ qml6-module-qtwebengine [!mipsel !mips64el] | qml-module-qtwebengine [mipsel mips64el],
+ libdtkdeclarative5 [mipsel mips64el],
+ qml-module-qtgraphicaleffects [mipsel mips64el]
 Recommends: uos-reporter, deepin-event-log, libvlc5 [!mipsel !mips64el]
 Description: Voice Notes is a lightweight memo tool to make text notes and voice recordings
   Voice Notes is a simple memo software with texts and voice recordings. You are able to save the recordings as MP3 format or texts.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.28.1
+  version: 6.5.29.1
   kind: app
   description: 4
     voice note for deepin os

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.28.1
+  version: 6.5.29.1
   kind: app
   description: |
     voice note for deepin os


### PR DESCRIPTION
    fix: Update MIPS architecture dependencies in debian/control
    
    - Added libdtkdeclarative5 and qml-module-qtgraphicaleffects for MIPS architecture to ensure proper functionality.
    - This change maintains compatibility with both Qt 5 and Qt 6.
    
    Log: Update MIPS architecture dependencies in debian/control
    
    bug: https://pms.uniontech.com/bug-view-320881.html
