### PR TITLE
fix: Fix no-network dialog size

### DIFF
--- a/src/views/vnotemainwindow.cpp
+++ b/src/views/vnotemainwindow.cpp
@@ -1773,6 +1773,7 @@ void VNoteMainWindow::showAsrErrMessage(const QString &strMessage)
     m_asrErrMeassage->setMessage(strMessage);
     m_asrErrMeassage->setVisible(true);
     m_asrErrMeassage->setMinimumHeight(60);
+    m_asrErrMeassage->setMinimumWidth(200);
     m_asrErrMeassage->setMaximumWidth(m_centerWidget->width());
     m_asrErrMeassage->adjustSize();
 


### PR DESCRIPTION
Fixed the resizing issue of the no-network dialog by providing default dimensions when none were specified.

Log: Adjust no-network dialog default size
Bug: https://pms.uniontech.com/bug-view-324785.html