### PR TITLE
fix(webrichtexteditor): add image drag-and-drop validation

### DIFF
--- a/src/views/webrichtexteditor.cpp
+++ b/src/views/webrichtexteditor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2019 UnionTech Software Technology Co.,Ltd.
+// Copyright (C) 2019 - 2026 UnionTech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -600,7 +600,26 @@ void WebRichTextEditor::contextMenuEvent(QContextMenuEvent *e)
  */
 void WebRichTextEditor::dragEnterEvent(QDragEnterEvent *event)
 {
-    event->acceptProposedAction();
+    // 只接受图片文件的拖拽（jpg, png, bmp）
+    if (event->mimeData()->hasUrls()) {
+        bool hasValidImage = false;
+        for (const auto &url : event->mimeData()->urls()) {
+            QString suffix = QFileInfo(url.path()).suffix().toLower();
+            if (suffix == "jpg" || suffix == "png" || suffix == "bmp") {
+                hasValidImage = true;
+                break;
+            }
+        }
+        if (hasValidImage) {
+            event->acceptProposedAction();
+        } else {
+            event->ignore();
+        }
+    } else if (event->mimeData()->hasImage()) {
+        event->acceptProposedAction();
+    } else {
+        event->ignore();
+    }
 }
 
 /**
@@ -620,7 +639,26 @@ void WebRichTextEditor::dragLeaveEvent(QDragLeaveEvent *event)
  */
 void WebRichTextEditor::dragMoveEvent(QDragMoveEvent *e)
 {
-    Q_UNUSED(e);
+    // 只接受图片文件的拖拽（jpg, png, bmp）
+    if (e->mimeData()->hasUrls()) {
+        bool hasValidImage = false;
+        for (const auto &url : e->mimeData()->urls()) {
+            QString suffix = QFileInfo(url.path()).suffix().toLower();
+            if (suffix == "jpg" || suffix == "png" || suffix == "bmp") {
+                hasValidImage = true;
+                break;
+            }
+        }
+        if (hasValidImage) {
+            e->acceptProposedAction();
+        } else {
+            e->ignore();
+        }
+    } else if (e->mimeData()->hasImage()) {
+        e->acceptProposedAction();
+    } else {
+        e->ignore();
+    }
 }
 
 void WebRichTextEditor::dropEvent(QDropEvent *event)


### PR DESCRIPTION
- Implement MIME type checking to only accept image files (jpg, png, bmp)
- Add URL validation logic to filter valid image formats during drag operations
- Update dragEnterEvent and dragMoveEvent handlers to properly handle image file validation before accepting proposed actions
- Prevent non-image files from being processed in the rich text editor Log: fix(webrichtexteditor): add image drag-and-drop validation Bug: https://pms.uniontech.com/bug-view-354083.html