### PR TITLE
fix(dbus): activate existing window on repeated launch

### DIFF
--- a/src/dbus/VoiceNoteDBusService.cpp
+++ b/src/dbus/VoiceNoteDBusService.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -51,6 +51,22 @@ bool VoiceNoteDBusService::initDBusService()
     qInfo() << "  Object: /org/deepin/voicenote";
     
     return true;
+}
+
+void VoiceNoteDBusService::ActivateWindow()
+{
+    qInfo() << "D-Bus: ActivateWindow called";
+
+    auto windows = qApp->topLevelWindows();
+    if (!windows.isEmpty()) {
+        QWindow *window = windows.first();
+        window->showNormal();
+        window->raise();
+        window->requestActivate();
+        qInfo() << "  Window activated successfully";
+    } else {
+        qWarning() << "  No top-level windows found";
+    }
 }
 
 QString VoiceNoteDBusService::GetNotesList()

--- a/src/dbus/VoiceNoteDBusService.h
+++ b/src/dbus/VoiceNoteDBusService.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,6 +25,9 @@ public slots:
 
     // D-Bus接口2: 录音
     bool RecordVoice(int folderId, int noteId);
+
+    // D-Bus接口3: 激活窗口（从最小化恢复并显示到前台）
+    void ActivateWindow();
 };
 
 #endif // VOICENOTEDBUSSERVICE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2020 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 - 2026 Deepin Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -44,6 +44,20 @@
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
+static void activateExistingInstanceViaDBus()
+{
+    QDBusInterface iface("org.deepin.voicenote",
+                         "/org/deepin/voicenote",
+                         "org.deepin.voicenote",
+                         QDBusConnection::sessionBus());
+    if (iface.isValid()) {
+        qInfo() << "Calling ActivateWindow on existing instance via D-Bus";
+        iface.asyncCall("ActivateWindow");
+    } else {
+        qWarning() << "D-Bus interface not available:" << QDBusConnection::sessionBus().lastError().message();
+    }
+}
+
 int main(int argc, char *argv[])
 {
 #ifdef __mips64
@@ -67,6 +81,7 @@ int main(int argc, char *argv[])
         DGuiApplicationHelper::instance()->setSingleInstanceInterval(-1);
         if (!DGuiApplicationHelper::instance()->setSingleInstance(app->applicationName(), DGuiApplicationHelper::UserScope)) {
             qWarning() << "Another instance of deepin-voice-note is already running";
+            activateExistingInstanceViaDBus();
             QCoreApplication::exit(0);
         }
     });
@@ -74,6 +89,7 @@ int main(int argc, char *argv[])
     DGuiApplicationHelper::instance()->setSingleInstanceInterval(-1);
     if (!DGuiApplicationHelper::instance()->setSingleInstance(app->applicationName(), DGuiApplicationHelper::UserScope)) {
         qWarning() << "Another instance of deepin-voice-note is already running";
+        activateExistingInstanceViaDBus();
         return 0;
     }
 #endif


### PR DESCRIPTION
Add ActivateWindow D-Bus method to restore and raise the existing window when user tries to launch a second instance.

添加ActivateWindow D-Bus接口，在重复启动时激活已有实例窗口，
从最小化状态恢复并显示到前台。

Log: 修复重复启动时激活已有窗口
PMS: BUG-364253
Influence: 重复启动语音笔记时，已有实例窗口会被激活显示到前台，
而非静默退出。