### PR TITLE
fix: Update icon sizes and layout adjustments in MainWindow and Windo…

### DIFF
--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -363,13 +363,13 @@ ApplicationWindow {
     IconLabel {
         id: appImage
 
-        height: 30
-        icon.height: 30
+        height: 36
+        icon.height: 36
         icon.name: "deepin-voice-note"
-        icon.width: 30
-        width: 30
+        icon.width: 36
+        width: 36
         x: 10
-        y: 10
+        y: 7
         z: 100
     }
 
@@ -377,12 +377,12 @@ ApplicationWindow {
         id: twoColumnModeBtn
 
         height: 30
-        icon.height: 14
+        icon.height: 16
         icon.name: "sidebar"
-        icon.width: 14
+        icon.width: 16
         visible: !(needHideSearch && search.visible) || leftBgArea.visible
         width: 30
-        x: 50
+        x: 66
         y: 10
         z: 100
 

--- a/src/gui/mainwindow/WindowTitleBar.qml
+++ b/src/gui/mainwindow/WindowTitleBar.qml
@@ -21,7 +21,7 @@ TitleBar {
     signal titleOpenSetting
 
     enableInWindowBlendBlur: false
-    height: 40
+    height: 50
     width: 0
 
     background: Rectangle {


### PR DESCRIPTION
…wTitleBar

- Increased icon dimensions in MainWindow to 36x36 for better visibility.
- Adjusted the position of the app image and two-column mode button for improved layout.
- Updated WindowTitleBar height from 40 to 50 for a more balanced appearance.

bug: https://pms.uniontech.com/bug-view-332357.html
     https://pms.uniontech.com/bug-view-332381.html