### PR TITLE
fix(audio): log D-Bus interface re-initialization on default source/sink change

### DIFF
--- a/src/common/audiowatcher.cpp
+++ b/src/common/audiowatcher.cpp
@@ -433,6 +433,7 @@ void AudioWatcher::onDefaultSourceChanaged(const QDBusObjectPath &defaultSourceP
                                                 );
         m_defaultSourcePath = newPath;
         if (!newPath.isEmpty() && newPath != "/") {
+            qInfo() << "Re-initializing default source D-Bus interface for path:" << newPath;
             initDefaultSourceDBusInterface();
         } else {
             qWarning() << "DefaultSource path changed to invalid:" << newPath;
@@ -460,6 +461,7 @@ void AudioWatcher::onDefaultSinkChanaged(const QDBusObjectPath &defaultSinkePath
                                                 );
         m_defaultSinkPath = newPath;
         if (!newPath.isEmpty() && newPath != "/") {
+            qInfo() << "Re-initializing default sink D-Bus interface for path:" << newPath;
             initDefaultSinkDBusInterface();
         } else {
             qWarning() << "DefaultSink path changed to invalid:" << newPath;


### PR DESCRIPTION
fix(audio): log D-Bus interface re-initialization on default source/sink change
- Add qInfo log in onDefaultSourceChanaged() before re-initializing the default source D-Bus interface to record the new path being applied
- Add qInfo log in onDefaultSinkChanaged() before re-initializing the default sink D-Bus interface for the same purpose

修复(audio): 在默认输入/输出源切换时记录 D-Bus 接口重新初始化日志

- 在 onDefaultSourceChanaged() 中重新初始化默认输入源 D-Bus 接口前增加 qInfo 日志，记录正在应用的新路径
- 在 onDefaultSinkChanaged() 中重新初始化默认输出源 D-Bus 接口前增加 qInfo 日志，用途相同

Log: 在默认输入/输出源切换重新初始化 D-Bus 接口前补充日志，完善设备切换过程的可观测性