### PR TITLE
fix: Update menu item state handling in FolderListView.qml

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -610,7 +610,8 @@ Item {
                 }
 
                 MenuItem {
-                    enabled: !isPlay && !isRecordingAudio
+                    id: deleteMenuItem
+                    enabled: !root.isPlay && !root.isRecordingAudio
                     text: qsTr("Delete")
 
                     onTriggered: {
@@ -634,7 +635,8 @@ Item {
                 }
 
                 MenuItem {
-                    enabled: !isPlay && !isRecordingAudio 
+                    id: newNoteMenuItem
+                    enabled: !root.isPlay && !root.isRecordingAudio 
                     text: qsTr("New Note")
 
                     onTriggered: {


### PR DESCRIPTION
- Refactored the enabled property for the delete and new note menu items to reference the root context's isPlay and isRecordingAudio properties. This change ensures that the menu items are correctly enabled or disabled based on the application's playback and recording states, improving user interaction consistency.

This fix enhances the user experience by preventing unintended actions when the application is in specific states.

bug: https://pms.uniontech.com/bug-view-341637.html