### PR TITLE
fix: block keyboard shortcuts during drag-and-drop operations

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,6 +14,7 @@ Item {
     id: root
 
     property int currentDropIndex: -1
+    property bool isDragging: false
     property bool isPlay: false
     property bool isRecordingAudio: false
     property bool isVoiceToText: false
@@ -191,7 +192,7 @@ Item {
             event.accepted = true;
             break;
         case Qt.Key_Delete:
-            if (webVisible || isRecordingAudio || isPlay) {
+            if (root.isDragging || webVisible || isRecordingAudio || isPlay) {
                 console.log("No notes available, cannot delete folder");
                 return;
             }
@@ -492,6 +493,8 @@ Item {
                 id: folderMouseArea
 
                 property bool held: false
+
+                onHeldChanged: root.isDragging = held
 
                 acceptedButtons: Qt.LeftButton | Qt.RightButton
                 anchors.fill: parent

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,7 @@ import org.deepin.dtk 1.0
 Item {
     id: rootItem
 
+    property bool isDragging: false
     property bool isPlay: false
     property bool isRecordingAudio: false
     property bool isSearch: false
@@ -238,7 +239,7 @@ Item {
              event.accepted = true;
              break;
         case Qt.Key_Delete:
-            if (webVisible || isRecordingAudio || isPlay) {
+            if (rootItem.isDragging || webVisible || isRecordingAudio || isPlay) {
                 console.log("No notes available, cannot delete");
                 return;
             }
@@ -897,6 +898,8 @@ Item {
                 id: noteItemMouseArea
 
                 property bool held: false
+
+                onHeldChanged: rootItem.isDragging = held
 
                 acceptedButtons: Qt.LeftButton | Qt.RightButton
                 anchors.fill: parent

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -92,7 +92,7 @@ ApplicationWindow {
     Shortcuts {
         id: shortcuts
 
-        enabled: rootWindow.active
+        enabled: rootWindow.active && !itemListView.isDragging && !folderListView.isDragging
 
         blockCreateKeys: {
             var shouldBlock = (isRecordingAudio || webEngineView.titleBar.isPlaying || itemListView.isSearch || itemListView.isSearching || webEngineView.titleBar.isSearching || isVoiceToText);
@@ -103,6 +103,7 @@ ApplicationWindow {
                            || webEngineView.titleBar.isPlaying
                            || !webEngineView.titleBar.recordBtnEnabled
         initialOnlyCreateFolder: initRect.visible
+        isDragging: itemListView.isDragging || folderListView.isDragging
 
         onCopy: {
             webEngineView.copy();

--- a/src/gui/mainwindow/Shortcuts.qml
+++ b/src/gui/mainwindow/Shortcuts.qml
@@ -12,6 +12,8 @@ Item {
     property bool blockRecordingKey: false
     // 录音状态，用于禁用播放快捷键
     property bool isRecordingAudio: false
+    // 拖拽状态下禁用所有快捷键
+    property bool isDragging: false
 
     signal copy
     signal createFolder
@@ -30,7 +32,7 @@ Item {
 
         //帮助手册
         autoRepeat: false
-        enabled: true
+        enabled: !item.isDragging
         sequence: "F1"
 
         onActivated: {
@@ -40,7 +42,7 @@ Item {
 
     Shortcut {
         id: ctrl_Shift_H
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
 
         //快捷键界面
         sequence: "Ctrl+Shift+/"
@@ -52,7 +54,7 @@ Item {
 
     Shortcut {
         id: ctrl_S
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
 
         sequence: "Ctrl+S"
 
@@ -63,7 +65,7 @@ Item {
 
     Shortcut {
         id: ctrl_D
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
 
         sequence: "Ctrl+D"
 
@@ -77,7 +79,7 @@ Item {
 
         sequence: "Ctrl+N"
 
-        enabled: !item.blockCreateKeys
+        enabled: !item.isDragging && !item.blockCreateKeys
 
         onActivated: {
             createFolder();
@@ -86,7 +88,7 @@ Item {
 
     Shortcut {
         id: rename
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
 
         sequence: "F2"
 
@@ -97,7 +99,7 @@ Item {
 
     Shortcut {
         id: renameNoteShort
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
 
         sequence: "F3"
 
@@ -109,7 +111,7 @@ Item {
     Shortcut {
         id: ctrl_R
         // 初始页面、录音中或显式要求屏蔽录音快捷键时，均不响应 Ctrl+R
-        enabled: !item.initialOnlyCreateFolder && !rootWindow.isRecordingAudio && !item.blockRecordingKey
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder && !rootWindow.isRecordingAudio && !item.blockRecordingKey
 
         sequence: "Ctrl+R"
 
@@ -135,7 +137,7 @@ Item {
 
         sequence: "Ctrl+B"
 
-        enabled: !item.blockCreateKeys && !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.blockCreateKeys && !item.initialOnlyCreateFolder
 
         onActivated: {
             createNote();
@@ -147,7 +149,7 @@ Item {
 
         sequence: "Ctrl+A"
 
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
         onActivated: {}
     }
 
@@ -156,7 +158,7 @@ Item {
 
         sequence: "Ctrl+C"
 
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
         onActivated: {
             copy();
         }
@@ -167,7 +169,7 @@ Item {
 
         sequence: "Ctrl+X"
 
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
         onActivated: {}
     }
 
@@ -176,7 +178,7 @@ Item {
 
         sequence: "Ctrl+V"
 
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
         onActivated: {}
     }
 
@@ -185,7 +187,7 @@ Item {
 
         sequence: "Alt+M"
 
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
         onActivated: {
             showJsContextMenu();
         }
@@ -196,7 +198,7 @@ Item {
 
         sequence: "Ctrl+Z"
 
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
         onActivated: {}
     }
 
@@ -205,7 +207,7 @@ Item {
 
         sequence: "Ctrl+Shift+Z"
 
-        enabled: !item.initialOnlyCreateFolder
+        enabled: !item.isDragging && !item.initialOnlyCreateFolder
         onActivated: {}
     }
 }


### PR DESCRIPTION
Expose isDragging state from ItemListView and FolderListView, disable all Shortcut elements and Delete key during drag.

拖拽记事本或文件夹时屏蔽所有快捷键操作（Delete、Ctrl+N、
Ctrl+B、F2、F3、Ctrl+R、Ctrl+S 等），避免误触。

Log: 拖拽过程中屏蔽快捷键操作
PMS: BUG-361629
Influence: 拖拽过程中所有快捷键和Delete键被禁用，松手后自动恢复。