### PR TITLE
fix: Tiny audio inputs close to 0 still drew graphical fluctuations.

### DIFF
--- a/src/widgets/vnwaveform.cpp
+++ b/src/widgets/vnwaveform.cpp
@@ -77,7 +77,12 @@ void VNWaveform::paintEvent(QPaintEvent *event)
     const QColor endColor(1, 121, 255);
 
     for (int i = 0; (i < m_audioScaleSamples.size() && i < m_maxShowedSamples); i++) {
-        qreal scaler = qSqrt(m_audioScaleSamples[i]) / m_frameGain;
+        qreal scaler = 0.0;
+        // 类似linein的方式，在没有真实输入的情况下，因为电流等原因导致的接近0的微小音频也会引起波动
+        // 用户不希望此种场景造成波动，所以设定了阈值，超过阈值再绘制波动即可
+        if (m_frameGain > 2 * m_defaultGain) {
+            scaler = qSqrt(m_audioScaleSamples[i]) / m_frameGain;
+        }
 
         qreal waveHeight = scaler * height();
 


### PR DESCRIPTION
1. Set a minimum audio threshold; do not draw graphical fluctuations for audio below this threshold.

In scenarios without actual input, tiny audio signals close to 0 caused by factors such as electrical current can also trigger fluctuations. Users do not want such scenarios to cause fluctuations, so a threshold is set, and fluctuations are only drawn when the threshold is exceeded.

fix: 接近0的音频微小输入仍然绘制了图形波动

1. 设置音频最小阈值，低于阈值的音频不绘制图形波动

在没有真实输入的情况下，因为电流等原因导致的接近0的微小音频也会引起波动，用户不希望此种场景造成波动，所以设定了阈值，超过阈值再绘制波动即可

Bug: https://pms.uniontech.com/bug-view-324985.html