### PR TITLE
fix: Add environment variable for Chromium flags on SW-64 architecture

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,10 @@ int main(int argc, char *argv[])
     qDebug() << "MIPS64: Applied DTK configuration workarounds";
 #endif
 
+#ifdef __sw_64__
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--js-flags=--jitless");
+#endif
+
     DApplication *app = new DApplication(argc, argv);
 
     qInfo() << "Starting deepin-voice-note application...";


### PR DESCRIPTION
- Introduced a new environment variable setting for QTWEBENGINE_CHROMIUM_FLAGS to enable JIT-less JavaScript execution specifically for the SW-64 architecture.
- This change aims to optimize performance and compatibility for applications running on this architecture.

This addition enhances the application's adaptability to different system architectures.

bug: https://pms.uniontech.com/bug-view-347387.html