### PR TITLE
fix(ui): add missing scrollbar to note list view

### DIFF
--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -679,6 +679,9 @@ Item {
         spacing: itemSpacing
         visible: true
 
+        ScrollBar.vertical: ScrollBar {
+        }
+
         delegate: Rectangle {
             id: rootItemDelegate
 


### PR DESCRIPTION
Add ScrollBar.vertical to ItemListView to show scrollbar when scrolling, matching the behavior of the notebook list view.

为笔记列表添加缺失的垂直滚动条，与记事本列表行为保持一致。

Log: 为笔记列表添加滚动条
PMS: BUG-277299
Influence: 笔记列表滚动时现在会显示滚动条，与记事本列表的交互体验一致。

## Summary by Sourcery

New Features:
- Display a vertical scrollbar when scrolling the note item list view.