### PR TITLE
fix(vnote): flush editor content before note save actions

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -1043,14 +1043,25 @@ void VNoteMainManager::vNoteSearch(const QString &text)
 void VNoteMainManager::updateNoteWithResult(const QString &result)
 {
     qInfo() << "Updating note with result";
-    updateNoteWithResultForNote(m_currentNoteId, result);
+    updateNoteWithResultForNote(m_currentNoteId, currentTextChangeSerial(), result);
     qInfo() << "Note update with result finished";
 }
 
-void VNoteMainManager::updateNoteWithResultForNote(int noteId, const QString &result)
+void VNoteMainManager::updateNoteWithResultForNote(int noteId, quint64 serial, const QString &result)
 {
     VNoteItem *note = getNoteById(noteId);
-    m_richTextManager->onUpdateNoteWithResult(note, result);
+    m_richTextManager->onUpdateNoteWithResult(note, serial, result);
+}
+
+quint64 VNoteMainManager::currentTextChangeSerial() const
+{
+    return m_richTextManager ? m_richTextManager->currentTextChangeSerial() : 0;
+}
+
+void VNoteMainManager::flushNoteWithResultForNote(int noteId, quint64 serial, const QString &result)
+{
+    VNoteItem *note = getNoteById(noteId);
+    m_richTextManager->flushNoteWithResult(note, serial, result);
 }
 
 int VNoteMainManager::loadSearchNotes(const QString &key)

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -55,7 +55,9 @@ public:
     Q_INVOKABLE QString getNotePlainTitle(const int &noteId);
     Q_INVOKABLE void vNoteSearch(const QString &text);
     Q_INVOKABLE void updateNoteWithResult(const QString &result);
-    Q_INVOKABLE void updateNoteWithResultForNote(int noteId, const QString &result);
+    Q_INVOKABLE void updateNoteWithResultForNote(int noteId, quint64 serial, const QString &result);
+    Q_INVOKABLE quint64 currentTextChangeSerial() const;
+    Q_INVOKABLE void flushNoteWithResultForNote(int noteId, quint64 serial, const QString &result);
     Q_INVOKABLE int loadSearchNotes(const QString &key);
     Q_INVOKABLE int loadAudioSource();
     Q_INVOKABLE void changeAudioSource(const int &source);
@@ -103,7 +105,7 @@ signals:
     void noSearchResult();
     void searchFinished(const QList<QVariantMap> &notesData, const QString &key);
     void moveFinished(const QVariantList &index, const int &srcFolderIndex, const int &dstFolderIndex);
-    void needUpdateNote(int noteId);
+    void needUpdateNote(int noteId, quint64 serial);
     void updateRichTextSearch(const QString &key);
     void scrollChange(const bool &isTop);
     void updateEditNote(const int &noteId, const QString &time);

--- a/src/common/webrichetextmanager.cpp
+++ b/src/common/webrichetextmanager.cpp
@@ -141,7 +141,7 @@ void WebRichTextManager::updateNote()
         m_updateInProgress = true;
         m_updateRequestNoteId = m_textChangeNoteId;
         m_updateRequestSerial = m_textChangeSerial;
-        emit needUpdateNote(m_updateRequestNoteId);
+        emit needUpdateNote(m_updateRequestNoteId, m_updateRequestSerial);
     }
     // qInfo() << "Note update finished";
 }
@@ -161,12 +161,37 @@ int WebRichTextManager::currentNoteId() const
     return m_noteData ? m_noteData->noteId : -1;
 }
 
+quint64 WebRichTextManager::currentTextChangeSerial() const
+{
+    return m_textChangeSerial;
+}
+
 void WebRichTextManager::requestUpdateNoteNow()
 {
     updateNote();
 }
 
