### PR TITLE
fix: Update file name filtering to use QRegularExpression for Qt 6 co…

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -18,6 +18,11 @@
 #include <QBuffer>
 #include <QFileInfo>
 #include <QProcess>
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
 #include <QTextDocument>
 #include <QTextDocumentFragment>
 
@@ -391,12 +396,15 @@ QString Utils::filteredFileName(QString fileName, const QString &defaultName)
 {
     qDebug() << "Filtering file name:" << fileName << "default:" << defaultName;
     //使用正则表达式除去不符合规范的字符并清理文件名两端的空白字符，中间的空白字符不做处理
-    // QString name = fileName.replace(QRegExp("[\"\'\\[\\]\\\\/:|<>+=;,?*]"), "").trimmed();
-    // if (name.isEmpty()) {
-    //     return defaultName;
-    // }
-    // return name;
-    return QString();
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QString name = fileName.replace(QRegularExpression("[\"\'\\[\\]\\\\/:|<>+=;,?*]"), "").trimmed();
+#else
+    QString name = fileName.replace(QRegExp("[\"\'\\[\\]\\\\/:|<>+=;,?*]"), "").trimmed();
+#endif
+    if (name.isEmpty()) {
+        return defaultName;
+    }
+    return name;
 }
 
 bool Utils::isWayland()


### PR DESCRIPTION
…mpatibility

- Modified the file name filtering logic to utilize QRegularExpression when compiling with Qt 6 or higher, ensuring compatibility with the latest Qt features.
- Retained the previous QRegExp implementation for earlier Qt versions, maintaining functionality across different environments.

Log: Improved file name filtering method for better compatibility with Qt 6.

bug: https://pms.uniontech.com/bug-view-331421.html