### PR TITLE
fix(editor): reject unsupported file drag into rich text

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -1110,6 +1110,28 @@ void VNoteMainManager::changeAudioSource(const int &source)
     VoiceRecoderHandler::instance()->changeMode(source);
 }
 
+bool VNoteMainManager::canInsertImages(const QList<QUrl> &filePaths) const
+{
+    if (filePaths.isEmpty())
+        return false;
+
+    for (const QUrl &path : filePaths) {
+        if (!path.isLocalFile())
+            return false;
+
+        const QString localPath = QDir::cleanPath(path.toLocalFile());
+        const QFileInfo fileInfo(localPath);
+        if (!fileInfo.exists() || !fileInfo.isFile())
+            return false;
+
+        QImageReader imageReader(localPath);
+        if (!imageReader.canRead())
+            return false;
+    }
+
+    return true;
+}
+
 void VNoteMainManager::insertImages(const QList<QUrl> &filePaths)
 {
     qDebug() << "Inserting" << filePaths.size() << "images";

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -59,6 +59,7 @@ public:
     Q_INVOKABLE int loadSearchNotes(const QString &key);
     Q_INVOKABLE int loadAudioSource();
     Q_INVOKABLE void changeAudioSource(const int &source);
+    Q_INVOKABLE bool canInsertImages(const QList<QUrl> &filePaths) const;
     Q_INVOKABLE void insertImages(const QList<QUrl> &filePaths);
     Q_INVOKABLE void checkNoteVoice(const QVariantList &index);
     Q_INVOKABLE void checkNoteText(const QVariantList &index);

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -300,10 +300,26 @@ Item {
                 DropArea {
                     anchors.fill: parent
 
+                    property bool currentDragCanDropImages: false
+
+                    onEntered: function(drag) {
+                        currentDragCanDropImages = drag.hasUrls && VNoteMainManager.canInsertImages(drag.urls);
+                        drag.accepted = currentDragCanDropImages;
+                    }
+                    onExited: {
+                        currentDragCanDropImages = false;
+                    }
+                    onPositionChanged: function(drag) {
+                        drag.accepted = currentDragCanDropImages;
+                    }
                     onDropped: function(drop) {
-                        if (drop.hasUrls) {
+                        if (currentDragCanDropImages) {
+                            drop.accepted = true;
                             VNoteMainManager.insertImages(drop.urls);
+                        } else {
+                            drop.accepted = false;
                         }
+                        currentDragCanDropImages = false;
                     }
                 }
 

--- a/src/handler/web_engine_handler.cpp
+++ b/src/handler/web_engine_handler.cpp
@@ -14,6 +14,7 @@
 #include "setting.h"
 #include "globaldef.h"
 #include "common/utils.h"
+#include "common/VNoteMainManager.h"
 
 #include <QApplication>
 #include <QCursor>
@@ -25,7 +26,9 @@
 #include <QJsonObject>
 #include <QCollator>
 #include <QDir>
+#include <QDropEvent>
 #include <QFile>
+#include <QFileInfo>
 #include <QTimer>
 #include <QCursor>
 #include <QMimeData>
@@ -161,10 +164,72 @@ void WebEngineHandler::setTarget(QObject *targetWebEngine)
     qInfo() << "Setting target web engine";
     if (targetWebEngine != m_targetWebEngine) {
         qInfo() << "targetWebEngine is not equal to m_targetWebEngine";
+        if (m_targetWebEngine)
+            m_targetWebEngine->removeEventFilter(this);
         m_targetWebEngine = targetWebEngine;
+        if (m_targetWebEngine)
+            m_targetWebEngine->installEventFilter(this);
         Q_EMIT targetChanged();
     }
     qInfo() << "Target web engine setting finished";
+}
+
+bool WebEngineHandler::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == m_targetWebEngine) {
+        switch (event->type()) {
+        case QEvent::DragEnter: {
+            auto *dropEvent = static_cast<QDropEvent *>(event);
+            const QMimeData *mimeData = dropEvent->mimeData();
+            m_dragImageCheckUrls = mimeData && mimeData->hasUrls() ? mimeData->urls() : QList<QUrl>();
+            m_dragCanInsertImages = !m_dragImageCheckUrls.isEmpty() && VNoteMainManager::instance()->canInsertImages(m_dragImageCheckUrls);
+            if (!m_dragImageCheckUrls.isEmpty() && !m_dragCanInsertImages) {
+                dropEvent->setDropAction(Qt::IgnoreAction);
+                dropEvent->ignore();
+                return true;
+            }
+            break;
+        }
+        case QEvent::DragMove: {
+            auto *dropEvent = static_cast<QDropEvent *>(event);
+            const QMimeData *mimeData = dropEvent->mimeData();
+            if (mimeData && mimeData->hasUrls()) {
+                const QList<QUrl> urls = mimeData->urls();
+                if (urls != m_dragImageCheckUrls) {
+                    m_dragImageCheckUrls = urls;
+                    m_dragCanInsertImages = VNoteMainManager::instance()->canInsertImages(m_dragImageCheckUrls);
+                }
+                if (!m_dragCanInsertImages) {
+                    dropEvent->setDropAction(Qt::IgnoreAction);
+                    dropEvent->ignore();
+                    return true;
+                }
+            }
+            break;
+        }
+        case QEvent::Drop: {
+            auto *dropEvent = static_cast<QDropEvent *>(event);
+            const QMimeData *mimeData = dropEvent->mimeData();
+            const bool canInsertImages = mimeData && mimeData->hasUrls() && VNoteMainManager::instance()->canInsertImages(mimeData->urls());
+            m_dragImageCheckUrls.clear();
+            m_dragCanInsertImages = false;
+            if (mimeData && mimeData->hasUrls() && !canInsertImages) {
+                dropEvent->setDropAction(Qt::IgnoreAction);
+                dropEvent->ignore();
+                return true;
+            }
+            break;
+        }
+        case QEvent::DragLeave:
+            m_dragImageCheckUrls.clear();
+            m_dragCanInsertImages = false;
+            break;
+        default:
+            break;
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
 }
 
 /**

--- a/src/handler/web_engine_handler.h
+++ b/src/handler/web_engine_handler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,6 +11,7 @@
 #include <QObject>
 #include <QRect>
 #include <QEventLoop>
+#include <QUrl>
 
 // 条件编译：根据 Qt 版本包含不同的 WebEngine 头文件
 #ifdef USE_QT5
@@ -99,6 +100,9 @@ public Q_SLOTS:
     void onMenuClicked(ActionManager::ActionKind kind);
     void onPaste(bool isVoice);
 
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
 private:
     void initFontsInformation();
     void connectWebContent();
@@ -137,6 +141,9 @@ private:
 
     QStringList m_fontList;  // 字体列表
     QString m_defaultFont;   // 默认字体
+
+    QList<QUrl> m_dragImageCheckUrls;
+    bool m_dragCanInsertImages { false };
 
     QVariant m_callJsResult;  // js 函数调用返回值
     QEventLoop m_callJsLoop;  // js 函数调用等待


### PR DESCRIPTION
Check dragged URLs before accepting drops in the rich text editor.

在富文本编辑区接收拖拽前检查文件 URL 是否为可插入图片。

Filter unsupported files at both QML DropArea and WebEngine native drag event levels.

同时在 QML DropArea 和 WebEngine 原生拖拽事件层过滤不支持的文件。

Log: 修复不支持文件拖入富文本时鼠标角标显示为可接收
PMS: BUG-354419

Influence: 拖拽 doc、zip 等不支持文件到富文本编辑区时显示不可接收状态，避免用户误以为应用支持打开这些文件；图片拖拽插入不受影响。