-void WebRichTextManager::onUpdateNoteWithResult(VNoteItem *data, const QString &result)
+bool WebRichTextManager::saveNoteWithResult(VNoteItem *data, const QString &result)
+{
+    if (!data) {
+        return false;
+    }
+    if (data->htmlCode == result) {
+        return true;
+    }
+
+    data->htmlCode = result;
+    VNoteItemOper noteOps(data);
+    const bool updateOk = noteOps.updateNote();
+    if (!updateOk) {
+        qWarning() << "Failed to save note";
+    } else {
+        qDebug() << "Note saved successfully";
+    }
+    return updateOk;
+}
+
+void WebRichTextManager::onUpdateNoteWithResult(VNoteItem *data, quint64 serial, const QString &result)
 {
     qDebug() << "Updating note with result";
     if (!data) {
@@ -177,15 +202,33 @@ void WebRichTextManager::onUpdateNoteWithResult(VNoteItem *data, const QString &
         emit finishedUpdateNote();
         return;
     }
-    data->htmlCode = result;
-    VNoteItemOper noteOps(data);
-    const bool updateOk = noteOps.updateNote();
-    if (!updateOk) {
-        qWarning() << "Failed to save note";
-    } else {
-        qDebug() << "Note saved successfully";
+
+    if (data->noteId != m_updateRequestNoteId || serial != m_updateRequestSerial) {
+        qWarning() << "Discard stale note update result, noteId:" << data->noteId
+                   << "serial:" << serial
+                   << "requestNoteId:" << m_updateRequestNoteId
+                   << "requestSerial:" << m_updateRequestSerial;
+        m_updateInProgress = false;
+        m_updateRequestNoteId = -1;
+        m_updateRequestSerial = 0;
+        emit finishedUpdateNote();
+        return;
     }
-    if (updateOk && data->noteId == m_textChangeNoteId && m_updateRequestSerial == m_textChangeSerial) {
+
+    if (data->noteId != m_textChangeNoteId || serial != m_textChangeSerial) {
+        qWarning() << "Discard outdated note update result, noteId:" << data->noteId
+                   << "serial:" << serial
+                   << "textChangeNoteId:" << m_textChangeNoteId
+                   << "textChangeSerial:" << m_textChangeSerial;
+        m_updateInProgress = false;
+        m_updateRequestNoteId = -1;
+        m_updateRequestSerial = 0;
+        emit finishedUpdateNote();
+        return;
+    }
+
+    const bool updateOk = saveNoteWithResult(data, result);
+    if (updateOk) {
         m_textChange = false;
         m_textChangeNoteId = -1;
     }
@@ -194,6 +237,37 @@ void WebRichTextManager::onUpdateNoteWithResult(VNoteItem *data, const QString &
     m_updateRequestSerial = 0;
     emit finishedUpdateNote();
     qInfo() << "Note update with result finished";
+}
+
+bool WebRichTextManager::clearTextChangeState(int noteId, quint64 serial)
+{
+    bool clearedUpdateRequest = false;
+
+    if (noteId == m_textChangeNoteId && serial == m_textChangeSerial) {
+        m_textChange = false;
+        m_textChangeNoteId = -1;
+    }
+    if (noteId == m_updateRequestNoteId && serial == m_updateRequestSerial) {
+        m_updateInProgress = false;
+        m_updateRequestNoteId = -1;
+        m_updateRequestSerial = 0;
+        clearedUpdateRequest = true;
+    }
+
+    return clearedUpdateRequest;
+}
+
+void WebRichTextManager::flushNoteWithResult(VNoteItem *data, quint64 serial, const QString &result)
+{
+    if (!data) {
+        return;
+    }
+
+    if (saveNoteWithResult(data, result)) {
+        if (clearTextChangeState(data->noteId, serial)) {
+            emit finishedUpdateNote();
+        }
+    }
 }
 
 void WebRichTextManager::insertVoiceItem(const QString &voicePath, qint64 voiceSize)

--- a/src/common/webrichetextmanager.h
+++ b/src/common/webrichetextmanager.h
@@ -24,7 +24,9 @@ public:
     bool hasPendingTextChange() const;
     int pendingTextChangeNoteId() const;
     int currentNoteId() const;
+    quint64 currentTextChangeSerial() const;
     void requestUpdateNoteNow();
+    void flushNoteWithResult(VNoteItem *data, quint64 serial, const QString &result);
 
 public slots:
     void onLoadFinsh();
@@ -33,12 +35,12 @@ public slots:
 
     void updateNote();
 
-    void onUpdateNoteWithResult(VNoteItem *data, const QString &result);
+    void onUpdateNoteWithResult(VNoteItem *data, quint64 serial, const QString &result);
 
     void insertVoiceItem(const QString &voicePath, qint64 voiceSize);
 
 signals:
-    void needUpdateNote(int noteId);
+    void needUpdateNote(int noteId, quint64 serial);
     void noteTextChanged();
     void updateSearch();
     void scrollChange(const bool &isTop);
@@ -46,6 +48,8 @@ signals:
 
 private:
     void setData(VNoteItem *data, const QString reg);
+    bool saveNoteWithResult(VNoteItem *data, const QString &result);
+    bool clearTextChangeState(int noteId, quint64 serial);
 
 private:
     VNoteItem *m_noteData {nullptr};

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -40,6 +40,7 @@ Item {
     signal mouseChanged(int mousePosX, int mousePosY)
     signal mulChoices(int choices)
     signal noteItemChanged(int index)
+    signal requestNoteContextMenu(var noteIds, int popupIndex, var popupX, var popupY)
 
     function changeCurrentIndex(index) {
         itemListView.currentIndex = index;
@@ -74,6 +75,25 @@ Item {
         if (newDelegate) newDelegate.isSelected = true;
         itemListView.currentIndex = index;
         itemListView.lastCurrentIndex = index;
+    }
+
+    function popupNoteContextMenu(noteIds, popupIndex, popupX, popupY) {
+        if (!noteIds || noteIds.length === 0)
+            return;
+
+        VNoteMainManager.checkNoteVoice(noteIds);
+        VNoteMainManager.checkNoteText(noteIds);
+        if (popupIndex >= 0 && popupIndex < itemModel.count) {
+            var item = itemListView.itemAtIndex(popupIndex);
+            if (item) {
+                try {
+                    noteCtxMenu.popup(item, popupX, popupY);
+                    return;
+                } catch (e) {
+                }
+            }
+        }
+        noteCtxMenu.popup();
     }
 
     function onDeleteNote() {
@@ -219,7 +239,6 @@ Item {
         // 在当前选中项位置弹出笔记右键菜单
         if (selectedNoteItem.length === 0)
             return;
-        // 保持与右键逻辑一致：刷新 contextIndex、检查语音可用性和文本内容
         var validIndexes = validSelectedNoteIndexes();
         if (validIndexes.length === 0)
             return;
@@ -228,16 +247,10 @@ Item {
         for (var i = 0; i < validIndexes.length; i++) {
             list.push(itemModel.get(validIndexes[i]).noteId);
         }
-        VNoteMainManager.checkNoteVoice(list);
-        VNoteMainManager.checkNoteText(list);
         var item = itemListView.itemAtIndex(itemListView.contextIndex);
         if (!item)
             return;
-        try {
-            noteCtxMenu.popup(item, item.width / 2, item.height);
-        } catch (e) {
-            noteCtxMenu.popup();
-        }
+        requestNoteContextMenu(list, itemListView.contextIndex, item.width / 2, item.height);
     }
 
     height: 480
@@ -319,7 +332,6 @@ Item {
                 list.push(itemModel.get(validIndexes[i]).noteId);
             }
             VNoteMainManager.checkNoteVoice(list);
-            VNoteMainManager.checkNoteText(list);
         }
     }
 
@@ -1032,9 +1044,7 @@ Item {
                         for (var i = 0; i < validIndexes.length; i++) {
                             list.push(itemModel.get(validIndexes[i]).noteId);
                         }
-                        VNoteMainManager.checkNoteVoice(list);
-                        VNoteMainManager.checkNoteText(list);
-                        noteCtxMenu.popup();
+                        requestNoteContextMenu(list, -1, 0, 0);
                     } else {
                         // 录音时禁用笔记切换
                         if (isRecordingAudio) {

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -192,13 +192,16 @@ ApplicationWindow {
                 return;
             }
 
-            // Ctrl+S 保存为 txt，只检查是否有文本内容，与右键菜单逻辑保持一致
-            if (!VNoteMainManager.hasNoteText(currentNoteId)) {
-                console.warn("当前笔记没有文本内容，不执行保存操作");
-                return;
-            }
+            webEngineView.flushCurrentNote(function() {
+                // Ctrl+S 保存为 txt，只检查是否有文本内容，与右键菜单逻辑保持一致
+                currentNoteId = VNoteMainManager.currentNoteId();
+                if (!VNoteMainManager.hasNoteText(currentNoteId)) {
+                    console.warn("当前笔记没有文本内容，不执行保存操作");
+                    return;
+                }
 
-            itemListView.onSaveNote();
+                itemListView.onSaveNote();
+            });
         }
         onSaveVoice: {
             // 检查是否有笔记可以保存
@@ -825,6 +828,11 @@ ApplicationWindow {
                     onNoteItemChanged: {
                         VNoteMainManager.vNoteChanged(index);
                     }
+                    onRequestNoteContextMenu: function(noteIds, popupIndex, popupX, popupY) {
+                        webEngineView.flushCurrentNote(function() {
+                            itemListView.popupNoteContextMenu(noteIds, popupIndex, popupX, popupY);
+                        });
+                    }
                 }
             }
         }
@@ -922,7 +930,9 @@ ApplicationWindow {
                         itemListView.onSaveAudio();
                     }
                     onSaveNote: {
-                        itemListView.onSaveNote();
+                        webEngineView.flushCurrentNote(function() {
+                            itemListView.onSaveNote();
+                        });
                     }
                 }
             }

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -42,6 +42,21 @@ Item {
         webView.forceActiveFocus();
     }
 
+    function flushCurrentNote(callback) {
+        var noteId = VNoteMainManager.currentNoteId();
+        var serial = VNoteMainManager.currentTextChangeSerial();
+        webView.runJavaScript("getHtml()", function(result) {
+            if (result !== null && result !== undefined) {
+                VNoteMainManager.flushNoteWithResultForNote(noteId, serial, result);
+            } else {
+                console.warn("flushCurrentNote getHtml returned null, noteId:", noteId, "serial:", serial);
+            }
+            if (callback) {
+                callback();
+            }
+        });
+    }
+
     function showJsContextMenu() {
         // 仅在编辑区可见时尝试弹出；是否在编辑器内由JS自行判断
         if (webVisible) {
@@ -618,10 +633,11 @@ Item {
     Connections {
         target: VNoteMainManager
 
-        onNeedUpdateNote: function(noteId) {
+        onNeedUpdateNote: function(noteId, serial) {
             var requestNoteId = noteId;
+            var requestSerial = serial;
             webView.runJavaScript("getHtml()", function (result) {
-                VNoteMainManager.updateNoteWithResultForNote(requestNoteId, result);
+                VNoteMainManager.updateNoteWithResultForNote(requestNoteId, requestSerial, result);
             });
         }
         onScrollChange: isTop => {


### PR DESCRIPTION
Bind editor flush requests to note id and change serial.

将编辑器 flush 请求绑定到笔记 ID 和变更序号。

Reuse flushed note content before context menu and save actions.

右键菜单和保存动作前复用已同步的笔记内容。

Log: 修复新建笔记快速右键保存菜单置灰问题
PMS: BUG-366545
Influence: 新建或编辑笔记后立即右键、快捷键弹出菜单或保存时，会先同步编辑器最新内容，避免保存笔记菜单误置灰或导出旧内容。

## Summary by Sourcery

Bind editor flush requests and note update operations to a specific note ID and text change serial to avoid stale saves and ensure latest content is used for actions like context menus and save.

Bug Fixes:
- Prevent saving or exporting outdated content by discarding stale note update results that do not match the current note ID and text change serial.
- Fix note context menu save option being incorrectly disabled for newly created or recently edited notes by flushing and persisting editor content before opening menus or saving.

Enhancements:
- Add support for flushing the current note content on demand and reusing the flushed result for context menus and keyboard save actions.
- Introduce a serial-based mechanism in the rich text manager and main manager to track text changes and validate note update results.
- Refactor note context menu invocation in the item list and main window to centralize pre-checks and ensure editor content is synchronized before menu display or save operations.