### PR TITLE
chore: Update version to 6.5.53

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.52.1
+  version: 6.5.53.1
   kind: app
   description: |
     voice note for deepin os

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.53) unstable; urgency=medium
+
+  * fix: Update message display and toolbar behavior in WebEngineView.qml and index.js
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Tue, 06 Jan 2026 17:14:07 +0800
+
 deepin-voice-note (6.5.52) UNRELEASED; urgency=medium
 
   * feat: Integrate D-Bus service for voice note management 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.52.1
+  version: 6.5.53.1
   kind: app
   description: 4
     voice note for deepin os

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.52.1
+  version: 6.5.53.1
   kind: app
   description: |
     voice note for deepin os

--- a/mips64/linglong.yaml
+++ b/mips64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.52.1
+  version: 6.5.53.1
   kind: app
   description: |
     voice note for deepin os

--- a/sw64/linglong.yaml
+++ b/sw64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.52.1
+  version: 6.5.53.1
   kind: app
   description: |
     voice note for deepin os


### PR DESCRIPTION
- Incremented version number to 6.5.53
- Updated version in all architecture-specific linglong.yaml files and the debian changelog.

Log: Version bump for deepin-voice-note to reflect latest changes.