### PR TITLE
chore: Update version to 6.5.49

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.48.1
+  version: 6.5.49.1
   kind: app
   description: |
     voice note for deepin os

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.49) unstable; urgency=medium
+
+  * fix: Add jsCallGetAppDataPath method and enhance voice path handling
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 13 Nov 2025 20:28:48 +0800
+
 deepin-voice-note (6.5.48) unstable; urgency=medium
 
   * fix bugs. 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.48.1
+  version: 6.5.49.1
   kind: app
   description: 4
     voice note for deepin os

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.48.1
+  version: 6.5.49.1
   kind: app
   description: |
     voice note for deepin os

--- a/mips64/linglong.yaml
+++ b/mips64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.48.1
+  version: 6.5.49.1
   kind: app
   description: |
     voice note for deepin os

--- a/sw64/linglong.yaml
+++ b/sw64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.48.1
+  version: 6.5.49.1
   kind: app
   description: |
     voice note for deepin os


### PR DESCRIPTION
- Incremented version number to 6.5.49.
- Updated version in all architecture-specific linglong.yaml files and the debian changelog.

Log: Version bump for deepin-voice-note to reflect latest changes.