### PR TITLE
fix(ui): fix settings dialog always-on-top and reduce clipboard log n…

### DIFF
--- a/src/common/jscontent.cpp
+++ b/src/common/jscontent.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2019 UnionTech Software Technology Co.,Ltd.
+// Copyright (C) 2019-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -343,10 +343,10 @@ void JsContent::jsCallSetClipData(const QString &text, const QString &html)
 
 void JsContent::onClipChange(QClipboard::Mode mode)
 {
-    qInfo() << "Clipboard change detected, mode:" << mode;
+    qDebug() << "Clipboard change detected, mode:" << mode;
     if (QClipboard::Clipboard == mode && QApplication::clipboard()->mimeData() != m_clipData) {
         qDebug() << "Clipboard content changed externally";
         emit callJsClipboardDataChanged();
     }
-    qInfo() << "Clipboard change handling finished";
+    qDebug() << "Clipboard change handling finished";
 }

--- a/src/gui/dialog/SettingDialog.qml
+++ b/src/gui/dialog/SettingDialog.qml
@@ -12,7 +12,8 @@ import org.deepin.dtk 1.0
 Settings.SettingsDialog {
     id: control
 
-    flags: Qt.WindowCloseButtonHint | Qt.WindowStaysOnTopHint
+    flags: Qt.Window | Qt.WindowCloseButtonHint
+    modality: Qt.WindowModal
     height: 548
     width: 664
 


### PR DESCRIPTION
…oise

Remove WindowStaysOnTopHint from settings dialog and add WindowModal modality so it stays above main window but not above other apps.

移除设置窗口的置顶标志，改用WindowModal模态使其仅在主窗口之上。

Log: 修复设置窗口置顶问题并降低剪贴板日志级别
PMS: BUG-364661
Influence: 设置窗口不再全局置顶，仅在语音记事本主窗口之上；剪贴板相关日志从Info降为Debug减少日志噪音。

## Summary by Sourcery

Adjust settings dialog window behavior and reduce clipboard logging verbosity.

Bug Fixes:
- Ensure the settings dialog only stays above the main window instead of always staying on top of all applications.

Enhancements:
- Change clipboard-related logging from info to debug level to reduce log noise.