### PR TITLE
fix: Add audio recording state management across main components

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -15,6 +15,7 @@ Item {
 
     property int currentDropIndex: -1
     property bool isPlay: false
+    property bool isRecordingAudio: false 
     property int itemHeight: 30
     property int lastDropIndex: -1
     property int listHeight: 700
@@ -574,7 +575,7 @@ Item {
                 }
 
                 MenuItem {
-                    enabled: !isPlay
+                    enabled: !isPlay && !isRecordingAudio 
                     text: qsTr("New Note")
 
                     onTriggered: {

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -21,6 +21,7 @@ Item {
     property bool hasScroll: false
     property bool initialVisible: false
     property bool isRecording: false
+    property bool isRecordingAudio: false 
     property bool noSearchResult: false
     property bool webVisible: true
     property alias titleBar: title
@@ -205,6 +206,7 @@ Item {
             Layout.fillWidth: true
             imageBtnEnable: webVisible
             isInitialInterface: initialVisible
+            isRecordingAudio: rootItem.isRecordingAudio 
 
             onTitleOpenSetting: {
                 rootItem.openSetting();

--- a/src/gui/mainwindow/WindowTitleBar.qml
+++ b/src/gui/mainwindow/WindowTitleBar.qml
@@ -11,6 +11,7 @@ TitleBar {
     property bool isInitialInterface: true
     property bool isPlaying: false
     property bool isRecording: false
+    property bool isRecordingAudio: false  
     property bool isSearching: false
     property bool recorderBtnEnable: true
     property bool recordingHover: false
@@ -49,7 +50,7 @@ TitleBar {
         anchors.left: titleBar.left
         anchors.leftMargin: 10
         anchors.verticalCenter: titleBar.verticalCenter
-        enabled: !isPlaying && !isSearching
+        enabled: !isPlaying && !isSearching && !isRecordingAudio
         hoverEnabled: !isInitialInterface
         icon.name: "new_note"
 

--- a/src/handler/voice_recoder_handler.cpp
+++ b/src/handler/voice_recoder_handler.cpp
@@ -66,6 +66,7 @@ void VoiceRecoderHandler::stopRecoder()
         emit finishedRecod(m_recordPath, m_recordMsec);
         m_type = RecoderType::Idle;
         OpsStateInterface::instance()->operState(OpsStateInterface::StateRecording, false);
+        emit recoderStateChange(m_type); 
         updateWave(0.0);
     } else {
         qDebug() << "Recorder already idle";


### PR DESCRIPTION
- Introduced `isRecordingAudio` property to manage audio recording state in MainWindow, FolderListView, WebEngineView, and WindowTitleBar.
- Updated menu item and button states to disable actions while audio is being recorded.
- Implemented connections to listen for recording state changes from the VoiceRecoderHandler.

Log: Enhanced user experience by preventing note creation and other actions during audio recording.

https://pms.uniontech.com/bug-view-335263.html
https://pms.uniontech.com/bug-view-335479.html