### PR TITLE
fix(folder): improve folder drag auto-scroll feedback

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -63,6 +63,8 @@ Item {
         }
         lastDropIndex = -1;
         currentDropIndex = -1;
+        folderListView.hoverIndex = -1;
+        hideScrollHintLine();
     }
 
     function getCurrentFolder() {
@@ -98,12 +100,16 @@ Item {
             return;
         if (folderListView.contentY < folderListView.bottomContentY()) {
             scrollTimer.isUp = false;
+            showScrollHintLine(false);
             scrollTimer.running = true;
+        } else {
+            hideScrollHintLine();
         }
     }
 
     function rollStop() {
         scrollTimer.running = false;
+        hideScrollHintLine();
     }
 
     function rollUp() {
@@ -111,8 +117,20 @@ Item {
             return;
         if (folderListView.contentY > folderListView.topContentY()) {
             scrollTimer.isUp = true;
+            showScrollHintLine(true);
             scrollTimer.running = true;
+        } else {
+            hideScrollHintLine();
         }
+    }
+
+    function showScrollHintLine(isUp) {
+        scrollHintLine.y = isUp ? 0 : Math.max(0, height - scrollHintLine.implicitHeight);
+        scrollHintLine.visible = true;
+    }
+
+    function hideScrollHintLine() {
+        scrollHintLine.visible = false;
     }
 
     function toggleSearch(isSearch) {
@@ -254,6 +272,7 @@ Item {
                 if (folderListView.contentY <= topY) {
                     running = false;
                     folderListView.contentY = topY;
+                    hideScrollHintLine();
                     folderListView.refreshDragTargetAfterScroll();
                     return;
                 }
@@ -264,6 +283,7 @@ Item {
                 if (folderListView.contentY >= bottomY) {
                     running = false;
                     folderListView.contentY = bottomY;
+                    hideScrollHintLine();
                     folderListView.refreshDragTargetAfterScroll();
                     return;
                 }
@@ -300,6 +320,17 @@ Item {
         implicitHeight: 3
         implicitWidth: folderListView.width
         visible: false
+        z: 2
+    }
+
+    Rectangle {
+        id: scrollHintLine
+
+        color: DTK.themeType === ApplicationHelper.LightType ? "#66000000" : "#66FFFFFF"
+        implicitHeight: 3
+        implicitWidth: folderListView.width
+        visible: false
+        z: 2
     }
 
     ListView {
@@ -348,6 +379,7 @@ Item {
             lastDropIndex = -1;
             dragControl.visible = false;
             dragControl.imageSource = "";
+            hideScrollHintLine();
         }
 
         function refreshDragTargetAfterScroll() {


### PR DESCRIPTION
Use real content offsets when calculating drag targets and scroll bounds.

拖拽排序时使用真实内容偏移计算目标位置和滚动边界。

Keep drag state, hover state and current folder selection consistent after moving.

移动文件夹后保持拖拽状态、悬停状态和当前文件夹选中状态一致。

Show scroll hint line while dragging near folder list auto-scroll area.

拖拽触发记事本列表自动滚动时显示滚动提示线。

Log: 修复文件夹拖拽自动滚动排序及提示异常
PMS: BUG-338763

Influence: 文件夹拖拽到列表边缘自动滚动时，排序目标位置更准确，避免悬停状态、插入线、当前选中项或滚动提示显示异常。

## Summary by Sourcery

Improve visual feedback and state consistency when auto-scrolling the folder list during drag-and-drop reordering.

Bug Fixes:
- Reset folder hover index and drag-related visual state when drag operations stop or are cancelled to avoid stale hover or selection indicators.
- Hide the scroll hint and auto-scroll visuals when scrolling reaches list bounds or drag auto-scroll stops, preventing lingering UI artifacts.

Enhancements:
- Add a scroll hint line that appears near the folder list edges while drag auto-scroll is active, clarifying the scroll direction and area to users.