### PR TITLE
fix(vnote): disable note operations during voice-to-text

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,7 @@
 #include "handler/web_engine_handler.h"
 #include "handler/vnote_message_dialog_handler.h"
 #include "handler/voice_recoder_handler.h"
+#include "handler/voice_to_text_task_manager.h"
 #include "audio/recording_curves.h"
 #include "dbus/VoiceNoteDBusService.h"
 
@@ -295,16 +296,25 @@ void VNoteMainManager::vNoteCreateFolder()
     qInfo() << "Folder creation finished";
 }
 
-void VNoteMainManager::vNoteDeleteFolder(const int &index)
+bool VNoteMainManager::vNoteDeleteFolder(const int &index)
 {
     qDebug() << "Deleting folder at index:" << index;
     // 录音或播放中禁止删除
     if (VoiceRecoderHandler::instance()->getRecoderType() == VoiceRecoderHandler::Recording
         || OpsStateInterface::instance()->isPlaying()) {
         qWarning() << "Cannot delete folder while recording or playing";
-        return;
+        return false;
     }
     VNoteFolder *folder = getFloderByIndex(index);
+    if (!folder) {
+        qWarning() << "Invalid folder index for deletion:" << index;
+        return false;
+    }
+
+    if (hasActiveVoiceToTextTaskInFolder(folder->id)) {
+        qWarning() << "Cannot delete folder while voice-to-text is converting, folder ID:" << folder->id;
+        return false;
+    }
 
     int listIndex = m_folderSort.indexOf(QString::number(folder->id));
     if (-1 != listIndex) {
@@ -313,14 +323,11 @@ void VNoteMainManager::vNoteDeleteFolder(const int &index)
     }
 
     setting::instance()->setOption(VNOTE_FOLDER_SORT, m_folderSort.join(","));
-    if (folder) {
-        VNoteFolderOper folderOper(folder);
-        folderOper.deleteVNoteFolder(folder);
-        qDebug() << "Folder deleted successfully";
-    } else {
-        qWarning() << "Invalid folder index for deletion:" << index;
-    }
+    VNoteFolderOper folderOper(folder);
+    folderOper.deleteVNoteFolder(folder);
+    qDebug() << "Folder deleted successfully";
     qInfo() << "Folder deletion finished";
+    return true;
 }
 
 void VNoteMainManager::vNoteChanged(const int &index)
