### PR TITLE
fix: Enhance note creation process with folder validation

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.41.1
+  version: 6.5.42.1
   kind: app
   description: |
     voice note for deepin os

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.42) unstable; urgency=medium
+
+  * fix: Enhance note creation process with folder validation
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 25 Sep 2025 14:46:27 +0800
+
 deepin-voice-note (6.5.41) unstable; urgency=medium
 
   * chore: Update linglong base and runtime

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.41.1
+  version: 6.5.42.1
   kind: app
   description: 4
     voice note for deepin os

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.41.1
+  version: 6.5.42.1
   kind: app
   description: |
     voice note for deepin os

--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -404,6 +404,11 @@ void VNoteMainManager::createNote()
         qWarning() << "Cannot create note: No current folder selected";
         return;
     }
+    VNoteFolder *currentFolder = getFloderById(m_currentFolderIndex);
+    if (currentFolder == nullptr) {
+        qWarning() << "Cannot create note: Current folder not found for ID:" << m_currentFolderIndex;
+        return;
+    }
     qDebug() << "Creating new note in folder ID:" << m_currentFolderIndex;
     VNoteItem tmpNote;
     tmpNote.folderId = m_currentFolderIndex;
@@ -414,6 +419,10 @@ void VNoteMainManager::createNote()
     tmpNote.noteTitle = noteOper.getDefaultNoteName(tmpNote.folderId);
 
     VNoteItem *newNote = noteOper.addNote(tmpNote);
+    if (newNote == nullptr) {
+        qWarning() << "Create note failed: addNote returned null";
+        return;
+    }
     m_currentNoteId = newNote->noteId;
 
     m_noteItems.append(newNote);
@@ -423,9 +432,8 @@ void VNoteMainManager::createNote()
     data.insert(NOTE_TIME_KEY, Utils::convertDateTime(newNote->modifyTime));
     data.insert(NOTE_MODIFY_TIME_KEY, newNote->modifyTime.toString("yyyy-MM-dd hh:mm:ss"));
     data.insert(NOTE_ISTOP_KEY, newNote->isTop);
-    VNoteFolder *folder = getFloderById(newNote->folderId);
-    data.insert(NOTE_FOLDER_ICON_KEY, QString::number(folder->defaultIcon));
-    data.insert(NOTE_FOLDER_NAME_KEY, folder->name);
+    data.insert(NOTE_FOLDER_ICON_KEY, QString::number(currentFolder->defaultIcon));
+    data.insert(NOTE_FOLDER_NAME_KEY, currentFolder->name);
     data.insert(NOTE_ID_KEY, newNote->noteId);
 
     emit addNoteAtHead(data);

--- a/src/db/vnoteitemoper.cpp
+++ b/src/db/vnoteitemoper.cpp
@@ -142,8 +142,10 @@ VNoteItem *VNoteItemOper::addNote(VNoteItem &note)
     qDebug() << "Adding new note to folder:" << note.folderId;
     VNoteFolderOper folderOps;
     VNoteFolder *folder = folderOps.getFolder(note.folderId);
-
-    Q_ASSERT(nullptr != folder);
+    if (Q_UNLIKELY(folder == nullptr)) {
+        qWarning() << "Cannot add note: folder not found for ID:" << note.folderId;
+        return nullptr;
+    }
 
     folder->maxNoteIdRef()++;
 


### PR DESCRIPTION
- Added checks to ensure the current folder is selected and exists before creating a note.
- Implemented error handling for cases where the folder or note creation fails, providing appropriate warnings.

Log: Improved robustness of the note creation functionality by validating folder existence.

bug: https://pms.uniontech.com/bug-view-335623.html