### PR TITLE
fix: Update recording state handling in MainWindow.qml

### DIFF
--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -419,7 +419,8 @@ ApplicationWindow {
         target: VoiceRecoderHandler
 
         onRecoderStateChange: function(type) {
-            isRecordingAudio = (type === VoiceRecoderHandler.Recording);
+            // 录音中或录音暂停时都视为"正在录音"状态，禁用相关操作
+            isRecordingAudio = (type === VoiceRecoderHandler.Recording || type === VoiceRecoderHandler.Paused);
             console.log("MainWindow: Recording state changed to:", type, "isRecordingAudio:", isRecordingAudio);
         }
     }


### PR DESCRIPTION
- Modified the onRecoderStateChange function to consider both recording and paused states as "recording" to disable related operations.
- This change enhances user experience by preventing unintended actions during recording or pause states.

bug: https://pms.uniontech.com/bug-view-341643.html