### PR TITLE
fix(vnote): keep copied images visible and viewable

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -39,6 +39,8 @@
 #include <QProcess>
 #include <QDesktopServices>
 #include <QDebug>
+#include <QImageReader>
+#include <QTimer>
 
 #include <DSysInfo>
 
@@ -91,7 +93,7 @@ void VNoteMainManager::initConnections()
     connect(m_richTextManager, &WebRichTextManager::noteTextChanged, this, &VNoteMainManager::onNoteChanged, Qt::QueuedConnection);
     connect(m_richTextManager, &WebRichTextManager::updateSearch, this, &VNoteMainManager::updateSearch);
     connect(m_richTextManager, &WebRichTextManager::scrollChange, this, &VNoteMainManager::scrollChange);
-    connect(m_richTextManager, &WebRichTextManager::finishedUpdateNote, this, &VNoteMainManager::exitWithSave);
+    connect(m_richTextManager, &WebRichTextManager::finishedUpdateNote, this, &VNoteMainManager::onRichTextSaveFinished);
     connect(VoiceRecoderHandler::instance(), &VoiceRecoderHandler::finishedRecod, this, &VNoteMainManager::insertVoice);
     qInfo() << "Connections initialized";
 }
@@ -337,8 +339,16 @@ void VNoteMainManager::vNoteChanged(const int &index)
         qWarning() << "Invalid note index:" << index;
         return;
     }
