### PR TITLE
fix(vnote): keep move dialog item states consistent

### DIFF
--- a/src/gui/dialog/MoveDialog.qml
+++ b/src/gui/dialog/MoveDialog.qml
@@ -47,30 +47,17 @@ DialogWindow {
 
             ScrollBar.vertical: ScrollBar {
             }
-            delegate: ItemDelegate {
-                backgroundVisible: true
+            delegate: Rectangle {
+                id: folderItem
+
+                property bool isHovered: false
+
+                color: index === dialog.index
+                    ? palette.highlight
+                    : (isHovered ? (DTK.themeType === ApplicationHelper.LightType ? "#1A000000" : "#1AFFFFFF") : "transparent")
                 height: 30
-                spacing: 8
+                radius: 6
                 width: 336
-
-                // 条件设置normalBackgroundVisible属性，仅在支持的DTK版本中使用
-                Component.onCompleted: {
-                    if (DTK.majorVersion >= 6) {
-                        // 在DTK 6.x中可能支持此属性
-                        if (typeof normalBackgroundVisible !== "undefined") {
-                            normalBackgroundVisible = index % 2 === 0;
-                        }
-                    }
-                }
-
-                onClicked: dialog.index = index
-
-                background: Rectangle {
-                    radius: 6
-                    color: index === dialog.index
-                        ? (DTK.themeType === ApplicationHelper.LightType ? "#33000000" : "#33FFFFFF")
-                        : "transparent"
-                }
 
                 // text: model.name
                 RowLayout {
@@ -124,10 +111,26 @@ DialogWindow {
 
                         Layout.alignment: Qt.AlignVCenter
                         Layout.fillWidth: true
+                        color: index === dialog.index ? palette.highlightedText : DTK.palette.windowText
                         font.pixelSize: 14
                         horizontalAlignment: Text.AlignLeft
                         text: model.name
                         verticalAlignment: Text.AlignVCenter
+                    }
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+
+                    onClicked: {
+                        dialog.index = index;
+                    }
+                    onEntered: {
+                        folderItem.isHovered = true;
+                    }
+                    onExited: {
+                        folderItem.isHovered = false;
                     }
                 }
             }


### PR DESCRIPTION
fix(vnote): keep move dialog item states consistent

Preserve the default selected folder visibility in the move-note dialog, use explicit hover state handling for folder items, and keep text colors bound to the correct selected or normal state.

保持移动笔记弹窗中默认选中文件夹的可见状态，显式处理文件夹项 hover 状态，并确保文字颜色随选中或普通状态正确切换。

Log: 修复移动笔记弹窗再次打开后文件夹文字颜色异常
PMS: bug-365291
Influence: 移动笔记弹窗中默认选中项、hover 项和普通项显示状态一致；再次打开弹窗时文件夹文字颜色正常，避免因 hover 状态残留导致文字不可读。