### PR TITLE
fix(multi-select): disable save voice button when no voice in selecte…

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -1006,7 +1006,7 @@ void VNoteMainManager::checkNoteVoice(const QVariantList &index)
     foreach (auto id, index) {
         int noteIndex = id.toInt();
         VNoteItem *item = getNoteById(noteIndex);
-        if (item->haveVoice()) {
+        if (item && item->haveVoice()) {
             hasVoice = true;
             break;
         }

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -252,6 +252,14 @@ Item {
     }
     onSelectSizeChanged: {
         mulChoices(selectSize);
+        if (selectSize > 1) {
+            var list = [];
+            for (var i = 0; i < selectedNoteItem.length; i++) {
+                list.push(itemModel.get(selectedNoteItem[i]).noteId);
+            }
+            VNoteMainManager.checkNoteVoice(list);
+            VNoteMainManager.checkNoteText(list);
+        }
     }
 
     ListModel {


### PR DESCRIPTION
…d notes

Call checkNoteVoice/checkNoteText in onSelectSizeChanged handler when entering multi-select mode, matching existing context menu pattern.

多选笔记时在onSelectSizeChanged中调用checkNoteVoice/checkNoteText， 与右键菜单逻辑保持一致，确保无语音笔记被选中时保存语音按钮置灰。

Log: 多选无语音笔记时保存语音按钮置灰
PMS: BUG-339519
Influence: 多选笔记时正确判断是否有语音，无语音则保存语音按钮置灰；同时修复checkNoteVoice空指针问题。