### PR TITLE
 fix: Update header formatting in voice notes documentation

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.30.1
+  version: 6.5.31.1
   kind: app
   description: |
     voice note for deepin os

--- a/assets/deepin-voice-note/voice-notes/en_US/voice-notes.md
+++ b/assets/deepin-voice-note/voice-notes/en_US/voice-notes.md
@@ -1,4 +1,4 @@
-# Voice Notes | deepin-voice-note
+# Voice Notes|deepin-voice-note|
 
 ## Overview
 

--- a/assets/deepin-voice-note/voice-notes/zh_HK/voice-notes.md
+++ b/assets/deepin-voice-note/voice-notes/zh_HK/voice-notes.md
@@ -1,4 +1,4 @@
-# 語音記事本 | deepin-voice-note
+# 語音記事本|deepin-voice-note|
 
 ## 概述
 

--- a/assets/deepin-voice-note/voice-notes/zh_TW/voice-notes.md
+++ b/assets/deepin-voice-note/voice-notes/zh_TW/voice-notes.md
@@ -1,4 +1,4 @@
-# 語音記事本 | deepin-voice-note
+# 語音記事本|deepin-voice-note|
 
 ## 概述
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.31) unstable; urgency=medium
+
+  * fix: Update header formatting in voice notes documentation
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Tue, 24 Jun 2025 17:49:33 +0800
+
 deepin-voice-note (6.5.30) unstable; urgency=medium
 
   * chore: New version 6.5.30.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.30.1
+  version: 6.5.31.1
   kind: app
   description: 4
     voice note for deepin os

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.30.1
+  version: 6.5.31.1
   kind: app
   description: |
     voice note for deepin os


### PR DESCRIPTION
 fix: Update header formatting in voice notes documentation
    
    - Adjusted header formatting in English, Traditional Chinese, and Hong Kong Chinese voice notes documentation by removing spaces around the pipe symbol.
    - This change improves consistency in the documentation style.
    
    Log: Update header formatting in voice notes documentation
    
    bug: https://pms.uniontech.com/bug-view-321609.html