### PR TITLE
fix: Standardize voice file path handling across modules

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -35,6 +35,20 @@ Utils::Utils()
     qInfo() << "Utils constructor called";
 }
 
+QString Utils::makeVoiceAbsolute(const QString &voicePath)
+{
+    const QUrl url(voicePath);
+    if (url.isValid() && !url.scheme().isEmpty())
+        return voicePath;
+    const QString vNative = QDir::toNativeSeparators(voicePath);
+    if (QDir::isAbsolutePath(vNative))
+        return vNative;
+    const QString appData = QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+    if (appData.isEmpty())
+        return voicePath;
+    return QDir::toNativeSeparators(QDir::cleanPath(appData + QDir::separator() + vNative));
+}
+
 /**
  * @brief Utils::convertDateTime
  * @param dateTime 时间

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -64,4 +64,6 @@ public:
     static bool isCommunityEdition();
     // 将音频绝对路径转换为相对路径（AppData/voicenote/... -> voicenote/...）
     static QString makeVoiceRelative(const QString &voicePath);
+    // 将音频相对路径转换为绝对路径（voicenote/... -> AppData/voicenote/...），若已为绝对/URL则原样返回
+    static QString makeVoiceAbsolute(const QString &voicePath);
 };

--- a/src/handler/voice_player_handler.cpp
+++ b/src/handler/voice_player_handler.cpp
@@ -11,25 +11,6 @@
 #include <QLibrary>
 #include <QDebug>
 #include <QUrl>
-namespace {
-// voicePath 为相对路径时，转换为绝对路径
-static inline QString expandVoiceToAbsolute(const QString &voicePath)
-{
-    const QUrl url(voicePath);
-    if (url.isValid() && !url.scheme().isEmpty()) {
-        return voicePath;
-    }
-    const QString vNative = QDir::toNativeSeparators(voicePath);
-    if (QDir::isAbsolutePath(vNative)) {
-        return vNative;
-    }
-    const QString appData = QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
-    if (appData.isEmpty()) {
-        return voicePath;
-    }
-    return QDir::toNativeSeparators(QDir::cleanPath(appData + QDir::separator() + vNative));
-}
-}
 
 #include "vnoteitem.h"
 #include "common/vlcplayer.h"
@@ -83,7 +64,7 @@ void VoicePlayerHandler::playVoice(const QVariant &json, bool bIsSame)
         parser.parse(json, m_voiceBlock.get());
         // 展开相对路径为绝对路径，便于实际播放
         if (m_voiceBlock && !m_voiceBlock->voicePath.isEmpty()) {
-            m_voiceBlock->voicePath = expandVoiceToAbsolute(m_voiceBlock->voicePath);
+            m_voiceBlock->voicePath = Utils::makeVoiceAbsolute(m_voiceBlock->voicePath);
         }
     }
 

--- a/src/handler/web_engine_handler.cpp
+++ b/src/handler/web_engine_handler.cpp
@@ -538,8 +538,13 @@ void WebEngineHandler::processVoiceMenuRequest(QObject *request)
         return;
     }
 
+    // 展开相对路径为绝对路径，避免误判
+    if (m_voiceBlock && !m_voiceBlock->voicePath.isEmpty()) {
+        m_voiceBlock->voicePath = Utils::makeVoiceAbsolute(m_voiceBlock->voicePath);
+    }
+
     // 语音文件不存在使用弹出提示
-    if (!QFile(m_voiceBlock->voicePath).exists()) {
+    if (!QFile::exists(m_voiceBlock->voicePath)) {
         // 异步操作，防止阻塞前端事件
         QTimer::singleShot(0, this, [this] {
             Q_EMIT requestMessageDialog(VNoteMessageDialogHandler::VoicePathNoAvail);
@@ -568,8 +573,13 @@ void WebEngineHandler::processVoiceMenuRequest(QWebEngineContextMenuRequest *req
         return;
     }
 
+    // 展开相对路径为绝对路径，避免误判
+    if (m_voiceBlock && !m_voiceBlock->voicePath.isEmpty()) {
+        m_voiceBlock->voicePath = Utils::makeVoiceAbsolute(m_voiceBlock->voicePath);
+    }
+
     // 语音文件不存在使用弹出提示
-    if (!QFile(m_voiceBlock->voicePath).exists()) {
+    if (!QFile::exists(m_voiceBlock->voicePath)) {
         qInfo() << "Voice file does not exist";
         // 异步操作，防止阻塞前端事件
         QTimer::singleShot(0, this, [this] {

--- a/src/task/exportnoteworker.cpp
+++ b/src/task/exportnoteworker.cpp
@@ -253,9 +253,10 @@ ExportNoteWorker::ExportError ExportNoteWorker::exportOneVoice(VNoteBlock *noteb
         QString baseFileName = m_exportPath + "/" + noteblock->ptrVoice->voiceTitle;
         QString fileSuffix = ".mp3";
         QString dstFileName = getExportFileName(baseFileName, fileSuffix);
-        qDebug() << "Copying voice file to:" << dstFileName;
-        if (!QFile::copy(noteblock->ptrVoice->voicePath, dstFileName)) {
-            qWarning() << "Failed to copy voice file from:" << noteblock->ptrVoice->voicePath;
+        const QString srcPath = Utils::makeVoiceAbsolute(noteblock->ptrVoice->voicePath);
+        qDebug() << "Copying voice file from:" << srcPath << "to:" << dstFileName;
+        if (!QFile::copy(srcPath, dstFileName)) {
+            qWarning() << "Failed to copy voice file from:" << srcPath;
             error = Savefailed; //保存失败
         } else {
             qInfo() << "Successfully exported voice to:" << dstFileName;


### PR DESCRIPTION
- Add Utils::makeVoiceAbsolute() method to convert relative voice paths to absolute paths consistently
- Refactor voice_player_handler.cpp to use centralized path conversion utility instead of local helper
- Update web_engine_handler.cpp to use Utils::makeVoiceAbsolute() for voice menu request processing
- Fix exportnoteworker.cpp to properly convert relative paths before file copy operations
- Remove duplicate expandVoiceToAbsolute() implementations across multiple modules
- Ensure consistent handling of voicenote/ relative paths and AppData/voicenote/ absolute paths

This standardization resolves voice playback failures, context menu operation errors, and export functionality issues caused by inconsistent path format handling between different application modules.

修复: 统一各模块间语音文件路径处理逻辑

- 添加Utils::makeVoiceAbsolute()方法，统一处理相对路径到绝对路径的转换
- 重构voice_player_handler.cpp使用集中式路径转换工具替代本地辅助函数
- 更新web_engine_handler.cpp在语音菜单请求处理中使用Utils::makeVoiceAbsolute()
- 修复exportnoteworker.cpp在文件复制操作前正确转换相对路径
- 移除多个模块中重复的expandVoiceToAbsolute()实现
- 确保voicenote/相对路径和AppData/voicenote/绝对路径的一致性处理

此标准化解决了由于不同应用模块间路径格式处理不一致导致的语音播放失败、右键菜单操作错误和导出功能问题。

bug： https://pms.uniontech.com/bug-view-340979.html
            https://pms.uniontech.com/bug-view-340969.html