### PR TITLE
fix: Update network state check to use NetworkManager D-Bus

### DIFF
--- a/src/handler/voice_to_text_handler.cpp
+++ b/src/handler/voice_to_text_handler.cpp
@@ -64,17 +64,19 @@ void VoiceToTextHandler::onA2TStart()
 bool VoiceToTextHandler::checkNetworkState()
 {
     qDebug() << "Checking network state";
-    QDBusInterface network("org.deepin.dde.Network1", "/org/deepin/dde/Network1",
-                           "org.deepin.dde.Network1");
+    QDBusInterface network("org.freedesktop.NetworkManager",
+                           "/org/freedesktop/NetworkManager",
+                           "org.freedesktop.NetworkManager",
+                           QDBusConnection::systemBus());
 
     if (!network.isValid()) {
-        qWarning() << "Failed to obtain the network status DBUS";
+        qWarning() << "Failed to obtain the network status from NetworkManager D-Bus";
         return false;
     }
 
     QVariant ret = network.property("State");
     bool isConnected = (ret.toInt() == 70);
-    qDebug() << "Network state:" << (isConnected ? "Connected" : "Disconnected");
+    qDebug() << "Network state:" << ret.toInt() << (isConnected ? "Connected" : "Disconnected");
     return isConnected;
 }
 


### PR DESCRIPTION
- Changed the D-Bus interface for network state checking from Deepin's Network1 to the standard freedesktop NetworkManager.
- Improved logging for network status retrieval to provide clearer error messages and state information.

Log: Enhanced network connectivity checks by utilizing the more widely supported NetworkManager D-Bus interface, improving reliability and clarity in network state reporting.

bug: https://pms.uniontech.com/bug-view-337823.html