### PR TITLE
fix(audio): add validity check for D-Bus default source/sink paths be…

### DIFF
--- a/src/common/audiowatcher.cpp
+++ b/src/common/audiowatcher.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -41,9 +41,17 @@ void AudioWatcher::initDeviceWacther()
     if (m_audioDBusInterface->isValid()) {
         qInfo() << "音频服务初始化成功！音频服务： " << AudioService << " 地址：" << AudioPath << " 接口：" << AudioInterface;
         m_defaultSourcePath = m_audioDBusInterface->property("DefaultSource").value<QDBusObjectPath>().path();
-        initDefaultSourceDBusInterface();
+        if (!m_defaultSourcePath.isEmpty() && m_defaultSourcePath != "/") {
+            initDefaultSourceDBusInterface();
+        } else {
+            qWarning() << "DefaultSource path is invalid:" << m_defaultSourcePath;
+        }
         m_defaultSinkPath = m_audioDBusInterface->property("DefaultSink").value<QDBusObjectPath>().path();
-        initDefaultSinkDBusInterface();
+        if (!m_defaultSinkPath.isEmpty() && m_defaultSinkPath != "/") {
+            initDefaultSinkDBusInterface();
+        } else {
+            qWarning() << "DefaultSink path is invalid:" << m_defaultSinkPath;
+        }
         qInfo() << "\n**************** cunrrent default input or output active port **********************"
                 << "\ncurrent input active port name:" << m_inAudioPort.name
                 << "\ncurrent input active port availability(0 for Unknown, 1 for Not Available, 2 for Available.):" << m_inAudioPort.availability
@@ -412,8 +420,9 @@ void AudioWatcher::onSinkVolumeChanged(double value)
  */
 void AudioWatcher::onDefaultSourceChanaged(const QDBusObjectPath &defaultSourcePath)
 {
-    if (m_defaultSourcePath != defaultSourcePath.path()) {
-        qInfo() << "默认输入源地址改变:" <<  m_defaultSourcePath << " To " << defaultSourcePath.path();
+    const QString newPath = defaultSourcePath.path();
+    if (m_defaultSourcePath != newPath) {
+        qInfo() << "默认输入源地址改变:" <<  m_defaultSourcePath << " To " << newPath;
         QDBusConnection::sessionBus().disconnect(AudioService,
                                                  m_defaultSourcePath,
                                                  PropertiesInterface,
@@ -422,9 +431,12 @@ void AudioWatcher::onDefaultSourceChanaged(const QDBusObjectPath &defaultSourceP
                                                  this,
                                                  SLOT(onDBusAudioPropertyChanged(QDBusMessage))
                                                 );
-        m_defaultSourcePath = defaultSourcePath.path();
-        //重新初始化默认输入源接口
-        initDefaultSourceDBusInterface();
+        m_defaultSourcePath = newPath;
+        if (!newPath.isEmpty() && newPath != "/") {
+            initDefaultSourceDBusInterface();
+        } else {
+            qWarning() << "DefaultSource path changed to invalid:" << newPath;
+        }
         emit sigDeviceChange(Micphone);
     }
 }
@@ -435,8 +447,9 @@ void AudioWatcher::onDefaultSourceChanaged(const QDBusObjectPath &defaultSourceP
  */
 void AudioWatcher::onDefaultSinkChanaged(const QDBusObjectPath &defaultSinkePath)
 {
-    if (m_defaultSinkPath != defaultSinkePath.path()) {
-        qInfo() << "默认输出源地址改变:" <<  m_defaultSinkPath << " To " << defaultSinkePath.path();
+    const QString newPath = defaultSinkePath.path();
+    if (m_defaultSinkPath != newPath) {
+        qInfo() << "默认输出源地址改变:" <<  m_defaultSinkPath << " To " << newPath;
         QDBusConnection::sessionBus().disconnect(AudioService,
                                                  m_defaultSinkPath,
                                                  PropertiesInterface,
@@ -445,9 +458,12 @@ void AudioWatcher::onDefaultSinkChanaged(const QDBusObjectPath &defaultSinkePath
                                                  this,
                                                  SLOT(onDBusAudioPropertyChanged(QDBusMessage))
                                                 );
-        m_defaultSinkPath = defaultSinkePath.path();
-        //重新初始化默认输出源接口
-        initDefaultSinkDBusInterface();
+        m_defaultSinkPath = newPath;
+        if (!newPath.isEmpty() && newPath != "/") {
+            initDefaultSinkDBusInterface();
+        } else {
+            qWarning() << "DefaultSink path changed to invalid:" << newPath;
+        }
         emit sigDeviceChange(Internal);
     }
 }


### PR DESCRIPTION
…fore initialization

- Validate m_defaultSourcePath and m_defaultSinkPath in initDeviceWactcher() before calling initDefaultSourceDBusInterface() and initDefaultSinkDBusInterface(), skip initialization and log warning when path is empty or "/"
- Apply the same validity check in onDefaultSourceChanaged() and onDefaultSinkChanaged() before re-initializing interfaces on device change
- Extract repeated defaultSourcePath.path() / defaultSinkePath.path() calls to local newPath variable to avoid redundant D-Bus calls

修复(audio): 增加 D-Bus 默认输入/输出源路径有效性校验

- 在 initDeviceWactcher() 中校验 m_defaultSourcePath 和 m_defaultSinkPath，当路径为空或 "/" 时跳过初始化并记录警告日志
- 在 onDefaultSourceChanaged() 和 onDefaultSinkChanaged() 中同样增加路径有效性检查，避免设备切换时使用无效路径重新初始化
- 将重复调用的 defaultSourcePath.path() / defaultSinkePath.path() 提取为局部变量 newPath，减少冗余 D-Bus 调用

Log: 增加音频 D-Bus 接口初始化前的路径有效性校验，防止无效路径导致初始化异常

## Summary by Sourcery

Validate D-Bus default audio source and sink paths before initializing their interfaces to avoid using invalid object paths and improve logging around device changes.

Bug Fixes:
- Skip initialization of default source and sink D-Bus interfaces when the reported object path is empty or "/" to prevent initialization errors.
- Apply the same path validity checks when the default source or sink changes to avoid reinitializing interfaces on invalid paths.

Enhancements:
- Reduce redundant D-Bus calls when handling default source and sink changes by caching the new object path in a local variable.
- Update the SPDX copyright header years for the audio watcher source file.