### PR TITLE
fix: dragging the progress bar requires a position jump.

### DIFF
--- a/src/widgets/vnoteplaywidget.cpp
+++ b/src/widgets/vnoteplaywidget.cpp
@@ -180,9 +180,8 @@ void VNotePlayWidget::onSliderReleased()
         if (pos >= m_slider->maximum()) {
             onCloseBtnClicked();
         } else {
-            if (m_player->getState() == VlcPalyer::Playing) {
-                m_player->setPosition(pos);
-            }
+            // 播放和暂停时，都需要跳转位置，否则体验不好
+            m_player->setPosition(pos);
         }
     }
 }


### PR DESCRIPTION
When playing or pausing an audio file, dragging the progress bar requires a position jump. 
录音文件在播放和暂停时，拖动进度条，都需要跳转位置。

Bug: https://pms.uniontech.com/bug-view-353041.html