### PR TITLE
fix: Remove global space key shortcut to prevent unintended voice pla…

### DIFF
--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -121,13 +121,7 @@ ApplicationWindow {
             }
             VNoteMainManager.createNote();
         }
-        onPlayPauseVoice: {
-            if (initRect.visible) {
-                console.log("No notes available, cannot play/pause voice");
-                return;
-            }
-            VNoteMainManager.resumeVoicePlayer();
-        }
+
         onRenameFolder: {
             if (initRect.visible) {
                 console.log("No notes available, cannot rename folder");

--- a/src/gui/mainwindow/Shortcuts.qml
+++ b/src/gui/mainwindow/Shortcuts.qml
@@ -10,6 +10,8 @@ Item {
     property bool initialOnlyCreateFolder: false
     // 录音过程中禁用录音快捷键，避免重复启动录音导致崩溃
     property bool blockRecordingKey: false
+    // 录音状态，用于禁用播放快捷键
+    property bool isRecordingAudio: false
 
     signal copy
     signal createFolder
@@ -115,16 +117,8 @@ Item {
         }
     }
 
-    Shortcut {
-        id: playPause
-        enabled: !item.initialOnlyCreateFolder
-
-        sequence: "Space"
-
-        onActivated: {
-            playPauseVoice();
-        }
-    }
+    // 移除全局空格键快捷键，让JavaScript层独自处理语音播放/暂停
+    // JavaScript层已经有完整的录音状态检查和选中状态检查逻辑
 
     Shortcut {
         id: ctrl_B


### PR DESCRIPTION
…yback

- Remove global space key shortcut from Shortcuts.qml that bypassed JavaScript selection checks
- Remove corresponding onPlayPauseVoice handler from MainWindow.qml
- Let JavaScript layer (index.js) handle space key exclusively with proper state validation
- JavaScript layer already includes recording state check (global_isRecording) and selection check ($('.li.active'))
- Prevent space key from triggering voice playback during recording or when no voice block is selected

This fix resolves the issue where pressing space during recording or without selecting any voice block would unexpectedly trigger voice playback from previously played audio files.

修复: 移除全局空格键快捷键以防止意外的语音播放

- 从Shortcuts.qml中移除绕过JavaScript选中检查的全局空格键快捷键
- 从MainWindow.qml中移除对应的onPlayPauseVoice处理函数
- 让JavaScript层(index.js)独占处理空格键并进行适当的状态验证
- JavaScript层已包含录音状态检查(global_isRecording)和选中状态检查($('.li.active'))
- 防止在录音时或未选中语音块时按空格键触发语音播放

此修复解决了在录音过程中或未选中任何语音块时按空格键会意外触发播放之前音频文件的问题。

bug: https://pms.uniontech.com/bug-view-341017.html