### PR TITLE
fix(desktop): add trailing semicolon to Keywords field

### DIFF
--- a/assets/deepin-voice-note.desktop
+++ b/assets/deepin-voice-note.desktop
@@ -10,7 +10,7 @@ Terminal=false
 TryExec=deepin-voice-note
 Type=Application
 X-Deepin-Vendor=user-custom
-Keywords=deepin-voice-note
+Keywords=deepin-voice-note;
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
According to FreeDesktop.org specification, the Keywords field should end with a semicolon separator for proper parsing.

根据FreeDesktop.org规范，Keywords字段应以分号结尾以确保正确解析。

Log: 修复desktop文件中Keywords字段格式
PMS: BUG-366913
Influence: 修复桌面启动器关键词搜索功能，确保关键字匹配正常工作。

## Summary by Sourcery

Bug Fixes:
- Fix keyword search in the desktop launcher by correcting the Keywords field format in the desktop entry file.