### PR TITLE
Commit20251127

### DIFF
--- a/src/audio/gstreamrecorder.cpp
+++ b/src/audio/gstreamrecorder.cpp
@@ -185,8 +185,14 @@ void GstreamRecorder::deinit()
 {
     qDebug() << "Deinitializing GstreamRecorder...";
     stopRecord();
-    objectUnref(m_pipeline);
-    gst_deinit();
+
+    // 确保管道状态切换到 NULL 再释放，避免 GStreamer 在 PLAYING 状态析构元素
+    if (m_pipeline) {
+        setStateToNull();
+        objectUnref(m_pipeline);
+        m_pipeline = nullptr;
+    }
+
     qDebug() << "GstreamRecorder deinitialized";
 }
 
@@ -352,8 +358,14 @@ void GstreamRecorder::setOutputFile(const QString &path)
         
         // 销毁旧管道以避免filesink location修改问题
         qDebug() << "Destroying existing pipeline to avoid filesink location modification";
-        gst_object_unref(m_pipeline);
-        m_pipeline = nullptr;
+
+        // 完成了正常的 EOS 处理和文件写入，这里只做快速清理：
+        // 确保管道处于 NULL 状态后再 unref，避免 GStreamer 在 PLAYING 状态析构元素。
+        if (m_pipeline) {
+            setStateToNull();
+            objectUnref(m_pipeline);
+            m_pipeline = nullptr;
+        }
         qDebug() << "Old pipeline destroyed, will create new pipeline for next recording";
     } else if (m_pipeline != nullptr) {
         qDebug() << "Pipeline exists but output file is same, no need to rebuild";

--- a/src/gui/mainwindow/Shortcuts.qml
+++ b/src/gui/mainwindow/Shortcuts.qml
@@ -108,12 +108,22 @@ Item {
 
     Shortcut {
         id: ctrl_R
-        enabled: !item.initialOnlyCreateFolder && !item.blockRecordingKey
+        // 初始页面、录音中或显式要求屏蔽录音快捷键时，均不响应 Ctrl+R
+        enabled: !item.initialOnlyCreateFolder && !rootWindow.isRecordingAudio && !item.blockRecordingKey
 
         sequence: "Ctrl+R"
 
         onActivated: {
-            startRecording();
+            console.warn("Ctrl+R activated - initialOnlyCreateFolder:", item.initialOnlyCreateFolder,
+                         "isRecordingAudio:", rootWindow.isRecordingAudio,
+                         "blockRecordingKey:", item.blockRecordingKey);
+
+            // 双重保护：只在未录音时启动录音，录音过程中不响应
+            if (!rootWindow.isRecordingAudio) {
+                startRecording();
+            } else {
+                console.warn("Ctrl+R ignored: recording is already in progress");
+            }
         }
     }
 


### PR DESCRIPTION
修复: 避免重复按录音快捷键导致崩溃并改进录音状态处理

确保 Ctrl+R 仅在未录音时才触发开始录音

使用 isRecordingAudio 与 blockRecordingKey 双重保护录音快捷键

录音进行中屏蔽 Ctrl+R，避免重复创建录音管道

在释放前先将 GStreamer 管道状态切换为 NULL，防止在 PLAYING 状态下析构

调整 GstreamRecorder::setOutputFile() 中管道复用逻辑，避免不安全的 unref

在 deinit() 中保留 stopRecord() + 状态重置的安全清理流程

该修复解决了在录音过程中频繁按 Ctrl+R 导致崩溃的问题，