### PR TITLE
fix(shortcut): disable Ctrl+S for empty notes

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -1126,6 +1126,15 @@ bool VNoteMainManager::isInSearchMode() const
     return !m_searchText.isEmpty();
 }
 
+bool VNoteMainManager::hasNoteText(int noteId)
+{
+    VNoteItem *item = getNoteById(noteId);
+    if (item) {
+        return item->haveText();
+    }
+    return false;
+}
+
 void VNoteMainManager::preViewShortcut(const QPointF &point)
 {
     // qInfo() << "Previewing shortcut at point:" << point.x() << "," << point.y();

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -78,6 +78,13 @@ public:
     Q_INVOKABLE int currentNoteId() const;
 
     /**
+     * @brief 检查指定笔记是否有文本内容
+     * @param noteId 笔记 ID
+     * @return true 有文本内容，false 无文本内容
+     */
+    Q_INVOKABLE bool hasNoteText(int noteId);
+
+    /**
      * @brief 在指定笔记的 HTML 中插入语音转文字结果
      * @param noteId 笔记 ID
      * @param voiceId 语音块唯一标识（UUID，用于精确定位语音元素）

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -173,6 +173,31 @@ ApplicationWindow {
             VoiceRecoderHandler.startRecoder();
         }
         onSaveNote: {
+            // 检查是否有笔记可以保存
+            if (initRect.visible) {
+                console.warn("当前没有打开任何笔记本，不执行保存操作");
+                return;
+            }
+
+            // 检查笔记列表是否为空
+            if (itemListView.model.count === 0) {
+                console.warn("当前笔记列表为空，不执行保存操作");
+                return;
+            }
+
+            // 检查当前笔记ID是否有效
+            var currentNoteId = VNoteMainManager.currentNoteId();
+            if (currentNoteId <= 0) {
+                console.warn("当前没有选中的笔记，不执行保存操作");
+                return;
+            }
+
+            // Ctrl+S 保存为 txt，只检查是否有文本内容，与右键菜单逻辑保持一致
+            if (!VNoteMainManager.hasNoteText(currentNoteId)) {
+                console.warn("当前笔记没有文本内容，不执行保存操作");
+                return;
+            }
+
             itemListView.onSaveNote();
         }
         onSaveVoice: {


### PR DESCRIPTION
Add content check before saving to prevent Ctrl+S on empty notes. This aligns with right-click menu behavior (checkNoteText).

添加笔记内容检查，空笔记时禁用 Ctrl+S 保存，与右键菜单逻辑保持一致。

Log: 修复空笔记按Ctrl+S仍能保存的问题
PMS: BUG-366535
Influence: 修复后空笔记（无文本内容）按Ctrl+S不会触发保存，与右键菜单保存置灰逻辑一致。