### PR TITLE
fix: Change childActions return type to QVariantList

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.31.1
+  version: 6.5.32.1
   kind: app
   description: |
     voice note for deepin os

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.32) unstable; urgency=medium
+
+  * fix: Change childActions return type to QVariantList
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 26 Jun 2025 13:52:37 +0800
+
 deepin-voice-note (6.5.31) unstable; urgency=medium
 
   * fix: Update header formatting in voice notes documentation

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.31.1
+  version: 6.5.32.1
   kind: app
   description: 4
     voice note for deepin os

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.31.1
+  version: 6.5.32.1
   kind: app
   description: |
     voice note for deepin os

--- a/src/common/actionmanager.cpp
+++ b/src/common/actionmanager.cpp
@@ -226,9 +226,14 @@ ActionManager::ComponentType ActionManager::actionCompType(ActionKind id)
 /*!
  * \brief 返回菜单项 \a id 的子菜单项列表
  */
-QList<ActionManager::ActionKind> ActionManager::childActions(ActionKind id)
+QVariantList ActionManager::childActions(ActionKind id)
 {
-    return childActionMap.value(id);
+    QList<ActionKind> children = childActionMap.value(id);
+    QVariantList result;
+    for (ActionKind child : children) {
+        result.append(static_cast<int>(child));
+    }
+    return result;
 }
 
 /*!

--- a/src/common/actionmanager.h
+++ b/src/common/actionmanager.h
@@ -143,7 +143,7 @@ public:
     Q_INVOKABLE QString actionText(ActionKind id);
     Q_INVOKABLE ComponentType actionCompType(ActionKind id);
     // 获取子菜单项
-    Q_INVOKABLE QList<ActionKind> childActions(ActionKind id);
+    Q_INVOKABLE QVariantList childActions(ActionKind id);
     // 用于 QML 组件初始化和标记动作触发
     Q_INVOKABLE void setActionObject(ActionKind id, QObject *obj);
     Q_SLOT void actionTriggerFromQuick(ActionKind actionId);


### PR DESCRIPTION
-  It can't work use QList<int> in Qml of Qt5.
- Change ActionManager::childActions() return type from QList<ActionKind> to QVariantList

Log: Change childActions return type to QVariantList

bug: https://pms.uniontech.com/bug-view-321525.html