### PR TITLE
fix(search): prevent crash when exporting notes with invalid ID

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -523,6 +523,10 @@ void VNoteMainManager::saveAs(const QVariantList &index, const QString &path, Sa
         if (!i.isValid())
             continue;
         VNoteItem *noteData = getNoteById(i.toInt());
+        if (noteData == nullptr) {
+            qWarning() << "Failed to get note by ID:" << i.toInt() << ", skipping";
+            continue;
+        }
         noteDataList.append(noteData);
     }
     if (noteDataList.size() == 0) {


### PR DESCRIPTION
- Add null pointer check in saveAs() after getNoteById() returns
- Skip invalid notes instead of appending nullptr to export list
- Ensure noteDataList.size() check catches all invalid note cases

Log: 修复搜索结果页面导出笔记时因笔记ID无效导致的崩溃问题

PMS: BUG-365373

Influence: 修复后从搜索结果页面按 Ctrl+S 导出时，不再因获取不到有效笔记而崩溃，导出功能在所有场景下均能稳定运行。