### PR TITLE
fix: Add voice-to-text state management

### DIFF
--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -88,6 +88,7 @@ signals:
     void updateEditNote(const int &noteId, const QString &time);
     void noteTitleChanged(const int &noteId, const QString &newTitle);
     void saveVoiceStateChanged(bool enabled);
+    void voiceToTextStateChanged(bool isConverting);
 
 private slots:
     void onVNoteFoldersLoaded();

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -18,6 +18,7 @@ ApplicationWindow {
     property int createFolderBtnHeight: 40
     property bool isRecording: webEngineView.isRecording
     property bool isRecordingAudio: false
+    property bool isVoiceToText: false
     property int leftAreaMaxWidth: 300
     property int leftAreaMinWidth: 125
     property int leftViewWidth: 220
@@ -94,8 +95,7 @@ ApplicationWindow {
         enabled: rootWindow.active
 
         blockCreateKeys: {
-            var shouldBlock = (isRecordingAudio || webEngineView.titleBar.isPlaying || itemListView.isSearch || itemListView.isSearching || webEngineView.titleBar.isSearching);
-            console.warn("blockCreateKeys:", shouldBlock, "- isRecordingAudio:", isRecordingAudio, "isPlaying:", webEngineView.titleBar.isPlaying, "isSearch:", itemListView.isSearch, "isSearching:", itemListView.isSearching, "titleBar.isSearching:", webEngineView.titleBar.isSearching);
+            var shouldBlock = (isRecordingAudio || webEngineView.titleBar.isPlaying || itemListView.isSearch || itemListView.isSearching || webEngineView.titleBar.isSearching || isVoiceToText);
             return shouldBlock;
         }
         // 与右上录音按钮同条件：按钮不可用或正在播放时禁用 Ctrl+R
@@ -408,6 +408,9 @@ ApplicationWindow {
         }
         onSelectNoteByIndex: function(selectIndex) {
             itemListView.selectNoteItem(selectIndex);
+        }
+        onVoiceToTextStateChanged: function(isConverting) {
+            isVoiceToText = isConverting;
         }
     }
 

--- a/src/handler/voice_to_text_handler.cpp
+++ b/src/handler/voice_to_text_handler.cpp
@@ -11,6 +11,7 @@
 #include "common/vnoteitem.h"
 #include "common/vnotea2tmanager.h"
 #include "common/jscontent.h"
+#include "common/VNoteMainManager.h"
 #include "opsstateinterface.h"
 
 /**
@@ -57,6 +58,7 @@ void VoiceToTextHandler::onA2TStart()
 {
     qInfo() << "VoiceToTextHandler onA2TStart called";
     OpsStateInterface::instance()->operState(OpsStateInterface::StateVoice2Text, true);
+    emit VNoteMainManager::instance()->voiceToTextStateChanged(true);
     Q_EMIT JsContent::instance()->callJsSetVoiceText(QString(""), JsContent::AsrFlag::Start);
     QTimer::singleShot(0, this, [this]() { m_a2tManager->startAsr(m_voiceBlock->voicePath, m_voiceBlock->voiceSize); });
 }
@@ -86,6 +88,7 @@ void VoiceToTextHandler::onA2TError(int error)
     // TODO(renbin): 弹窗提示
     Q_EMIT JsContent::instance()->callJsSetVoiceText("", JsContent::AsrFlag::End);
     OpsStateInterface::instance()->operState(OpsStateInterface::StateVoice2Text, false);
+    emit VNoteMainManager::instance()->voiceToTextStateChanged(false);
 }
 
 void VoiceToTextHandler::onA2TSuccess(const QString &text)
@@ -93,4 +96,5 @@ void VoiceToTextHandler::onA2TSuccess(const QString &text)
     qInfo() << "VoiceToTextHandler onA2TSuccess called";
     Q_EMIT JsContent::instance()->callJsSetVoiceText(text, JsContent::AsrFlag::End);
     OpsStateInterface::instance()->operState(OpsStateInterface::StateVoice2Text, false);
+    emit VNoteMainManager::instance()->voiceToTextStateChanged(false);
 }


### PR DESCRIPTION
- Introduced voiceToTextStateChanged signal in VNoteMainManager to notify UI about the voice-to-text conversion state.
- Updated MainWindow.qml to include isVoiceToText property and handle state changes from the voice-to-text handler.
- Enhanced VoiceToTextHandler to emit state changes during conversion start, success, and error events.

This addition improves user experience by providing real-time feedback on the voice-to-text conversion process.

bug: https://pms.uniontech.com/bug-view-342383.html