### PR TITLE
fix(dbus): preserve maximized state when restoring from minimize

### DIFF
--- a/src/dbus/VoiceNoteDBusService.cpp
+++ b/src/dbus/VoiceNoteDBusService.cpp
@@ -32,25 +32,45 @@ VoiceNoteDBusService::~VoiceNoteDBusService()
 bool VoiceNoteDBusService::initDBusService()
 {
     qInfo() << "Initializing D-Bus service";
-    
+
     QDBusConnection connection = QDBusConnection::sessionBus();
-    
+
     if (!connection.registerService("org.deepin.voicenote")) {
         qWarning() << "Failed to register D-Bus service:" << connection.lastError().message();
         return false;
     }
-    
-    if (!connection.registerObject("/org/deepin/voicenote", this, 
+
+    if (!connection.registerObject("/org/deepin/voicenote", this,
                                    QDBusConnection::ExportAllSlots)) {
         qWarning() << "Failed to register D-Bus object:" << connection.lastError().message();
         return false;
     }
-    
+
     qInfo() << "  D-Bus service registered successfully";
     qInfo() << "  Service: org.deepin.voicenote";
     qInfo() << "  Object: /org/deepin/voicenote";
-    
+
+    trackMainWindowState();
+
     return true;
+}
+
+void VoiceNoteDBusService::trackMainWindowState()
+{
+    auto windows = qApp->topLevelWindows();
+    if (windows.isEmpty())
+        return;
+
+    QWindow *window = windows.first();
+    // 记录初始状态
+    m_wasMaximized = (window->windowState() & Qt::WindowMaximized);
+
+    connect(window, &QWindow::windowStateChanged, this, [this](Qt::WindowState newState) {
+        // 最小化时不更新记录，保留之前的状态供恢复时使用
+        if (newState != Qt::WindowMinimized) {
+            m_wasMaximized = (newState & Qt::WindowMaximized);
+        }
+    });
 }
 
 void VoiceNoteDBusService::ActivateWindow()
@@ -60,12 +80,17 @@ void VoiceNoteDBusService::ActivateWindow()
     auto windows = qApp->topLevelWindows();
     if (!windows.isEmpty()) {
         QWindow *window = windows.first();
-        window->showNormal();
+        qWarning() << "[ActivateWindow] m_wasMaximized:" << m_wasMaximized
+                   << " windowState:" << window->windowState();
+        if (m_wasMaximized) {
+            window->showMaximized();
+        } else {
+            window->showNormal();
+        }
         window->raise();
         window->requestActivate();
-        qInfo() << "  Window activated successfully";
     } else {
-        qWarning() << "  No top-level windows found";
+        qWarning() << "[ActivateWindow] No top-level windows found";
     }
 }
 

--- a/src/dbus/VoiceNoteDBusService.h
+++ b/src/dbus/VoiceNoteDBusService.h
@@ -19,6 +19,12 @@ public:
 
     bool initDBusService();
 
+private:
+    // 跟踪窗口最大化状态（DDE 最小化时会丢失 Maximized 标志）
+    bool m_wasMaximized = false;
+
+    void trackMainWindowState();
+
 public slots:
     // D-Bus接口1: 获取笔记列表
     QString GetNotesList();


### PR DESCRIPTION
Track window maximized state via windowStateChanged signal since DDE compositor loses Maximized flag on minimize. Use tracked state to correctly restore window with showMaximized() or showNormal().

DDE窗口管理器最小化时会丢失Qt::WindowMaximized标志，
通过监听windowStateChanged信号自行跟踪最大化状态，
在从启动器激活窗口时正确恢复为最大化或普通窗口。

Log: 修复最小化后从启动器打开窗口丢失最大化状态的问题
PMS: BUG-365283
Influence: 窗口最大化后最小化，再从启动器点击打开时能正确恢复为最大化状态，不再变为默认大小。