### PR TITLE
fix(editor): allow Enter newline while recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build
 .aider*
 .claude/
 .spec-workflow/
+.npm-cache/
+.codegraph/

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -1729,18 +1729,18 @@ async function insertImg(urlStr) {
  * trigger play/pause voice when key space / return / enter down
  */
 function triggerPlayPauseVoice(event) {
-    // 录音时禁止播放语音
-    if (global_isRecording) {
-        console.log("Cannot play voice while recording (triggered by keyboard)");
-        event.preventDefault();  // 阻止Enter/Space键的默认行为，防止删除选中内容
-        return false;
-    }
-    
     var currentLi = $('.li.active');
     if (currentLi.length > 0) {
-        event.preventDefault();
         var info = isRangeVoice();
         if (info.flag == 1) {
+            event.preventDefault();
+
+            // 录音时禁止播放语音
+            if (global_isRecording) {
+                console.log("Cannot play voice while recording (triggered by keyboard)");
+                return false;
+            }
+
             var curPlayback = currentLi.first().find('.voicePlayback');
             // 点击浮动窗口时视同点击焦点音频播放控件
             if (curPlayback.is(airVoicePlayback)) {


### PR DESCRIPTION
Limit voice playback shortcut blocking to selected voice blocks.

将语音播放快捷键拦截限制在选中语音块的场景。

Ignore local npm cache and code graph directories.

忽略本地 npm 缓存和代码图谱目录。

Log: 修复录音时编辑区回车无法换行
PMS: BUG-366061
Influence: 录音过程中，编辑区输入文字按回车可正常换行；选中语音块时仍禁止触发播放，避免录音被播放行为干扰。

## Summary by Sourcery

Allow editor Enter key to insert newlines while recording and keep blocking voice playback shortcuts only when a voice block is selected.

Bug Fixes:
- Fix inability to insert newlines with Enter in the editor while audio recording is active.

Enhancements:
- Limit keyboard-based voice playback blocking to cases where a voice block is actively selected.

Build:
- Ignore local npm cache and code graph directories in version control.