### PR TITLE
fix: Sync save voice button state between context menu and multiple s…

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -983,16 +983,18 @@ void VNoteMainManager::insertImages(const QList<QUrl> &filePaths)
 void VNoteMainManager::checkNoteVoice(const QVariantList &index)
 {
     qInfo() << "Checking note voice for" << index.size() << "notes";
+    bool hasVoice = false;
     foreach (auto id, index) {
         int noteIndex = id.toInt();
         VNoteItem *item = getNoteById(noteIndex);
         if (item->haveVoice()) {
-            ActionManager::instance()->enableAction(ActionManager::NoteSaveVoice, true);
-            return;
+            hasVoice = true;
+            break;
         }
     }
-    ActionManager::instance()->enableAction(ActionManager::NoteSaveVoice, false);
-    qInfo() << "Note voice check finished";
+    ActionManager::instance()->enableAction(ActionManager::NoteSaveVoice, hasVoice);
+    emit saveVoiceStateChanged(hasVoice);
+    qInfo() << "Note voice check finished, hasVoice:" << hasVoice;
 }
 
 void VNoteMainManager::checkNoteText(const QVariantList &index)

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -77,6 +77,7 @@ signals:
     void scrollChange(const bool &isTop);
     void updateEditNote(const int &noteId, const QString &time);
     void noteTitleChanged(const int &noteId, const QString &newTitle);
+    void saveVoiceStateChanged(bool enabled);
 
 private slots:
     void onVNoteFoldersLoaded();

--- a/src/gui/mainwindow/MultipleChoices.qml
+++ b/src/gui/mainwindow/MultipleChoices.qml
@@ -7,6 +7,7 @@ Item {
     id: rootWindow
 
     property int selectSize: 0
+    property bool saveVoiceEnabled: true
 
     signal deleteNote
     signal moveNote
@@ -14,6 +15,10 @@ Item {
     signal saveNote
 
     visible: false
+
+    function setSaveVoiceEnabled(enabled) {
+        saveVoiceEnabled = enabled;
+    }
 
     Rectangle {
         anchors.fill: parent
@@ -81,6 +86,7 @@ Item {
                         leftPadding: 0
                         rightPadding: 0
                         text: qsTr("Save Voice")
+                        enabled: saveVoiceEnabled
 
                         onClicked: {
                             saveAudio();

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -664,4 +664,14 @@ Item {
             }
         }
     }
+
+    Connections {
+        target: VNoteMainManager
+
+        onSaveVoiceStateChanged: enabled => {
+            if (multipleChoicesLoader.active && multipleChoicesLoader.item) {
+                multipleChoicesLoader.item.setSaveVoiceEnabled(enabled);
+            }
+        }
+    }
 }


### PR DESCRIPTION
…election view

- Add saveVoiceEnabled property to MultipleChoices.qml to control save voice button state
- Add setSaveVoiceEnabled() function in MultipleChoices.qml for external state updates
- Add saveVoiceStateChanged(bool enabled) signal to VNoteMainManager to notify UI state changes
- Modify VNoteMainManager::checkNoteVoice() to emit saveVoiceStateChanged signal after voice check
- Add Connections in WebEngineView.qml to listen for saveVoiceStateChanged and update MultipleChoices
- Ensure save voice button in multiple selection view matches context menu behavior (enabled/disabled based on voice content)

This fix resolves the inconsistency where the context menu save voice option was properly grayed out based on voice content, but the save voice button in the multiple selection detail view remained always enabled regardless of whether the selected notes contained voice recordings.

修复: 同步右键菜单和多选详情页中保存语音按钮的状态

- 在MultipleChoices.qml中添加saveVoiceEnabled属性来控制保存语音按钮状态
- 在MultipleChoices.qml中添加setSaveVoiceEnabled()函数供外部状态更新
- 在VNoteMainManager中添加saveVoiceStateChanged(bool enabled)信号来通知UI状态变化
- 修改VNoteMainManager::checkNoteVoice()在语音检查后发出saveVoiceStateChanged信号
- 在WebEngineView.qml中添加Connections监听saveVoiceStateChanged并更新MultipleChoices
- 确保多选详情页中的保存语音按钮与右键菜单行为一致(根据语音内容启用/禁用)

此修复解决了右键菜单中的保存语音选项能根据语音内容正确置灰，但多选详情页中的保存语音按钮无论选中笔记是否包含语音录制都始终保持启用状态的不一致问题。

https://pms.uniontech.com/bug-view-339519.html