### PR TITLE
fix: Add folder ID handling and enhance note deletion tracking

### DIFF
--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -67,6 +67,7 @@ signals:
     void updateNotes(const QList<QVariantMap> &notesData, const int &selectIndex);
     void addNoteAtHead(const QVariantMap &noteData);
     void addFolderFinished(const QVariantMap &folderData);
+    void notesDeleted(const QVariantMap &folderIdToDeletedCount);
     void noSearchResult();
     void searchFinished(const QList<QVariantMap> &notesData, const QString &key);
     void moveFinished(const QVariantList &index, const int &srcFolderIndex, const int &dstFolderIndex);

--- a/src/globaldef.h
+++ b/src/globaldef.h
@@ -62,6 +62,7 @@
 #define FOLDER_COUNT_KEY "notesCount"
 #define FOLDER_ICON_KEY "icon"
 #define FOLDER_SORT_KEY "sortNumber"
+#define FOLDER_ID_KEY "folderId"
 
 //Time format
 #define VNOTE_TIME_FMT "yyyy-MM-dd HH:mm:ss.zzz"

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -219,7 +219,8 @@ ApplicationWindow {
                 folderListView.model.append({
                     name: foldersData[i].name,
                     count: foldersData[i].notesCount,
-                    icon: foldersData[i].icon
+                    icon: foldersData[i].icon,
+                    folderId: foldersData[i].folderId
                 });
             }
         }
@@ -314,6 +315,20 @@ ApplicationWindow {
         }
         onAddNoteAtHead: {
             handleaddNote(noteData);
+        }
+        onNotesDeleted: {
+            
+            for (var i = 0; i < folderListView.model.count; i++) {
+                var folder = folderListView.model.get(i);
+                var fidStr = folder.folderId.toString();
+                var dec = folderIdToDeletedCount[fidStr];
+                if (dec !== undefined) {
+                    var oldCount = Number(folder.count);
+                    var newCount = oldCount - Number(dec);
+                    folder.count = newCount.toString();
+                    console.log("QML: Updated folder", folder.name, "count from", oldCount, "to", newCount);
+                }
+            }
         }
         onFinishedFolderLoad: {
             if (foldersData.length > 0) {
@@ -501,7 +516,7 @@ ApplicationWindow {
                 target: itemListView
 
                 onDeleteNotes: {
-                    folderListView.delNote(number);
+                    // 数量更新统一依赖后端 onNotesDeleted(folderId->count)
                 }
                 onDropRelease: {
                     var indexList = [];


### PR DESCRIPTION
- Introduced FOLDER_ID_KEY in global definitions for folder identification.
- Updated VNoteMainManager to include folder ID when loading notepads and track deleted notes per folder ID.
- Enhanced QML integration to update folder note counts upon deletion, improving UI responsiveness.

Log: Improved folder management and note deletion tracking for better user experience.

bug: https://pms.uniontech.com/bug-view-335319.html