### PR TITLE
fix: Implement timeout mechanism for speech-to-text

### DIFF
--- a/src/common/vnotea2tmanager.h
+++ b/src/common/vnotea2tmanager.h
@@ -9,6 +9,7 @@
 #include <QObject>
 #include <QDBusInterface>
 #include <QScopedPointer>
+#include <QTimer>
 
 struct asrMsg {
     QString code;
@@ -50,6 +51,7 @@ public:
         AudioOther, //其他
         NetworkError, //网络错误
         DontCareError,
+        TimeoutError, //超时错误
     };
 
 signals:
@@ -60,6 +62,8 @@ signals:
 public slots:
     //转写过程中，信息处理
     void onNotify(const QString &msg);
+    //超时处理
+    void onTimeout();
 
 protected:
     //转写信息解析
@@ -77,6 +81,7 @@ protected:
     //XunFei message code string
     const QString CODE_SUCCESS {"000000"};
     const QString CODE_NETWORK {"900003"};
+    const QString CODE_TIMEOUT {"900004"}; // 超时错误码
 
     //XunFei state code
     enum State {
@@ -98,6 +103,9 @@ protected:
         XF_other = 99,
     };
 
+    // 超时时间常量 (毫秒)
+    static const int ASR_TIMEOUT_MS = 60000; // 1分钟超时
+
     // 新接口相关
     QScopedPointer<QDBusInterface> m_newAsrInterface;
     
@@ -107,6 +115,9 @@ protected:
     
     // 接口类型标识
     bool m_useNewInterface;
+    
+    // 超时定时器
+    QTimer m_timeoutTimer;
 };
 
 #endif // VNOTEA2TMANAGER_H

--- a/src/views/vnotemainwindow.cpp
+++ b/src/views/vnotemainwindow.cpp
@@ -872,6 +872,10 @@ void VNoteMainWindow::onA2TError(int error)
         message = DApplication::translate(
                       "VNoteErrorMessage",
                       "The voice conversion failed due to the poor network connection, please have a check");
+    } else if (error == VNoteA2TManager::TimeoutError) {
+        message = DApplication::translate(
+                      "VNoteErrorMessage",
+                      "Voice to text conversion timed out, please try again");
     } else {
         message = DApplication::translate(
                       "VNoteErrorMessage",

--- a/translations/deepin-voice-note_zh_CN.ts
+++ b/translations/deepin-voice-note_zh_CN.ts
@@ -492,6 +492,11 @@
         <translation>网络异常，转写失败</translation>
     </message>
     <message>
+        <location filename="../src/views/vnotemainwindow.cpp" line="878"/>
+        <source>Voice to text conversion timed out, please try again</source>
+        <translation>转写超时，请重试</translation>
+    </message>
+    <message>
         <location filename="../src/views/vnotemainwindow.cpp" line="876"/>
         <source>Voice to text conversion failed</source>
         <translation>语音转文字失败</translation>


### PR DESCRIPTION
Added a 60-second timeout mechanism to terminate speech-to-text processing when:
1.UOS-AI backend stops unexpectedly
2.Network connection becomes unstable
3.Backend fails to send completion signal to Voice Notes

Log: Add speech-to-text timeout safeguard
Bug: https://pms.uniontech.com/bug-view-324785.html