### PR TITLE
fix: Update opacity handling in FolderListView and ItemListView during audio recording

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -316,7 +316,6 @@ Item {
         clip: true
         enabled: parent.enabled
         model: folderModel
-        opacity: isRecordingAudio ? 0.5 : 1.0  // 录音时置灰
 
         ScrollBar.vertical: ScrollBar {
             id: verticalScrollBar
@@ -330,6 +329,9 @@ Item {
             property var startMove: [-1, -1]
             property bool tooltipVisible: false
             property bool cancelRename: false
+            
+            // 录音时：当前文件夹保持正常显示，其他文件夹置灰
+            opacity: (isRecordingAudio && index !== folderListView.currentIndex) ? 0.5 : 1.0
 
             color: index === folderListView.currentIndex ? (root.activeFocus ? palette.highlight : DTK.themeType === ApplicationHelper.LightType ? "#33000000" : "#33FFFFFF") : (isHovered ? (DTK.themeType === ApplicationHelper.LightType ? "#1A000000" : "#1AFFFFFF") : "transparent")
             enabled: !isPlay || index === folderListView.currentIndex

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -654,7 +654,6 @@ Item {
         model: itemModel
         spacing: itemSpacing
         visible: true
-        opacity: isRecordingAudio ? 0.5 : 1.0  // 录音时置灰
 
         delegate: Rectangle {
             id: rootItemDelegate
@@ -666,6 +665,8 @@ Item {
 
             color: isSelected ? (rootItem.activeFocus ? palette.highlight : (DTK.themeType === ApplicationHelper.LightType ? "#33000000" : "#33FFFFFF")) : (DTK.themeType === ApplicationHelper.LightType ? "white" : "#0CFFFFFF")
             enabled: !isPlay || itemListView.currentIndex === index
+            // 录音时：当前项保持正常显示，其他项置灰
+            opacity: (isRecordingAudio && index !== itemListView.currentIndex) ? 0.5 : 1.0
             // 列表项高度始终使用非重命名的计算方式，重命名时高度保持不变
             height: (function() {
                 var topM = 8;

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -514,13 +514,13 @@ Item {
                 ActionManager.enableAction(ActionManager.NoteTop, false);
                 ActionManager.enableAction(ActionManager.NoteAddNew, false);
             } else {
-                // 录音或播放时禁用移动、置顶和新建
+                // 录音或播放时禁用移动和新建（会影响当前笔记），但置顶保持可用
                 ActionManager.enableAction(ActionManager.NoteMove, !isRecordingAudio && !isPlay);
-                ActionManager.enableAction(ActionManager.NoteTop, !isRecordingAudio && !isPlay);
+                ActionManager.enableAction(ActionManager.NoteTop, true);  // 置顶是轻量操作，始终可用
                 ActionManager.enableAction(ActionManager.NoteAddNew, !isRecordingAudio && !isPlay);
             }
             
-            // 录音时保存语音菜单置灰，但重命名和保存笔记保持可用
+            // 录音时保存语音菜单置灰，但重命名、置顶和保存笔记保持可用
             if (isRecordingAudio) {
                 ActionManager.enableAction(ActionManager.NoteSaveVoice, false);
             }

--- a/src/handler/web_engine_handler.cpp
+++ b/src/handler/web_engine_handler.cpp
@@ -10,6 +10,7 @@
 #include "vtextspeechandtrmanager.h"
 #include "voice_player_handler.h"
 #include "voice_to_text_handler.h"
+#include "voice_recoder_handler.h"
 #include "setting.h"
 #include "globaldef.h"
 
@@ -93,6 +94,17 @@ WebEngineHandler::WebEngineHandler(QObject *parent)
             Q_EMIT playingVoice(true);
         }
     });
+    
+    // 监听录音状态变化，控制编辑器中语音播放按钮的启用/禁用
+    connect(VoiceRecoderHandler::instance(), &VoiceRecoderHandler::recoderStateChange, this, 
+            [](VoiceRecoderHandler::RecoderType type) {
+        qInfo() << "WebEngineHandler: Recording state changed to:" << type;
+        // 录音时禁用播放按钮，非录音时启用
+        bool enablePlayButton = (type != VoiceRecoderHandler::Recording);
+        qInfo() << "WebEngineHandler: Setting voice play button enable to:" << enablePlayButton;
+        Q_EMIT JsContent::instance()->callJsSetVoicePlayBtnEnable(enablePlayButton);
+    });
+    
     qInfo() << "WebEngineHandler constructor finished";
 }
 

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -142,6 +142,7 @@ var global_activeColor = ''
 var global_disableColor = ''
 var global_theme = 1    // theme type 1:light 2:dark
 var global_themeColor = 'transparent'  //主题色
+var global_isRecording = false  // 录音状态标志
 var scrollHide = null  //滚动条隐藏定时器
 var scrollHideFont = null  //字体滚动条定时
 var isUlOrOl = false
@@ -604,6 +605,12 @@ function isRangeVoice() {
  * 播放按钮点击时触发
  */
 $('body').on('click', '.voiceBtn', function (e) {
+    // 录音时禁止播放语音
+    if (global_isRecording) {
+        console.log("Cannot play voice while recording");
+        return;
+    }
+    
     var curPlayback = $(this).parents('.voicePlayback:first');
     // 点击浮动窗口时视同点击焦点音频播放控件
     if (curPlayback.is(airVoicePlayback)) {
@@ -780,6 +787,10 @@ function initData(text) {
  * @returns {any}
  */
 function playButColor(status) {
+    // 更新录音状态（启用时不录音，禁用时在录音）
+    global_isRecording = !status;
+    console.log("playButColor: status=" + status + ", global_isRecording=" + global_isRecording);
+    
     if (!status) {
         setVoiceButColor(global_disableColor, global_disableColor)
 
@@ -1070,6 +1081,9 @@ function rightClick(e) {
  * @returns {any}
  */
 function setVoiceButColor(color, shdow) {
+    // 判断是否为禁用状态（颜色和阴影都是禁用色）
+    var isDisabled = (color === global_disableColor && shdow === global_disableColor);
+    
     $("#style").html(`
     :root {
         --highlightColor: ${color};
@@ -1077,7 +1091,8 @@ function setVoiceButColor(color, shdow) {
 
     .voiceBox .voiceBtn {
         background-color: ${color};
-        box-shadow: 0px 4px 6px 0px ${shdow}80; 
+        box-shadow: 0px 4px 6px 0px ${shdow}80;
+        ${isDisabled ? 'filter: grayscale(100%) opacity(0.5);' : ''}
     } 
     ::selection {
         background: ${color}!important;
@@ -1118,7 +1133,12 @@ function changeColor(flag, activeColor, disableColor, backgroundColor) {
     global_activeColor = activeColor
     global_disableColor = disableColor
     global_themeColor = backgroundColor
-    setVoiceButColor(global_activeColor, global_disableColor)
+    // 根据录音状态设置按钮颜色：录音时置灰，非录音时正常
+    if (global_isRecording) {
+        setVoiceButColor(global_disableColor, global_disableColor)
+    } else {
+        setVoiceButColor(global_activeColor, global_disableColor)
+    }
 
     $('.dropdown-fontsize>li>a').hover(function (e) {
         $(this).css('background-color', activeColor);


### PR DESCRIPTION
fix: Update opacity handling in FolderListView and ItemListView during audio recording

- Removed the previous opacity setting for the entire view when recording audio, allowing the current folder/item to remain fully visible.
- Implemented conditional opacity for other folders/items to indicate recording status, enhancing user feedback during audio sessions.

Log: Improved visual feedback for folder and item views during audio recording to enhance user experience and clarity.

bug: https://pms.uniontech.com/bug-view-337765.html