-    qDebug() << "Changing to note index:" << index;
-    m_currentNoteId = index;
+    if (index != m_currentNoteId && !saveCurrentNoteBeforeAction(PendingAction::SwitchNote, index)) {
+        return;
+    }
+    doSwitchNote(index);
+}
+
+void VNoteMainManager::doSwitchNote(int noteId)
+{
+    qDebug() << "Changing to note index:" << noteId;
+    m_currentNoteId = noteId;
     VNoteItem *data = getNoteById(m_currentNoteId);
     if (!data) {
         qWarning() << "vNoteChanged resolved to null note, skipping initData";
@@ -483,6 +493,14 @@ void VNoteMainManager::createNote()
         qWarning() << "Cannot create note: No current folder selected";
         return;
     }
+    if (!saveCurrentNoteBeforeAction(PendingAction::CreateNote)) {
+        return;
+    }
+    doCreateNote();
+}
+
+void VNoteMainManager::doCreateNote()
+{
     VNoteFolder *currentFolder = getFloderById(m_currentFolderIndex);
     if (currentFolder == nullptr) {
         qWarning() << "Cannot create note: Current folder not found for ID:" << m_currentFolderIndex;
@@ -854,13 +872,17 @@ void VNoteMainManager::onExportFinished(int err)
 void VNoteMainManager::onNoteChanged()
 {
     qInfo() << "Note changed, updating modification time";
-    VNoteItem *note = getNoteById(m_currentNoteId);
+    int changedNoteId = m_richTextManager ? m_richTextManager->pendingTextChangeNoteId() : -1;
+    if (changedNoteId < 0) {
+        changedNoteId = m_currentNoteId;
+    }
+    VNoteItem *note = getNoteById(changedNoteId);
     if (!note) {
-        qWarning() << "onNoteChanged: current note not found, id=" << m_currentNoteId << ", skip";
+        qWarning() << "onNoteChanged: changed note not found, id=" << changedNoteId << ", current=" << m_currentNoteId << ", skip";
         return;
     }
     note->modifyTime = QDateTime::currentDateTime();
-    emit updateEditNote(m_currentNoteId, Utils::convertDateTime(note->modifyTime));
+    emit updateEditNote(changedNoteId, Utils::convertDateTime(note->modifyTime));
     qInfo() << "Note change handling finished";
 }
 
@@ -876,12 +898,51 @@ void VNoteMainManager::updateSearch()
     qInfo() << "Search update finished";
 }
 
-void VNoteMainManager::exitWithSave()
+void VNoteMainManager::onRichTextSaveFinished()
 {
-    qInfo() << "Exiting with save";
-    if (m_eventloop.isRunning())
-        m_eventloop.quit();
-    qInfo() << "Exit with save finished";
+    if (m_pendingAction == PendingAction::None) {
+        return;
+    }
+
+    if (m_richTextManager && m_richTextManager->hasPendingTextChange()) {
+        qWarning() << "Pending note action canceled because rich text save did not finish successfully";
+        m_pendingAction = PendingAction::None;
+        m_pendingNoteId = -1;
+        return;
+    }
+
+    const PendingAction action = m_pendingAction;
+    const int noteId = m_pendingNoteId;
+    m_pendingAction = PendingAction::None;
+    m_pendingNoteId = -1;
+
+    if (action == PendingAction::SwitchNote) {
+        doSwitchNote(noteId);
+    } else if (action == PendingAction::CreateNote) {
+        doCreateNote();
+    }
+}
+
+bool VNoteMainManager::saveCurrentNoteBeforeAction(PendingAction action, int noteId)
+{
+    if (!m_richTextManager || !m_richTextManager->hasPendingTextChange()) {
+        return true;
+    }
+
+    const int pendingNoteId = m_richTextManager->pendingTextChangeNoteId();
+    const int richTextNoteId = m_richTextManager->currentNoteId();
+    if (pendingNoteId < 0 || pendingNoteId != richTextNoteId) {
+        return false;
+    }
+
+    if (m_pendingAction != PendingAction::None) {
+        return false;
+    }
+
+    m_pendingAction = action;
+    m_pendingNoteId = noteId;
+    m_richTextManager->requestUpdateNoteNow();
+    return false;
 }
 
 bool VNoteMainManager::getTop()
@@ -978,8 +1039,14 @@ void VNoteMainManager::vNoteSearch(const QString &text)
 void VNoteMainManager::updateNoteWithResult(const QString &result)
 {
     qInfo() << "Updating note with result";
-    m_richTextManager->onUpdateNoteWithResult(getNoteById(m_currentNoteId), result);
+    updateNoteWithResultForNote(m_currentNoteId, result);
     qInfo() << "Note update with result finished";
+}
+
+void VNoteMainManager::updateNoteWithResultForNote(int noteId, const QString &result)
+{
+    VNoteItem *note = getNoteById(noteId);
+    m_richTextManager->onUpdateNoteWithResult(note, result);
 }
 
 int VNoteMainManager::loadSearchNotes(const QString &key)
@@ -1053,17 +1120,37 @@ void VNoteMainManager::insertImages(const QList<QUrl> &filePaths)
     QString date = currentDateTime.toString("yyyyMMddhhmmss");
 
     for (auto path : filePaths) {
-        QString localPath = path.toLocalFile();
+        if (!path.isLocalFile()) {
+            qWarning() << "Unsupported non-local image URL:" << path;
+            continue;
+        }
+        QString localPath = QDir::cleanPath(path.toLocalFile());
         QFileInfo fileInfo(localPath);
-        QString suffix = fileInfo.suffix();
-        if (!(suffix == "jpg" || suffix == "png" || suffix == "bmp")) {
-            qWarning() << "Unsupported image format:" << suffix;
+        if (!fileInfo.exists() || !fileInfo.isFile()) {
+            qWarning() << "Image file does not exist or is not a file:" << localPath;
+            continue;
+        }
+        QImageReader imageReader(localPath);
+        if (!imageReader.canRead()) {
+            qWarning() << "Invalid image file:" << localPath;
+            continue;
+        }
+        QString suffix = fileInfo.suffix().toLower();
+        if (suffix.isEmpty()) {
+            suffix = QString::fromLatin1(imageReader.format()).toLower();
+        }
+        if (suffix == QStringLiteral("jpeg")) {
+            suffix = QStringLiteral("jpg");
+        }
+        if (suffix.isEmpty()) {
+            qWarning() << "Unsupported image format:" << localPath;
             continue;
         }
         //创建文件路径
         QString newPath = QString("%1/%2_%3.%4").arg(dirPath).arg(date).arg(++count).arg(suffix);
-        if (QFile::copy(QUrl(path).toLocalFile(), newPath)) {
-            paths.push_back(newPath);
+        if (QFile::copy(localPath, newPath)) {
+            const QString fileName = QString("%1_%2.%3").arg(date).arg(count).arg(suffix);
+            paths.push_back(QString("images/") + fileName);
         }
     }
     if (!paths.isEmpty()) {

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -10,8 +10,8 @@
 #include "vnoteforlder.h"
 #include "vnoteitem.h"
 
-#include <QVariantMap>
 #include <QEventLoop>
+#include <QVariantMap>
 
 class WebRichTextManager;
 class VoiceNoteDBusService;
@@ -55,6 +55,7 @@ public:
     Q_INVOKABLE QString getNotePlainTitle(const int &noteId);
     Q_INVOKABLE void vNoteSearch(const QString &text);
     Q_INVOKABLE void updateNoteWithResult(const QString &result);
+    Q_INVOKABLE void updateNoteWithResultForNote(int noteId, const QString &result);
     Q_INVOKABLE int loadSearchNotes(const QString &key);
     Q_INVOKABLE int loadAudioSource();
     Q_INVOKABLE void changeAudioSource(const int &source);
@@ -102,7 +103,7 @@ signals:
     void noSearchResult();
     void searchFinished(const QList<QVariantMap> &notesData, const QString &key);
     void moveFinished(const QVariantList &index, const int &srcFolderIndex, const int &dstFolderIndex);
-    void needUpdateNote();
+    void needUpdateNote(int noteId);
     void updateRichTextSearch(const QString &key);
     void scrollChange(const bool &isTop);
     void updateEditNote(const int &noteId, const QString &time);
@@ -119,9 +120,15 @@ private slots:
     void onExportFinished(int err);
     void onNoteChanged();
     void updateSearch();
-    void exitWithSave();
+    void onRichTextSaveFinished();
 
 private:
+    enum class PendingAction {
+        None,
+        SwitchNote,
+        CreateNote
+    };
+
     VNoteMainManager();
     void initData();
     void initConnections();
@@ -131,6 +138,9 @@ private:
     void loadSettings();
     bool hasActiveVoiceToTextTaskForNote(int noteId) const;
     bool hasActiveVoiceToTextTaskInFolder(qint64 folderId) const;
+    bool saveCurrentNoteBeforeAction(PendingAction action, int noteId = -1);
+    void doSwitchNote(int noteId);
+    void doCreateNote();
 
     VNoteItem* deleteNoteById(const int &id);
 
@@ -144,6 +154,8 @@ private:
     VoiceNoteDBusService *m_dbusService {nullptr};
     QString m_searchText;
     QEventLoop m_eventloop;
+    PendingAction m_pendingAction {PendingAction::None};
+    int m_pendingNoteId {-1};
 };
 
 #endif // VNOTEMAINMANAGER_H

--- a/src/common/webrichetextmanager.cpp
+++ b/src/common/webrichetextmanager.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
 #include "webrichetextmanager.h"
 #include "jscontent.h"
 #include "db/vnoteitemoper.h"
@@ -56,6 +59,8 @@ void WebRichTextManager::initConnect()
     qInfo() << "Initializing connections";
     connect(JsContent::instance(), &JsContent::textChange, this, [=](){
         m_textChange = true;
+        m_textChangeNoteId = m_noteData ? m_noteData->noteId : -1;
+        ++m_textChangeSerial;
         emit noteTextChanged();
     });
 
@@ -129,9 +134,35 @@ void WebRichTextManager::updateNote()
 {
     // qInfo() << "Updating note, text change flag:" << m_textChange;
     if (m_textChange) {
-        emit needUpdateNote();
+        if (m_updateInProgress) {
+            return;
+        }
+        m_updateInProgress = true;
+        m_updateRequestNoteId = m_textChangeNoteId;
+        m_updateRequestSerial = m_textChangeSerial;
+        emit needUpdateNote(m_updateRequestNoteId);
     }
     // qInfo() << "Note update finished";
+}
+
+bool WebRichTextManager::hasPendingTextChange() const
+{
+    return m_textChange;
+}
+
+int WebRichTextManager::pendingTextChangeNoteId() const
+{
+    return m_textChangeNoteId;
+}
+
+int WebRichTextManager::currentNoteId() const
+{
+    return m_noteData ? m_noteData->noteId : -1;
+}
+
+void WebRichTextManager::requestUpdateNoteNow()
+{
+    updateNote();
 }
 
 void WebRichTextManager::onUpdateNoteWithResult(VNoteItem *data, const QString &result)
@@ -139,16 +170,27 @@ void WebRichTextManager::onUpdateNoteWithResult(VNoteItem *data, const QString &
     qDebug() << "Updating note with result";
     if (!data) {
         qWarning() << "onUpdateNoteWithResult called with null data, skip";
+        m_updateInProgress = false;
+        m_updateRequestNoteId = -1;
+        m_updateRequestSerial = 0;
+        emit finishedUpdateNote();
         return;
     }
     data->htmlCode = result;
     VNoteItemOper noteOps(data);
-    if (!noteOps.updateNote()) {
+    const bool updateOk = noteOps.updateNote();
+    if (!updateOk) {
         qWarning() << "Failed to save note";
     } else {
         qDebug() << "Note saved successfully";
     }
-    m_textChange = false;
+    if (updateOk && data->noteId == m_textChangeNoteId && m_updateRequestSerial == m_textChangeSerial) {
+        m_textChange = false;
+        m_textChangeNoteId = -1;
+    }
+    m_updateInProgress = false;
+    m_updateRequestNoteId = -1;
+    m_updateRequestSerial = 0;
     emit finishedUpdateNote();
     qInfo() << "Note update with result finished";
 }

--- a/src/common/webrichetextmanager.h
+++ b/src/common/webrichetextmanager.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef WEBRICHTEXTMANAGER_H
 #define WEBRICHTEXTMANAGER_H
 
@@ -18,6 +21,10 @@ public:
     void clearJSContent();
 
     void initUpdateTimer();
+    bool hasPendingTextChange() const;
+    int pendingTextChangeNoteId() const;
+    int currentNoteId() const;
+    void requestUpdateNoteNow();
 
 public slots:
     void onLoadFinsh();
@@ -31,7 +38,7 @@ public slots:
     void insertVoiceItem(const QString &voicePath, qint64 voiceSize);
 
 signals:
-    void needUpdateNote();
+    void needUpdateNote(int noteId);
     void noteTextChanged();
     void updateSearch();
     void scrollChange(const bool &isTop);
@@ -45,6 +52,11 @@ private:
     QTimer *m_updateTimer {nullptr};
 
     bool m_textChange {false};
+    int m_textChangeNoteId {-1};
+    bool m_updateInProgress {false};
+    int m_updateRequestNoteId {-1};
+    quint64 m_textChangeSerial {0};
+    quint64 m_updateRequestSerial {0};
     QPoint m_mouseClickPos {-1, -1}; //鼠标点击位置
     bool m_setFocus {false}; //是否设置焦点
     //右键菜单

--- a/src/gui/dialog/ViewPictureDialog.qml
+++ b/src/gui/dialog/ViewPictureDialog.qml
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Window 2.15
 import QtQuick.Controls 2.15
@@ -8,6 +11,15 @@ Window {
     id: root
 
     property string filePath: ""
+    readonly property string imageSource: {
+        if (filePath.length === 0) {
+            return "";
+        }
+        if (filePath.indexOf("file://") === 0 || filePath.indexOf("qrc:/") === 0) {
+            return filePath;
+        }
+        return "file://" + filePath;
+    }
 
     color: "transparent"
     flags: Qt.FramelessWindowHint
@@ -34,7 +46,7 @@ Window {
 
         anchors.centerIn: backRect
         fillMode: Image.PreserveAspectFit
-        source: "file:///" + filePath
+        source: root.imageSource
         z: 100
 
         onStatusChanged: {

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -614,9 +614,10 @@ Item {
     Connections {
         target: VNoteMainManager
 
-        onNeedUpdateNote: {
+        onNeedUpdateNote: function(noteId) {
+            var requestNoteId = noteId;
             webView.runJavaScript("getHtml()", function (result) {
-                VNoteMainManager.updateNoteWithResult(result);
+                VNoteMainManager.updateNoteWithResultForNote(requestNoteId, result);
             });
         }
         onScrollChange: isTop => {

--- a/src/handler/web_engine_handler.cpp
+++ b/src/handler/web_engine_handler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,11 +24,13 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QCollator>
+#include <QDir>
 #include <QFile>
 #include <QTimer>
 #include <QCursor>
 #include <QMimeData>
 #include <QUuid>
+#include <QUrl>
 // 条件编译：QWebEngineContextMenuRequest 只在 Qt6 中存在
 #ifndef USE_QT5
 #include <QWebEngineContextMenuRequest>
@@ -64,6 +66,43 @@ const QString DEEPIN_DAEMON_APPEARANCE_INTERFACE = isV20() ? APPEARANCE_INTERFAC
 
 
 DGUI_USE_NAMESPACE
+
+namespace {
+
+QString normalizePicturePath(const QString &path)
+{
+    QString localPath = path;
+    const QUrl url(path);
+    if (url.isLocalFile()) {
+        localPath = url.toLocalFile();
+    }
+
+    const QString normalized = QDir::cleanPath(QDir::fromNativeSeparators(localPath));
+    QString result;
+    const QDir appDataDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+    const QString appImageRoot = QDir::cleanPath(appDataDir.filePath(QStringLiteral("images")));
+    const QString appImageRootWithSep = appImageRoot + QStringLiteral("/");
+
+    if (normalized.startsWith(QStringLiteral("images/"))) {
+        result = QDir::cleanPath(appDataDir.filePath(normalized));
+    } else {
+        if (normalized.startsWith(appImageRootWithSep)) {
+            result = normalized;
+        } else {
+            const QString webImageRoot = QDir::fromNativeSeparators(QStringLiteral(WEB_PATH) + QStringLiteral("/images/"));
+            if (normalized.startsWith(webImageRoot)) {
+                result = QDir::cleanPath(QDir(appImageRoot).filePath(normalized.mid(webImageRoot.size())));
+            }
+        }
+    }
+
+    if (!result.startsWith(appImageRootWithSep)) {
+        return QString();
+    }
+    return result;
+}
+
+}
 
 /*!
  * \class WebEngineHandler
@@ -408,10 +447,12 @@ void WebEngineHandler::onMenuClicked(ActionManager::ActionKind kind)
             // 粘贴事件，从剪贴板获取数据
             onPaste(isVoicePaste());
             break;
-        case ActionManager::PictureView:
+        case ActionManager::PictureView: {
             // 查看图片
-            Q_EMIT viewPicture(menuJson.toString());
+            const QString normalizedPath = normalizePicturePath(menuJson.toString());
+            Q_EMIT viewPicture(normalizedPath);
             break;
+        }
         case ActionManager::PictureSaveAs:
             // 另存图片
             savePictureAs();

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -215,6 +215,28 @@ function setInitFont(initFontName) {
 // 全局变量：存储 AppData 基准路径，仅用于编辑区内图片/音频路径转换
 var globalAppDataBase = null;
 
+function appImageRelPath(path) {
+    var normalized = (path || '').replace(/\\/g, '/');
+    if (normalized.indexOf('images/') === 0) {
+        return normalized;
+    }
+    if (globalAppDataBase && normalized.indexOf(globalAppDataBase + 'images/') === 0) {
+        return normalized.substring(globalAppDataBase.length);
+    }
+    return '';
+}
+
+function appImageUrl(relPath) {
+    if (!globalAppDataBase || relPath.indexOf('images/') !== 0) {
+        return '';
+    }
+    try {
+        return new URL(relPath, globalAppDataBase).href;
+    } catch (e) {
+        return '';
+    }
+}
+
 // 建立通信
 new QWebChannel(qt.webChannelTransport,
     function (channel) {
@@ -635,6 +657,9 @@ document.addEventListener('paste', function (event) {
     }
     setFocusScroll()
     removeNullP()
+    if (webobj && initFinish) {
+        webobj.jsCallTxtChange();
+    }
 });
 
 // 页面滚动到光标位置
@@ -767,19 +792,10 @@ function getHtml() {
     // 确保图片保存为相对路径
     $cloneCode.find('img').each(function () {
         var $img = $(this);
-        var relPath = $img.attr('data-rel-path');
+        var relPath = appImageRelPath($img.attr('data-rel-path')) || appImageRelPath($img.attr('src'));
         if (relPath) {
             $img.attr('src', relPath);
             $img.removeAttr('data-rel-path');
-        } else {
-            // 如果没有 data-rel-path，尝试从当前 src 提取相对路径
-            var src = $img.attr('src') || '';
-            if (src.indexOf('images/') >= 0) {
-                var idx = src.lastIndexOf('images/');
-                if (idx >= 0) {
-                    $img.attr('src', src.substring(idx));
-                }
-            }
         }
     });
     
@@ -1084,17 +1100,11 @@ function setHtml(html) {
     if (globalAppDataBase) {
         $('.note-editable img').each(function () {
             var $img = $(this);
-            var src = $img.attr('src') || '';
-            // 如果是相对路径 images/xxx，转换为绝对路径显示
-            if (src.indexOf('images/') === 0 || (src.indexOf('/images/') > 0 && !src.startsWith('file://') && !src.startsWith('http'))) {
-                var relPath = src.indexOf('images/') >= 0 ? src.substring(src.lastIndexOf('images/')) : src;
-                try {
-                    var absUrl = new URL(relPath, globalAppDataBase).href;
-                    $img.attr('src', absUrl);
-                    $img.attr('data-rel-path', relPath);
-                } catch (e) {
-                    // 转换失败，保持原样
-                }
+            var relPath = appImageRelPath($img.attr('src'));
+            var absUrl = relPath ? appImageUrl(relPath) : '';
+            if (absUrl) {
+                $img.attr('src', absUrl);
+                $img.attr('data-rel-path', relPath);
             }
         });
     }
@@ -1708,19 +1718,22 @@ function initVoiceDragAndDrop() {
 async function insertImg(urlStr) {
     // 后端已发送相对路径 images/xxx，显示时转换为绝对路径，保存时保持相对路径
     urlStr.forEach((item) => {
-        var relPath = ('' + item).replace(/\\/g, '/');
+        var rawPath = ('' + item).replace(/\\/g, '/');
+        var relPath = appImageRelPath(rawPath);
         // 显示时使用绝对路径
-        var displayUrl = relPath;
-        if (globalAppDataBase && relPath.indexOf('images/') === 0) {
-            try {
-                displayUrl = new URL(relPath, globalAppDataBase).href;
-            } catch (e) {
-                displayUrl = relPath;
-            }
+        var displayUrl = relPath || rawPath;
+        var appDataUrl = relPath ? appImageUrl(relPath) : '';
+        if (appDataUrl) {
+            displayUrl = appDataUrl;
         }
         $("#summernote").summernote('insertImage', displayUrl, function ($image) {
             // 保存相对路径到 data 属性，保存 HTML 时使用
-            $image.attr('data-rel-path', relPath);
+            if (relPath) {
+                $image.attr('data-rel-path', relPath);
+            }
+            if (webobj && initFinish) {
+                webobj.jsCallTxtChange();
+            }
         });
     })
 }


### PR DESCRIPTION
Save pending rich text changes before switching or creating notes, bind async HTML save callbacks to the requested note ID, and normalize copied image paths for display and preview.

快速切换或新建笔记前保存当前富文本变更，将异步 HTML 保存结果绑定到发起保存的笔记 ID，并规范化复制图片的显示和查看路径。

Log: 修复复制图片后切换笔记偶现空白及查看图片空白
PMS: BUG-365367
Influence: 插入或复制图片后快速切换、新建笔记时，图片内容可正常保存和恢复；复制到其他笔记的图片可正常显示和右键查看，避免异步保存错位或路径异常导致图片空白。