### PR TITLE
fix: Implement recording key blocking during audio recording

### DIFF
--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -93,6 +93,7 @@ ApplicationWindow {
         enabled: rootWindow.active
 
         blockCreateKeys: (isRecordingAudio || webEngineView.titleBar.isPlaying)
+        blockRecordingKey: isRecordingAudio
         initialOnlyCreateFolder: initRect.visible
 
         onCopy: {

--- a/src/gui/mainwindow/Shortcuts.qml
+++ b/src/gui/mainwindow/Shortcuts.qml
@@ -8,6 +8,8 @@ Item {
     property bool blockCreateKeys: false
     // 初始页面仅允许 Ctrl+N / F1，其它快捷键全部禁用
     property bool initialOnlyCreateFolder: false
+    // 录音过程中禁用录音快捷键，避免重复启动录音导致崩溃
+    property bool blockRecordingKey: false
 
     signal copy
     signal createFolder
@@ -104,7 +106,7 @@ Item {
 
     Shortcut {
         id: ctrl_R
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.initialOnlyCreateFolder && !item.blockRecordingKey
 
         sequence: "Ctrl+R"
 


### PR DESCRIPTION
- Added a new property to block recording shortcuts when audio is being recorded, preventing potential crashes from repeated recording attempts.
- Updated the shortcut enabling logic to incorporate this new property, ensuring a smoother user experience during recording sessions.

Log: Enhanced application stability by preventing shortcut conflicts during audio recording.

bug: https://pms.uniontech.com/bug-view-338707.html