### PR TITLE
fix(vnote): focus rich text editor after creating blank note

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -534,8 +534,7 @@ void VNoteMainManager::doCreateNote()
     data.insert(NOTE_ID_KEY, newNote->noteId);
 
     emit addNoteAtHead(data);
-    m_richTextManager->initData(newNote, "");
-    m_richTextManager->clearJSContent();
+    m_richTextManager->initData(newNote, "", true);
     qInfo() << "Note creation finished";
 }
 

--- a/src/common/jscontent.h
+++ b/src/common/jscontent.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2019 UnionTech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -81,6 +80,7 @@ signals:
     void calllJsShowEditToolbar(int x, int y); //显示编辑工具栏
     void callJsHideEditToolbar(); //隐藏编辑工具栏
     void callJsSetVoicePlayBtnEnable(bool enable); //设置播放按钮是否可用
+    void callJsFocusEditor(); //聚焦富文本编辑器
 
     void callJsVoicePlayProgressChanged(int progressMs);    // 通知前端播放进度变更
     void callJsDeleteSelection();                           // 通知前端删除当前选中内容

--- a/src/common/webrichetextmanager.cpp
+++ b/src/common/webrichetextmanager.cpp
@@ -67,6 +67,7 @@ void WebRichTextManager::initConnect()
     connect(JsContent::instance(), &JsContent::scrollTopChange, this, [=](bool isTop){
         emit scrollChange(isTop);
     });
+    connect(JsContent::instance(), &JsContent::setDataFinsh, this, &WebRichTextManager::onSetDataFinsh);
     qInfo() << "Connections initialized";
 }
 
@@ -239,18 +240,22 @@ void WebRichTextManager::onLoadFinsh()
 void WebRichTextManager::clearJSContent()
 {
     qDebug() << "Clearing JS content";
-    connect(JsContent::instance(), &JsContent::setDataFinsh, this, &WebRichTextManager::onSetDataFinsh);
     emit JsContent::instance()->callJsSetHtml("");
 
     // 开启100ms事件循环，保证js页面内容被刷新
     QEventLoop eveLoop;
     QTimer::singleShot(100, &eveLoop, SLOT(quit()));
     eveLoop.exec();
-    disconnect(JsContent::instance(), &JsContent::setDataFinsh, this, &WebRichTextManager::onSetDataFinsh);
     qDebug() << "JS content cleared";
 }
 
 void WebRichTextManager::onSetDataFinsh()
 {
     qInfo() << "Set data finished";
+    if (!m_setFocus) {
+        return;
+    }
+
+    m_setFocus = false;
+    emit JsContent::instance()->callJsFocusEditor();
 }

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -336,7 +336,7 @@ ApplicationWindow {
             itemListView.selectSize = 1;
             itemListView.changeCurrentIndex(topSize);
             folderListView.addNote(1);
-            itemListView.forceActiveFocus();
+            webEngineView.focusWebView();
         }
 
         function sortDescending(array) {

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -38,6 +38,10 @@ Item {
         webView.triggerWebAction(5);
     }
 
+    function focusWebView() {
+        webView.forceActiveFocus();
+    }
+
     function showJsContextMenu() {
         // 仅在编辑区可见时尝试弹出；是否在编辑器内由JS自行判断
         if (webVisible) {

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -270,6 +270,7 @@ new QWebChannel(qt.webChannelTransport,
         webobj.callJsHideEditToolbar.connect(hideRightMenu);
         webobj.callJsClipboardDataChanged.connect(shearPlateChange);
         webobj.callJsSetVoicePlayBtnEnable.connect(playButColor);
+        webobj.callJsFocusEditor.connect(focusEditor);
         webobj.callJsSetFontList.connect(setFontList);
 
         webobj.callJsVoicePlayProgressChanged.connect(updateProgressBar);
@@ -941,10 +942,9 @@ function initData(text) {
     })
 
     $('#summernote').summernote('code', html);
-    // 搜索功能
-    webobj.jsCallSetDataFinsh();
     initFinish = true;
     $('#summernote').summernote('editor.resetRecord')
+    webobj.jsCallSetDataFinsh();
 }
 
 /**
@@ -964,6 +964,10 @@ function playButColor(status) {
     } else {
         setVoiceButColor(global_activeColor, global_disableColor)
     }
+}
+
+function focusEditor() {
+    $('#summernote').summernote('editor.focus')
 }
 
 //录音插入数据
@@ -1127,13 +1131,12 @@ function setHtml(html) {
         webobj.jsCallTxtChange();
     }
     
-    // 搜索功能
-    webobj.jsCallSetDataFinsh();
     resetScroll()
     $('#summernote').summernote('editor.resetRecord')
 
     // We need call once at init, ensure the foreground color / background color is correct.
     switchTextColor(global_theme == 2)
+    webobj.jsCallSetDataFinsh();
 }
 
 /**


### PR DESCRIPTION
Pass the focus flag through the blank-note creation flow and trigger Summernote focus only after the editor reports content loading finished.

在新建空白笔记流程中传递焦点标记，并在编辑器完成内容加载后再触发 Summernote 聚焦。

Log: 修复新建空白笔记后输入光标未进入富文本编辑器
PMS: bug-366549
Influence: 新建空白笔记后，编辑器可自动获得输入焦点，用户可直接输入内容，避免光标停留在列表区域。