### PR TITLE
fix(editor): record undo snapshot on mouseup to preserve cursor position

### DIFF
--- a/src/web/js/summernote_v9_2.js
+++ b/src/web/js/summernote_v9_2.js
@@ -4256,6 +4256,7 @@
             }).on('mouseup', function (event) {
                 if (event.which !== 3) {
                     _this.context.triggerEvent('mouseup', event);
+                    _this.history.recordUndo();
                 }
             }).on('scroll', function (event) {
                 _this.context.triggerEvent('scroll', event);


### PR DESCRIPTION
The undo system's lazy snapshot mechanism did not capture cursor position when user clicked to move it, causing cursor to jump to a stale position after Ctrl+Z.

修复编辑器撤销时光标跳转到错误位置的问题，在mouseup时记录快照
以保存正确的光标位置。

Log: 修复撤销时光标位置跳转错误
PMS: BUG-332099
Influence: 用户点击移动光标后输入内容再撤销，光标现在会正确地
保持在点击位置，而不是跳转到之前的旧位置。