@@ -577,6 +584,11 @@ void VNoteMainManager::saveAs(const QVariantList &index, const QString &path, Sa
 VNoteFolder *VNoteMainManager::getFloderByIndex(const int &index)
 {
     qInfo() << "Getting folder by index:" << index;
+    if (index < 0 || index >= m_folderSort.size()) {
+        qWarning() << "Invalid folder index:" << index;
+        return nullptr;
+    }
+
     VNOTE_FOLDERS_MAP *folders = VNoteDataManager::instance()->getNoteFolders();
     int tmpIndex = m_folderSort.at(index).toInt();
     if (folders) {
@@ -647,7 +659,7 @@ VNoteItem *VNoteMainManager::deleteNoteById(const int &id)
     return nullptr;
 }
 
-void VNoteMainManager::deleteNote(const QList<int> &index)
+bool VNoteMainManager::deleteNote(const QList<int> &index)
 {
     // 删除之前清空JS详情页内容
     qDebug() << "Deleting" << index.size() << "notes";
@@ -655,12 +667,23 @@ void VNoteMainManager::deleteNote(const QList<int> &index)
     if (VoiceRecoderHandler::instance()->getRecoderType() == VoiceRecoderHandler::Recording
         || OpsStateInterface::instance()->isPlaying()) {
         qWarning() << "Cannot delete note while recording or playing";
-        return;
+        return false;
     }
+    for (int noteId : index) {
+        if (hasActiveVoiceToTextTaskForNote(noteId)) {
+            qWarning() << "Cannot delete note while voice-to-text is converting, note ID:" << noteId;
+            return false;
+        }
+    }
+
     m_richTextManager->clearJSContent();
     QList<VNoteItem *> noteDataList;
     for (int i = 0; i < index.size(); i++) {
         VNoteItem *note = getNoteById(index.at(i));
+        if (!note) {
+            qWarning() << "Failed to get note by ID for deletion:" << index.at(i);
+            continue;
+        }
         noteDataList.append(note);
         if (note->isTop)
             m_currentHasTop--;
@@ -689,15 +712,64 @@ void VNoteMainManager::deleteNote(const QList<int> &index)
         emit notesDeleted(variantMap);
     } else {
         qWarning() << "No notes to delete";
+        return false;
     }
     qInfo() << "Note deletion finished";
+    return true;
+}
+
+bool VNoteMainManager::hasActiveVoiceToTextTaskForNote(int noteId) const
+{
+    const QList<VoiceToTextTask> tasks = VoiceToTextTaskManager::instance()->getTasksForNote(noteId);
+    for (const auto &task : tasks) {
+        if (task.status == VoiceToTextTask::Converting) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool VNoteMainManager::hasActiveVoiceToTextTaskInFolder(qint64 folderId) const
+{
+    VNOTE_ALL_NOTES_MAP *noteAll = VNoteDataManager::instance()->getAllNotesInFolder();
+    if (!noteAll) {
+        return false;
+    }
+
+    noteAll->lock.lockForRead();
+    auto folderIt = noteAll->notes.constFind(folderId);
+    if (folderIt == noteAll->notes.constEnd() || !folderIt.value()) {
+        noteAll->lock.unlock();
+        return false;
+    }
+
+    VNOTE_ITEMS_MAP *folderNotes = folderIt.value();
+    folderNotes->lock.lockForRead();
+    bool hasActiveTask = false;
+    for (auto note : folderNotes->folderNotes) {
+        if (note && hasActiveVoiceToTextTaskForNote(note->noteId)) {
+            hasActiveTask = true;
+            break;
+        }
+    }
+    folderNotes->lock.unlock();
+    noteAll->lock.unlock();
+
+    return hasActiveTask;
 }
 
 void VNoteMainManager::moveNotes(const QVariantList &index, const int &folderIndex)
 {
     qDebug() << "Moving" << index.size() << "notes to folder index:" << folderIndex;
+    for (const QVariant &noteId : index) {
+        if (hasActiveVoiceToTextTaskForNote(noteId.toInt())) {
+            qWarning() << "Cannot move note while voice-to-text is converting, note ID:" << noteId.toInt();
+            return;
+        }
+    }
+
     VNOTE_FOLDERS_MAP *folders = VNoteDataManager::instance()->getNoteFolders();
-    if (index.isEmpty() || folderIndex < 0 || folderIndex >= folders->folders.size()) {
+    if (!folders || index.isEmpty() || folderIndex < 0 || folderIndex >= folders->folders.size()) {
         qWarning() << "Invalid move parameters";
         return;
     }

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -42,9 +42,9 @@ public:
     Q_INVOKABLE void vNoteChanged(const int &index);
     void vNoteChangedWithUIUpdate(const int &noteId);
     Q_INVOKABLE void vNoteCreateFolder();
-    Q_INVOKABLE void vNoteDeleteFolder(const int &index);
+    Q_INVOKABLE bool vNoteDeleteFolder(const int &index);
     Q_INVOKABLE void createNote();
-    Q_INVOKABLE void deleteNote(const QList<int> &index);
+    Q_INVOKABLE bool deleteNote(const QList<int> &index);
     Q_INVOKABLE void moveNotes(const QVariantList &index, const int &folderIndex);
     Q_INVOKABLE void saveAs(const QVariantList &index, const QString &path, const SaveAsType type = Note);
     Q_INVOKABLE void updateTop(const int &id, const bool &top);
@@ -122,6 +122,8 @@ private:
     int loadNotes(VNoteFolder *folder);
     void insertVoice(const QString &path, qint64 size);
     void loadSettings();
+    bool hasActiveVoiceToTextTaskForNote(int noteId) const;
+    bool hasActiveVoiceToTextTaskInFolder(qint64 folderId) const;
 
     VNoteItem* deleteNoteById(const int &id);
 

--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -53,6 +53,8 @@ Item {
             console.log("FolderListView: dropItems ignored while recording");
         } else if (isPlay) {
             console.log("FolderListView: dropItems ignored while playing");
+        } else if (isVoiceToText) {
+            console.log("FolderListView: dropItems ignored while voice to text is in progress");
         } else if (currentDropIndex != -1) {
             VNoteMainManager.moveNotes(selectedNoteItem, currentDropIndex);
         }
@@ -192,14 +194,15 @@ Item {
             event.accepted = true;
             break;
         case Qt.Key_Delete:
-            if (root.isDragging || webVisible || isRecordingAudio || isPlay) {
+            if (root.isDragging || webVisible || isRecordingAudio || isPlay || isVoiceToText) {
                 console.log("No notes available, cannot delete folder");
                 return;
             }
             
             messageDialogLoader.showDialog(VNoteMessageDialogHandler.DeleteFolder, ret => {
                 if (ret) {
-                    VNoteMainManager.vNoteDeleteFolder(folderListView.currentIndex);
+                    if (!VNoteMainManager.vNoteDeleteFolder(folderListView.currentIndex))
+                        return;
                     if (folderModel.count === 1)
                         folderEmpty();
                     folderModel.remove(folderListView.currentIndex);
@@ -615,18 +618,19 @@ Item {
 
                 MenuItem {
                     id: deleteMenuItem
-                    enabled: !root.isPlay && !root.isRecordingAudio
+                    enabled: !root.isPlay && !root.isRecordingAudio && !root.isVoiceToText
                     text: qsTr("Delete")
 
                     onTriggered: {
-                        if (webVisible) {
+                        if (webVisible || root.isVoiceToText) {
                             console.log("No notes available, cannot delete folder");
                             return;
                         }
                         
                         messageDialogLoader.showDialog(VNoteMessageDialogHandler.DeleteFolder, ret => {
                             if (ret) {
-                                VNoteMainManager.vNoteDeleteFolder(folderListView.contextIndex);
+                                if (!VNoteMainManager.vNoteDeleteFolder(folderListView.contextIndex))
+                                    return;
                                 if (folderModel.count === 1)
                                     folderEmpty();
                                 folderModel.remove(folderListView.contextIndex);

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -21,6 +21,7 @@ Item {
     property bool isRecordingAudio: false
     property bool isSearch: false
     property bool isSearching: false
+    property bool isVoiceToText: false
     property int itemSpacing: 6
     property alias model: itemModel
     property alias moveToFolderDialog: dialogWindow
@@ -60,7 +61,7 @@ Item {
     }
 
     function onDeleteNote() {
-        if (webVisible) {
+        if (webVisible || isVoiceToText) {
             console.log("No notes available, cannot delete");
             return;
         }
@@ -78,12 +79,15 @@ Item {
             var deleIndex = Number.MAX_SAFE_INTEGER;
             for (var i = 0; i < delList.length; i++) {
                 delIdList.push(itemModel.get(delList[i]).noteId);
-                itemModel.remove(delList[i]);
-                if (selectedNoteItem[i] < deleIndex)
-                    deleIndex = selectedNoteItem[i];
+                if (delList[i] < deleIndex)
+                    deleIndex = delList[i];
             }
-            VNoteMainManager.deleteNote(delIdList);
-            deleteNotes(selectedNoteItem.length);
+            if (!VNoteMainManager.deleteNote(delIdList))
+                return;
+            for (var j = 0; j < delList.length; j++) {
+                itemModel.remove(delList[j]);
+            }
+            deleteNotes(delList.length);
             if (itemModel.count === 0) {
                 selectedNoteItem = [];
                 selectSize = 0;
@@ -102,7 +106,7 @@ Item {
     }
 
     function onMoveNote() {
-        if (webVisible) {
+        if (webVisible || isVoiceToText) {
             console.log("No notes available, cannot move");
             return;
         }
@@ -239,7 +243,7 @@ Item {
              event.accepted = true;
              break;
         case Qt.Key_Delete:
-            if (rootItem.isDragging || webVisible || isRecordingAudio || isPlay) {
+            if (rootItem.isDragging || webVisible || isRecordingAudio || isPlay || isVoiceToText) {
                 console.log("No notes available, cannot delete");
                 return;
             }
@@ -271,6 +275,10 @@ Item {
         id: dialogWindow
 
         onMoveToFolder: {
+            if (isVoiceToText) {
+                console.log("Cannot move note while voice to text is in progress");
+                return;
+            }
             var indexList = [];
             for (var i = 0; i < selectedNoteItem.length; i++) {
                 indexList.push(itemModel.get(selectedNoteItem[i]).noteId);
@@ -529,8 +537,8 @@ Item {
             topItem.text = setTop ? qsTr("Sticky on Top") : qsTr("Unpin");
 
             ActionManager.enableVoicePlayActions(!isPlay && !isRecordingAudio);
-            // 录音或播放中禁用删除
-            ActionManager.enableAction(ActionManager.NoteDelete, !isRecordingAudio && !isPlay);
+            // 录音、播放或语音转文字中禁用删除
+            ActionManager.enableAction(ActionManager.NoteDelete, !isRecordingAudio && !isPlay && !isVoiceToText);
             
             // 在搜索状态下禁用移动、置顶和新建笔记选项
             if (isSearching) {
@@ -538,10 +546,10 @@ Item {
                 ActionManager.enableAction(ActionManager.NoteTop, false);
                 ActionManager.enableAction(ActionManager.NoteAddNew, false);
             } else {
-                // 录音或播放时禁用移动和新建（会影响当前笔记），但置顶保持可用
-                ActionManager.enableAction(ActionManager.NoteMove, !isRecordingAudio && !isPlay);
+                // 录音、播放或语音转文字时禁用移动和新建（会影响当前笔记），但置顶保持可用
+                ActionManager.enableAction(ActionManager.NoteMove, !isRecordingAudio && !isPlay && !isVoiceToText);
                 ActionManager.enableAction(ActionManager.NoteTop, true);  // 置顶是轻量操作，始终可用
-                ActionManager.enableAction(ActionManager.NoteAddNew, !isRecordingAudio && !isPlay);
+                ActionManager.enableAction(ActionManager.NoteAddNew, !isRecordingAudio && !isPlay && !isVoiceToText);
             }
             
             // 录音时保存语音菜单置灰，但重命名、置顶和保存笔记保持可用

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -390,8 +390,6 @@ ApplicationWindow {
         }
         onNoSearchResult: {
             label.visible = false;
-            folderListView.opacity = 0.4;
-            folderListView.enabled = false;
             webEngineView.webVisible = false;
             webEngineView.noSearchResult = true;
             webEngineView.titleBar.isSearching = true;
@@ -399,8 +397,6 @@ ApplicationWindow {
         }
         onSearchFinished: {
             label.visible = false;
-            folderListView.opacity = 0.4;
-            folderListView.enabled = false;
             webEngineView.webVisible = true;
             webEngineView.noSearchResult = false;
             webEngineView.titleBar.isSearching = true;
@@ -500,6 +496,8 @@ ApplicationWindow {
 
                     Layout.fillHeight: true
                     Layout.fillWidth: true
+                    enabled: !rootWindow.isVoiceToText && !itemListView.isSearching && !webEngineView.titleBar.isSearching
+                    opacity: enabled ? 1.0 : 0.4
                     webVisible: initRect.visible
                     isRecordingAudio: rootWindow.isRecordingAudio  // 传递录音状态
                     isVoiceToText: rootWindow.isVoiceToText  // 传递语音转文字状态
@@ -543,7 +541,7 @@ ApplicationWindow {
 
                     Layout.fillWidth: true
                     Layout.preferredHeight: createFolderBtnHeight
-                    enabled: !isRecordingAudio && !folderListView.isPlay && !webEngineView.titleBar.isSearching
+                    enabled: !isRecordingAudio && !folderListView.isPlay && !webEngineView.titleBar.isSearching && !rootWindow.isVoiceToText
                     text: qsTr("Create Notebook")
 
                     onClicked: {
@@ -559,8 +557,8 @@ ApplicationWindow {
                     // 数量更新统一依赖后端 onNotesDeleted(folderId->count)
                 }
                 onDropRelease: {
-                    if (rootWindow.isRecordingAudio || webEngineView.titleBar.isPlaying || folderListView.isPlay) {
-                        console.log("MainWindow: Drop ignored while recording or playing");
+                    if (rootWindow.isRecordingAudio || webEngineView.titleBar.isPlaying || folderListView.isPlay || rootWindow.isVoiceToText) {
+                        console.log("MainWindow: Drop ignored while recording, playing or voice to text");
                         return;
                     }
                     var indexList = [];
@@ -693,8 +691,6 @@ ApplicationWindow {
                         }
                         itemListView.view.visible = true;
                         label.visible = true;
-                        folderListView.opacity = 1;
-                        folderListView.enabled = true;
                         itemListView.isSearch = false;
                         itemListView.isSearching = false;
                         // 退出搜索时，只有当前记事本有笔记时才显示富文本编辑器
@@ -716,7 +712,7 @@ ApplicationWindow {
                                            ? Math.max(36, Math.ceil(DTK.fontManager.t6.pixelSize * 1.6))
                                            : 30
                     Layout.topMargin: 12
-                    enabled: !isRecordingAudio && !folderListView.isPlay  // 录音或播放时禁用搜索框
+                    enabled: !isRecordingAudio && !folderListView.isPlay && !rootWindow.isVoiceToText
                     placeholder: qsTr("Search")
                     topPadding: 0
                     bottomPadding: 0
@@ -750,8 +746,6 @@ ApplicationWindow {
                             }
                             itemListView.view.visible = true;
                             label.visible = true;
-                            folderListView.opacity = 1;
-                            folderListView.enabled = true;
                             itemListView.isSearch = false;
                             itemListView.isSearching = false;
                             // 清空搜索文本时，只有当前记事本有笔记时才显示富文本编辑器
@@ -787,9 +781,12 @@ ApplicationWindow {
 
                     Layout.fillHeight: true
                     Layout.fillWidth: true
+                    enabled: !rootWindow.isVoiceToText
+                    opacity: enabled ? 1.0 : 0.4
                     moveToFolderDialog.folderModel: folderListView.model
                     webVisible: initRect.visible
                     isRecordingAudio: rootWindow.isRecordingAudio
+                    isVoiceToText: rootWindow.isVoiceToText
 
                     onDeleteFinished: {
                         // 只有当列表不为空时才调用 toggleMultCho，避免覆盖 emptyItemList 设置的 webVisible = false
@@ -1072,4 +1069,3 @@ ApplicationWindow {
         }
     }
 }
-

--- a/src/gui/mainwindow/MultipleChoices.qml
+++ b/src/gui/mainwindow/MultipleChoices.qml
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import org.deepin.dtk 1.0
@@ -7,6 +10,8 @@ Item {
     id: rootWindow
 
     property int selectSize: 0
+    property bool deleteEnabled: true
+    property bool moveEnabled: true
     property bool saveVoiceEnabled: true
 
     signal deleteNote
@@ -18,6 +23,11 @@ Item {
 
     function setSaveVoiceEnabled(enabled) {
         saveVoiceEnabled = enabled;
+    }
+
+    function setOperationEnabled(move, del) {
+        moveEnabled = move;
+        deleteEnabled = del;
     }
 
     Rectangle {
@@ -59,6 +69,7 @@ Item {
                         icon.name: "move_note"
                         implicitHeight: 40
                         implicitWidth: 40
+                        enabled: moveEnabled
                         text: qsTr("Move")
 
                         onClicked: {
@@ -97,6 +108,7 @@ Item {
                         icon.name: "delete"
                         implicitHeight: 40
                         implicitWidth: 40
+                        enabled: deleteEnabled
                         text: qsTr("Delete")
 
                         onClicked: {

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -181,6 +181,7 @@ Item {
             multipleChoicesLoader.visible = true;
             multipleChoicesLoader.item.visible = true;
             multipleChoicesLoader.item.selectSize = choices;
+            multipleChoicesLoader.item.setOperationEnabled(!rootItem.isVoiceToText, !rootItem.isVoiceToText);
         } else {
             multipleChoicesLoader.visible = false;
             webVisible = true;
@@ -208,6 +209,7 @@ Item {
             imageBtnEnable: webVisible
             isInitialInterface: initialVisible
             isRecordingAudio: rootItem.isRecordingAudio 
+            isVoiceToText: rootItem.isVoiceToText
 
             onTitleOpenSetting: {
                 rootItem.openSetting();
@@ -677,6 +679,11 @@ Item {
         onSaveVoiceStateChanged: enabled => {
             if (multipleChoicesLoader.active && multipleChoicesLoader.item) {
                 multipleChoicesLoader.item.setSaveVoiceEnabled(enabled);
+            }
+        }
+        onVoiceToTextStateChanged: isConverting => {
+            if (multipleChoicesLoader.active && multipleChoicesLoader.item) {
+                multipleChoicesLoader.item.setOperationEnabled(!isConverting, !isConverting);
             }
         }
     }

--- a/src/gui/mainwindow/WindowTitleBar.qml
+++ b/src/gui/mainwindow/WindowTitleBar.qml
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Window 2.15
 import QtQuick.Layouts 1.15
@@ -14,6 +17,7 @@ TitleBar {
     property bool isRecording: false
     property bool isRecordingAudio: false  
     property bool isSearching: false
+    property bool isVoiceToText: false
     property bool recorderBtnEnable: true
     property bool recordingHover: false
     property bool recordBtnEnabled: recordBtn.enabled
@@ -52,7 +56,7 @@ TitleBar {
         anchors.left: titleBar.left
         anchors.leftMargin: 10
         anchors.verticalCenter: titleBar.verticalCenter
-        enabled: !isPlaying && !isSearching && !isRecordingAudio
+        enabled: !isPlaying && !isSearching && !isRecordingAudio && !isVoiceToText
         hoverEnabled: !isInitialInterface
         icon.name: "new_note"
 


### PR DESCRIPTION
Disable notebook and note list interactions while voice-to-text is in progress.

语音转文字过程中，禁止切换记事本、切换笔记、新建记事本、新建笔记、搜索、删除和移动，相关区域置灰显示。

Log: 修复语音转文字过程中可删除或切换笔记导致转换结果异常
PMS: BUG-365997
Influence: 语音转文字过程中，记事本和笔记区域置灰且不可操作；新建、搜索、删除、移动等入口禁用，避免转写结果丢失或状态异常。

## Summary by Sourcery

Prevent destructive notebook and note operations while voice-to-text conversion is in progress to avoid data loss or inconsistent state.

Bug Fixes:
- Block deletion and movement of notes and notebooks that have active voice-to-text conversion tasks.

Enhancements:
- Expose operation results from note and folder deletion APIs to QML so the UI can avoid updating when backend operations are rejected.
- Disable and visually dim notebook and note list areas, as well as related UI actions (create, move, delete, search), during voice-to-text conversion.
- Improve validation and safety checks for folder and note operations, including index bounds and null checks.