### PR TITLE
fix: Correct audio output device enablement logic in AudioWatcher

### DIFF
--- a/src/audio/audio_watcher.cpp
+++ b/src/audio/audio_watcher.cpp
@@ -146,7 +146,8 @@ void AudioWatcher::updateDeviceEnabled(const QString cardsStr, bool isEmitSig)
     if (isEmitSig)
         sigDeviceEnableChanged(Micphone, m_inIsEnable);
     m_outAudioPort = currentAuidoPort(m_outAuidoPorts,Internal);
-    m_outIsEnable = (m_outAudioPort.availability == 2 || m_inAudioPort.availability == 0)? true : false;
+    // 此时应该使用 m_outAudioPort.availability 来判断是否启用
+    m_outIsEnable = (m_outAudioPort.availability == 2 || m_outAudioPort.availability == 0)? true : false;
     if (isEmitSig)
         sigDeviceEnableChanged(Internal, m_outIsEnable);
 


### PR DESCRIPTION
- Updated the logic for determining the enablement of the output audio port in AudioWatcher::updateDeviceEnabled() to use m_outAudioPort.availability instead of m_inAudioPort.availability. This change ensures that the output device's availability is accurately assessed, improving the reliability of audio device management.

This fix addresses potential issues with audio output device detection and state management.

bug: https://pms.uniontech.com/bug-view-342693.html