### PR TITLE
fix(middleview): fix items overlapping with add button rendered in hi…

### DIFF
--- a/src/views/middleviewdelegate.cpp
+++ b/src/views/middleviewdelegate.cpp
@@ -371,20 +371,9 @@ void MiddleViewDelegate::paintItemBase(QPainter *painter, const QStyleOptionView
                 painter->fillPath(path, painter->brush());
                 painter->setPen(QPen(m_parentPb.color(DPalette::Normal, DPalette::WindowText)));
             } else {
-                // 计算是否是底部Item
-                int h = m_parentView->geometry().height() - 54 - 6;
-                if (rect.y() <= h && (rect.y() + rect.height()) >= h) {
-                    QLinearGradient linearGradient(QPoint(rect.x(), rect.y()), QPoint(rect.x(), rect.y() + rect.height()));
-                    linearGradient.setColorAt(0.1, option.palette.color(DPalette::Normal, DPalette::Highlight));
-                    linearGradient.setColorAt(1, Qt::white);
-                    painter->setBrush(QBrush(linearGradient));
-                    painter->fillPath(path, painter->brush());
-                    painter->setPen(QPen(m_parentPb.color(DPalette::Normal, DPalette::WindowText)));
-                } else {
-                    painter->setBrush(QBrush(m_parentPb.color(DPalette::Normal, DPalette::ItemBackground)));
-                    painter->fillPath(path, painter->brush());
-                    painter->setPen(QPen(m_parentPb.color(DPalette::Normal, DPalette::WindowText)));
-                }
+                painter->setBrush(QBrush(m_parentPb.color(DPalette::Normal, DPalette::ItemBackground)));
+                painter->fillPath(path, painter->brush());
+                painter->setPen(QPen(m_parentPb.color(DPalette::Normal, DPalette::WindowText)));
             }
         }
     }


### PR DESCRIPTION
…ghlight color

  - Remove incorrect QLinearGradient using DPalette::Highlight color for items overlapping the floating add button, which caused unselected items to appear visually identical to selected items when scrolling

  修复(middleview): 修复与新增按钮重叠的文件项被渲染成高亮颜色的问题

  - 移除对与浮动新增按钮重叠的文件项使用 DPalette::Highlight 颜色的错误 QLinearGradient 渐变，该渐变导致滚动时未选中的文件项看起来与选中项颜色一致

Log: 修复文件列表滚动时与"+"按钮重叠的文件项被错误渲染成高亮蓝色的问题
Bug: https://pms.uniontech.com/bug-view-278217.html

## Summary by Sourcery

Bug Fixes:
- Prevent non-selected items overlapping the floating add button from being rendered with highlight colors while scrolling