### PR TITLE
fix: Update default file name handling in search mode

### DIFF
--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -256,7 +256,12 @@ Item {
                 
                 var defaultFileName = "";
                 if (selectedNoteItem.length > 0 && itemModel.get(selectedNoteItem[0])) {
-                    defaultFileName = itemModel.get(selectedNoteItem[0]).name;
+                    // 在搜索模式下使用纯文本标题，避免HTML标签出现在文件名中
+                    if (isSearch) {
+                        defaultFileName = VNoteMainManager.getNotePlainTitle(itemModel.get(selectedNoteItem[0]).noteId);
+                    } else {
+                        defaultFileName = itemModel.get(selectedNoteItem[0]).name;
+                    }
                     if (saveType === VNoteMainManager.Text && !defaultFileName.toLowerCase().endsWith('.txt')) {
                         defaultFileName += '.txt';
                     } else if (saveType === VNoteMainManager.Html && !defaultFileName.toLowerCase().endsWith('.html')) {


### PR DESCRIPTION
- Modified the logic for setting the default file name to use plain text titles when in search mode, preventing HTML tags from appearing in file names.
- Retained the original behavior for non-search scenarios, ensuring consistent file naming.

Log: Enhanced file naming process for improved usability during note searches.

bug: https://pms.uniontech.com/bug-view-335313.html