### PR TITLE
fix(folder): correct folder scrollbar position

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -23,6 +23,8 @@ Item {
     property int listHeight: 700
     property int listWidth: 200
     property alias model: folderListView.model
+    property Item scrollBarParent: null
+    property int scrollBarRightOffset: 0
     property bool webVisible: true
 
     signal emptyItemList(bool isEmpty)
@@ -430,6 +432,55 @@ Item {
         ScrollBar.vertical: ScrollBar {
             id: verticalScrollBar
 
+            function updateGeometry() {
+                if (!parent)
+                    return;
+
+                x = root.mapToItem(parent, root.width + root.scrollBarRightOffset - width, 0).x;
+                y = root.scrollBarParent ? 0 : root.mapToItem(parent, 0, 0).y;
+                height = root.scrollBarParent ? parent.height : folderListView.height;
+            }
+
+            parent: root.scrollBarParent ? root.scrollBarParent : folderListView
+
+            Component.onCompleted: Qt.callLater(updateGeometry)
+            onParentChanged: Qt.callLater(updateGeometry)
+            onWidthChanged: Qt.callLater(updateGeometry)
+
+            Connections {
+                target: root
+
+                function onHeightChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onWidthChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onXChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onYChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+            }
+
+            Connections {
+                enabled: !!root.scrollBarParent
+                target: root.scrollBarParent
+
+                function onHeightChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onWidthChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onXChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onYChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+            }
         }
         delegate: Rectangle {
             id: rootItem

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -510,6 +510,8 @@ ApplicationWindow {
             color: DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#101010"
 
             ColumnLayout {
+                id: leftColumnLayout
+
                 anchors.bottomMargin: 10
                 anchors.fill: parent
                 anchors.leftMargin: 10
@@ -523,6 +525,8 @@ ApplicationWindow {
                     Layout.fillWidth: true
                     enabled: !rootWindow.isVoiceToText && !itemListView.isSearching && !webEngineView.titleBar.isSearching
                     opacity: enabled ? 1.0 : 0.4
+                    scrollBarParent: scrollBarOverlay
+                    scrollBarRightOffset: 10
                     webVisible: initRect.visible
                     isRecordingAudio: rootWindow.isRecordingAudio  // 传递录音状态
                     isVoiceToText: rootWindow.isVoiceToText  // 传递语音转文字状态
@@ -925,6 +929,52 @@ ApplicationWindow {
                         itemListView.onSaveNote();
                     }
                 }
+            }
+        }
+    }
+
+    Item {
+        id: scrollBarOverlay
+
+        function updateGeometry() {
+            y = folderListView.mapToItem(parent, 0, 0).y;
+        }
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        clip: true
+        height: folderListView.height
+        visible: leftBgArea.visible
+        z: 50
+
+        Component.onCompleted: Qt.callLater(updateGeometry)
+        onHeightChanged: Qt.callLater(updateGeometry)
+        onVisibleChanged: Qt.callLater(updateGeometry)
+
+        Connections {
+            target: folderListView
+
+            function onHeightChanged() {
+                Qt.callLater(scrollBarOverlay.updateGeometry);
+            }
+            function onYChanged() {
+                Qt.callLater(scrollBarOverlay.updateGeometry);
+            }
+        }
+
+        Connections {
+            target: leftBgArea
+
+            function onYChanged() {
+                Qt.callLater(scrollBarOverlay.updateGeometry);
+            }
+        }
+
+        Connections {
+            target: leftColumnLayout
+
+            function onYChanged() {
+                Qt.callLater(scrollBarOverlay.updateGeometry);
             }
         }
     }


### PR DESCRIPTION
Render folder list scrollbar on an overlay to avoid being clipped or covered.

将记事本列表滚动条渲染到覆盖层，避免被裁剪或被相邻区域遮挡。

Constrain scrollbar overlay to the folder list area and refresh geometry after layout changes.

限制滚动条覆盖层在记事本列表区域内，并在布局变化后刷新几何位置。

Log: 修复记事本列表滚动条位置及显示异常
PMS: BUG-331555

Influence: 记事本列表滚动条显示位置更准确，避免首次进入、悬浮或滚动时出现位置偏移、超出列表区域或被遮挡的问题。