### PR TITLE
fix: Block Ctrl+N shortcut during search mode and clear search highli…

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -1016,9 +1016,11 @@ void VNoteMainManager::checkNoteText(const QVariantList &index)
 
 void VNoteMainManager::clearSearch()
 {
-    // qInfo() << "Clearing search";
+    qInfo() << "Clearing search";
     m_searchText = "";
-    // qInfo() << "Search cleared";
+    // 发出信号清除搜索高亮
+    emit updateRichTextSearch("");
+    qInfo() << "Search cleared";
 }
 
 bool VNoteMainManager::isInSearchMode() const

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -93,7 +93,11 @@ ApplicationWindow {
 
         enabled: rootWindow.active
 
-        blockCreateKeys: (isRecordingAudio || webEngineView.titleBar.isPlaying)
+        blockCreateKeys: {
+            var shouldBlock = (isRecordingAudio || webEngineView.titleBar.isPlaying || itemListView.isSearch || itemListView.isSearching || webEngineView.titleBar.isSearching);
+            console.warn("blockCreateKeys:", shouldBlock, "- isRecordingAudio:", isRecordingAudio, "isPlaying:", webEngineView.titleBar.isPlaying, "isSearch:", itemListView.isSearch, "isSearching:", itemListView.isSearching, "titleBar.isSearching:", webEngineView.titleBar.isSearching);
+            return shouldBlock;
+        }
         blockRecordingKey: isRecordingAudio
         initialOnlyCreateFolder: initRect.visible
 


### PR DESCRIPTION
…ghts on exit

- Add search state checks to blockCreateKeys in MainWindow.qml to disable Ctrl+N during search
- Include itemListView.isSearch, itemListView.isSearching, and webEngineView.titleBar.isSearching in blockCreateKeys condition
- Emit updateRichTextSearch("") signal in VNoteMainManager::clearSearch() to clear WebEngineView search highlights
- Ensure Ctrl+N behavior matches UI button behavior (disabled during search, recording, and playback)
- Fix search highlight persistence issue where keywords remained highlighted after exiting search mode

This fix resolves inconsistent shortcut behavior during search mode and ensures proper cleanup of search highlights when users exit search functionality.

修复: 搜索模式下屏蔽Ctrl+N快捷键并在退出时清除搜索高亮

- 在MainWindow.qml的blockCreateKeys中添加搜索状态检查以在搜索时禁用Ctrl+N
- 在blockCreateKeys条件中包含itemListView.isSearch、itemListView.isSearching和webEngineView.titleBar.isSearching
- 在VNoteMainManager::clearSearch()中发出updateRichTextSearch("")信号以清除WebEngineView搜索高亮
- 确保Ctrl+N行为与UI按钮行为一致(在搜索、录音和播放时禁用)
- 修复搜索高亮持续问题，即用户退出搜索功能后关键字仍保持高亮的问题

此修复解决了搜索模式下快捷键行为不一致的问题，并确保用户退出搜索功能时正确清理搜索高亮。

https://pms.uniontech.com/bug-view-340201.html