### PR TITLE
fix: Implement restrictions on note and folder deletion during audio …

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.43.1
+  version: 6.5.44.1
   kind: app
   description: |
     voice note for deepin os

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.44) unstable; urgency=medium
+
+  * fix: Implement restrictions on note and folder deletion during audio recording and playback
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 10 Oct 2025 19:02:42 +0800
+
 deepin-voice-note (6.5.43) unstable; urgency=medium
 
   * fix: Implement restrictions on note and folder creation during audio recording and playback

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.43.1
+  version: 6.5.44.1
   kind: app
   description: 4
     voice note for deepin os

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice.note
-  version: 6.5.43.1
+  version: 6.5.44.1
   kind: app
   description: |
     voice note for deepin os

--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -290,6 +290,12 @@ void VNoteMainManager::vNoteCreateFolder()
 void VNoteMainManager::vNoteDeleteFolder(const int &index)
 {
     qDebug() << "Deleting folder at index:" << index;
+    // 录音或播放中禁止删除
+    if (VoiceRecoderHandler::instance()->getRecoderType() == VoiceRecoderHandler::Recording
+        || OpsStateInterface::instance()->isPlaying()) {
+        qWarning() << "Cannot delete folder while recording or playing";
+        return;
+    }
     VNoteFolder *folder = getFloderByIndex(index);
 
     int listIndex = m_folderSort.indexOf(QString::number(folder->id));
@@ -603,6 +609,12 @@ void VNoteMainManager::deleteNote(const QList<int> &index)
 {
     // 删除之前清空JS详情页内容
     qDebug() << "Deleting" << index.size() << "notes";
+    // 录音或播放中禁止删除
+    if (VoiceRecoderHandler::instance()->getRecoderType() == VoiceRecoderHandler::Recording
+        || OpsStateInterface::instance()->isPlaying()) {
+        qWarning() << "Cannot delete note while recording or playing";
+        return;
+    }
     m_richTextManager->clearJSContent();
     QList<VNoteItem *> noteDataList;
     for (int i = 0; i < index.size(); i++) {

--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -162,7 +162,7 @@ Item {
         root.forceActiveFocus();
     }
     Keys.onDeletePressed: {
-        if (webVisible) {
+        if (webVisible || isRecordingAudio || isPlay) {
             console.log("No notes available, cannot delete folder");
             return;
         }
@@ -551,7 +551,7 @@ Item {
                 }
 
                 MenuItem {
-                    enabled: !isPlay
+                    enabled: !isPlay && !isRecordingAudio
                     text: qsTr("Delete")
 
                     onTriggered: {

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -17,6 +17,7 @@ Item {
     id: rootItem
 
     property bool isPlay: false
+    property bool isRecordingAudio: false
     property bool isSearch: false
     property bool isSearching: false
     property int itemSpacing: 6
@@ -171,7 +172,7 @@ Item {
     width: 640
 
     Keys.onDeletePressed: {
-        if (webVisible) {
+        if (webVisible || isRecordingAudio || isPlay) {
             console.log("No notes available, cannot delete");
             return;
         }
@@ -443,6 +444,8 @@ Item {
             topItem.text = setTop ? qsTr("Sticky on Top") : qsTr("Unpin");
 
             ActionManager.enableVoicePlayActions(!isPlay);
+            // 录音或播放中禁用删除
+            ActionManager.enableAction(ActionManager.NoteDelete, !isRecordingAudio && !isPlay);
             
             // 在搜索状态下禁用移动、置顶和新建笔记选项
             if (isSearching) {

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -715,6 +715,7 @@ ApplicationWindow {
                     Layout.fillWidth: true
                     moveToFolderDialog.folderModel: folderListView.model
                     webVisible: initRect.visible
+                    isRecordingAudio: rootWindow.isRecordingAudio
 
                     onDeleteFinished: {
                         webEngineView.toggleMultCho(1);


### PR DESCRIPTION
…recording and playback

- Added checks to prevent the deletion of notes and folders while audio is being recorded or played.
- Updated UI elements to reflect these restrictions, enhancing user experience by avoiding conflicts during audio operations.

Log: Improved state management for note and folder deletion in relation to audio activities.

bug: https://pms.uniontech.com/bug-view-336411.html