### PR TITLE
chore: Update version to 6.5.60

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+deepin-voice-note (6.5.60) unstable; urgency=medium
+
+  * fix(vnote): keep move dialog item states consistent
+  * fix(vnote): focus rich text editor after creating blank note
+  * fix(vnote): keep copied images visible and viewable
+  * fix(shortcut): disable Ctrl+S for empty notes
+  * fix(vnote): disable note operations during voice-to-text
+  * fix(editor): allow Enter newline while recording
+  * fix(ui): fix settings dialog always-on-top and reduce clipboard log noise
+  * fix(dbus): preserve maximized state when restoring from minimize
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 17 Jun 2026 14:03:55 +0800
+
 deepin-voice-note (6.5.59) unstable; urgency=medium
 
   * fix(ui): add missing scrollbar to note list view

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.59.1
+  version: 6.5.60.1
   kind: app
   description: 4
     voice note for deepin os


### PR DESCRIPTION
- update version to 6.5.60

log: update version to 6.5.60

## Summary by Sourcery

Bump application metadata to version 6.5.60.1.

Build:
- Update linglong package configuration to version 6.5.60.1.

Chores:
- Align project versioning to 6.5.60.1 in configuration and packaging metadata.