### PR TITLE
fix(editor): position floating toolbar with text context menu

### DIFF
--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -27,6 +27,91 @@ Item {
     property bool webVisible: true
     property alias titleBar: title
 
+    Timer {
+        id: txtMenuToolbarTimer
+        interval: 50
+        repeat: false
+        property int retryCount: 0
+        readonly property int maxRetries: 8
+        onTriggered: rootItem.passTxtMenuToToolbar(txtCtxMenu, retryCount)
+    }
+
+    // 累加可见子项 implicitHeight/height（来自 DTK 布局，不用硬编码行高）
+    function txtMenuItemsHeight(menu) {
+        var sum = 0;
+        for (var i = 0; i < menu.count; ++i) {
+            var item = menu.itemAt(i);
+            if (!item || item.visible === false) {
+                continue;
+            }
+            var itemH = item.height > 0 ? item.height : item.implicitHeight;
+            if (itemH > 0) {
+                sum += itemH;
+            }
+        }
+        return sum;
+    }
+
+    function txtMenuEffectiveHeight(menu) {
+        var height = menu.height;
+        var itemsH = txtMenuItemsHeight(menu);
+        height = Math.max(height, itemsH);
+        height = Math.max(height, menu.implicitHeight);
+        if (menu.contentItem) {
+            height = Math.max(height, menu.contentItem.height);
+            height = Math.max(height, menu.contentItem.implicitHeight);
+        }
+        return height;
+    }
+
+    // menu.height 常为占位值；与可见子项总高度偏差大则视为未就绪
+    function isTxtMenuHeightReady(menu) {
+        var height = menu.height;
+        if (height <= 0 || !menu.visible) {
+            return false;
+        }
+        var itemsH = txtMenuItemsHeight(menu);
+        if (itemsH > 0 && height < itemsH * 0.85) {
+            return false;
+        }
+        return true;
+    }
+
+    function toJsInt(value) {
+        var n = Math.round(Number(value));
+        return isFinite(n) ? n : 0;
+    }
+
+    function passTxtMenuToToolbar(menu, retryCount) {
+        if (!menu.visible || !webView) {
+            return;
+        }
+
+        var menuWidth = menu.width > 0 ? menu.width : menu.implicitWidth;
+        var menuHeight = txtMenuEffectiveHeight(menu);
+
+        if (!isTxtMenuHeightReady(menu) && retryCount < txtMenuToolbarTimer.maxRetries) {
+            txtMenuToolbarTimer.retryCount = retryCount + 1;
+            txtMenuToolbarTimer.start();
+            return;
+        }
+
+        var webViewPos = webView.mapToItem(null, 0, 0);
+        var safeX = toJsInt(menu.x - webViewPos.x);
+        var safeY = toJsInt(menu.y - webViewPos.y);
+        var safeW = toJsInt(menuWidth);
+        var safeH = toJsInt(menuHeight);
+
+        if (safeW <= 0 || safeH <= 0) {
+            return;
+        }
+
+        webView.runJavaScript(
+            "if(typeof setMenuPosition === 'function') setMenuPosition("
+            + safeX + ", " + safeY + ", "
+            + safeW + ", " + safeH + ");");
+    }
+
     signal deleteNote
     signal moveNote
     signal openSetting
@@ -507,33 +592,18 @@ Item {
             }
 
             onOpened: {
-                // 菜单已经打开并定位好，获取真实位置
+                txtMenuToolbarTimer.stop();
+                txtMenuToolbarTimer.retryCount = 0;
                 Qt.callLater(function() {
-                    var menuX = txtCtxMenu.x;
-                    var menuY = txtCtxMenu.y;
-                    var menuWidth = txtCtxMenu.width;
-                    var menuHeight = txtCtxMenu.height;
-                    
-                    console.log("QML菜单位置: x=" + menuX + ", y=" + menuY + ", w=" + menuWidth + ", h=" + menuHeight);
-                    
-                    // 传递给JavaScript
-                    if (webView && menuWidth > 0 && menuHeight > 0) {
-                        var webViewPos = webView.mapToItem(null, 0, 0);
-                        var relativeX = menuX - webViewPos.x;
-                        var relativeY = menuY - webViewPos.y;
-                        
-                        console.log("转换为webView相对位置: x=" + relativeX + ", y=" + relativeY);
-                        
-                        var jsCode = "if(typeof setMenuPosition === 'function') setMenuPosition(" + 
-                                     relativeX + ", " + relativeY + ", " + menuWidth + ", " + menuHeight + ");";
-                        webView.runJavaScript(jsCode);
-                    }
+                    rootItem.passTxtMenuToToolbar(txtCtxMenu, 0);
                 });
             }
 
             onClosed: {
-                // 菜单关闭时隐藏悬浮工具栏
-                Webobj.callJsHideEditToolbar();
+                txtMenuToolbarTimer.stop();
+                // 菜单关闭不隐藏工具栏，仅解除定位锁定（b80965d 原始行为）
+                webView.runJavaScript(
+                    "if(typeof restoreAirPopoverTooltipPlacement === 'function') restoreAirPopoverTooltipPlacement();");
             }
 
             Connections {

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -137,6 +137,7 @@ var bTransVoiceIsReady = true;  //语音转文字是否准备好
 var initFinish = false;
 var isVoicePaste = false
 var isShowAir = true
+var contextMenuToolbarActive = false // 右键菜单期间禁止 airPopover.update 覆盖定位
 var nowClickVoice = null
 var global_activeColor = ''
 var lastRightClickX = 0;  // 保存右键点击的X坐标
@@ -152,6 +153,7 @@ const airPopoverHeight = 44  //悬浮工具栏高度
 const airPopoverWidth = 385  //悬浮工具栏宽度
 const airPopoverLeftMargin = 20 //悬浮工具栏距离编辑区左侧边距
 const airPopoverRightMargin = 35 //悬浮工具栏距离编辑区右侧边距
+const airPopoverMenuSpacing = 10 // 工具栏与右键菜单间距
 
 // 翻译列表
 var tooltipContent = {
@@ -1440,40 +1442,51 @@ function rightClick(e) {
         }
     }
     let info = isRangeVoice()
+    if (info.flag === 2) {
+        // 文本菜单弹出前先隐藏工具栏，待菜单位置确定后再重新定位显示
+        contextMenuToolbarActive = true;
+        $('#summernote').summernote('airPopover.hide');
+    }
     webobj.jsCallPopupMenu(info.flag, info.info);
     // 阻止默认右键事件
     // e.preventDefault()
+}
+
+function setAirPopoverTooltipPlacement(placement) {
+    $('.note-air-popover .note-btn, .note-air-popover .note-color-btn').each(function () {
+        var $btn = $(this);
+        $btn.attr('data-placement', placement);
+        var tip = $btn.data('bs.tooltip');
+        if (tip) {
+            tip.options.placement = placement;
+        }
+    });
+}
+
+function restoreAirPopoverTooltipPlacement() {
+    setAirPopoverTooltipPlacement('top');
+    contextMenuToolbarActive = false;
 }
 
 /**
  * 接收QML传来的菜单位置，计算并显示工具栏
  */
 function setMenuPosition(menuX, menuY, menuWidth, menuHeight) {
-    console.log("收到菜单位置: x=" + menuX + ", y=" + menuY + ", w=" + menuWidth + ", h=" + menuHeight);
-    console.log("右键点击位置: x=" + lastRightClickX + ", y=" + lastRightClickY);
-    
+    if (menuX <= 0 && lastRightClickX > 0) {
+        menuX = lastRightClickX;
+    }
+    if (menuY <= 0 && lastRightClickY > 0) {
+        menuY = lastRightClickY;
+    }
+
     var winWidth = $(window).width();
     var winHeight = $(window).height();
-    var scrollLeft = $(document).scrollLeft();
-    var scrollTop = $(document).scrollTop();
-    
-    // 获取工具栏实际尺寸
+
     var $airPopover = $('.note-air-popover');
-    var toolbarHeight = $airPopover.outerHeight() || 44;
-    var toolbarWidth = $airPopover.outerWidth() || 385;
-    
-    var spacing = 10;  // 固定间距
-    
-    console.log("工具栏尺寸: w=" + toolbarWidth + ", h=" + toolbarHeight);
-    console.log("窗口尺寸: w=" + winWidth + ", h=" + winHeight);
-    
-    // 计算菜单到顶部和底部的距离
-    var menuTopDistance = menuY;
-    var menuBottomDistance = winHeight - (menuY + menuHeight);
-    
-    console.log("菜单顶部距离: " + menuTopDistance + ", 底部距离: " + menuBottomDistance);
-    
-    // 计算工具栏X坐标（以点击位置为基准，确保不超出边界）
+    var toolbarHeight = $airPopover.outerHeight() || airPopoverHeight;
+    var toolbarWidth = $airPopover.outerWidth() || airPopoverWidth;
+    var spacing = airPopoverMenuSpacing;
+
     var toolbarX = lastRightClickX;
     if (toolbarX + toolbarWidth > winWidth) {
         toolbarX = winWidth - toolbarWidth - 10;
@@ -1481,31 +1494,38 @@ function setMenuPosition(menuX, menuY, menuWidth, menuHeight) {
     if (toolbarX < 10) {
         toolbarX = 10;
     }
-    
-    // 计算工具栏Y坐标
+
     var toolbarY;
-    if (menuTopDistance >= toolbarHeight + spacing) {
-        // 菜单上方空间足够，放在上方
-        toolbarY = menuY - toolbarHeight - spacing;
-        console.log("工具栏放在菜单上方");
-    } else if (menuBottomDistance >= toolbarHeight + spacing) {
-        // 菜单下方空间足够，放在下方
-        toolbarY = menuY + menuHeight + spacing;
-        console.log("工具栏放在菜单下方");
+    var toolbarBelowMenu = false;
+
+    if (menuHeight <= 0) {
+        toolbarY = menuY + spacing;
+        toolbarBelowMenu = true;
     } else {
-        // 上下都不够，放在空间更大的一侧
-        if (menuTopDistance > menuBottomDistance) {
-            toolbarY = 10;  // 贴顶
-            console.log("工具栏贴顶");
+        var menuTopDistance = menuY;
+        var menuBottomDistance = winHeight - (menuY + menuHeight);
+
+        if (menuTopDistance >= toolbarHeight + spacing) {
+            toolbarY = menuY - toolbarHeight - spacing;
+        } else if (menuBottomDistance >= toolbarHeight + spacing) {
+            toolbarY = menuY + menuHeight + spacing;
+            toolbarBelowMenu = true;
+        } else if (menuTopDistance > menuBottomDistance) {
+            toolbarY = 10;
         } else {
-            toolbarY = winHeight - toolbarHeight - 10;  // 贴底
-            console.log("工具栏贴底");
+            toolbarY = winHeight - toolbarHeight - 10;
+            toolbarBelowMenu = true;
         }
     }
-    
-    console.log("最终工具栏位置: x=" + toolbarX + ", y=" + toolbarY);
-    
-    // 显示工具栏（传入视口坐标，rightUpdate 内部会添加滚动偏移）
+
+    contextMenuToolbarActive = true;
+    setAirPopoverTooltipPlacement(toolbarBelowMenu ? 'bottom' : 'top');
+    $('.note-air-popover .note-btn, .note-air-popover .note-color-btn').each(function () {
+        var tip = $(this).data('bs.tooltip');
+        if (tip) {
+            $(this).tooltip('hide');
+        }
+    });
     showRightMenu(toolbarX, toolbarY);
 }
 
@@ -2083,46 +2103,35 @@ function showRightMenu(x, y) {
         }
         // 检查是否在 .translateText 或 .voiceBox 内
         var $container = $(container);
-        if ($container.closest('.translateText').length > 0 || 
+        if ($container.closest('.translateText').length > 0 ||
             $container.closest('.voiceBox').length > 0) {
-            console.log("在 translateText/voiceBox 区域，不显示悬浮工具栏");
             return;
         }
     }
-    $('#summernote').summernote('airPopover.rightUpdate', x, y)
+    $('#summernote').summernote('airPopover.rightUpdate', x, y);
 }
 
-// 悬浮工具栏延迟隐藏定时器（QML菜单关闭时启动，工具栏按钮点击时取消）
-var hideToolbarTimer = null;
 var toolbarButtonClicked = false;
 
-// 监听悬浮工具栏按钮的mousedown事件
-// e.preventDefault() 阻止浏览器默认行为（移动选区/焦点到按钮位置）
-// 同时取消延迟隐藏定时器，防止工具栏被误隐藏
-$(document).on('mousedown', '.note-air-popover .note-btn', function(e) {
-    e.preventDefault();
+// 点击工具栏时置位，供 changeContent / hideRightMenu 避免误隐藏
+$(document).on('mousedown', '.note-air-popover, .note-air-popover *', function (e) {
     toolbarButtonClicked = true;
-    if (hideToolbarTimer) {
-        clearTimeout(hideToolbarTimer);
-        hideToolbarTimer = null;
+    if ($(e.target).closest('.note-btn').length) {
+        e.preventDefault();
     }
 });
 
-$(document).on('click', '.note-air-popover .note-btn', function(e) {
-    setTimeout(function() { toolbarButtonClicked = false; }, 100);
+$(document).on('click', '.note-air-popover, .note-air-popover *', function (e) {
+    setTimeout(function () { toolbarButtonClicked = false; }, 100);
 });
 
-// 右键隐藏悬浮工具栏（延迟执行，给工具栏按钮点击事件取消的机会）
 function hideRightMenu() {
     if (toolbarButtonClicked) {
         toolbarButtonClicked = false;
         return;
     }
-    if (hideToolbarTimer) clearTimeout(hideToolbarTimer);
-    hideToolbarTimer = setTimeout(function() {
-        $('#summernote').summernote('airPopover.hide');
-        hideToolbarTimer = null;
-    }, 300);
+    $('#summernote').summernote('airPopover.hide');
+    restoreAirPopoverTooltipPlacement();
 }
 
 // 重置滚动条

--- a/src/web/js/summernote_v9_2.js
+++ b/src/web/js/summernote_v9_2.js
@@ -7190,6 +7190,9 @@
             }
         };
         AirPopover.prototype.update = function () {
+            if (typeof contextMenuToolbarActive !== 'undefined' && contextMenuToolbarActive) {
+                return;
+            }
             var styleInfo = this.context.invoke('editor.currentStyle');
             let selStr = window.getSelection().toString();
             this.isShowOlUl(styleInfo)
@@ -7259,24 +7262,32 @@
          */
         AirPopover.prototype.rightUpdate = function (x, y) {
             var styleInfo = this.context.invoke('editor.currentStyle');
-            var rect = lists.last(styleInfo.range.getClientRects());
-            this.isShowOlUl(styleInfo)
-            if (rect) {
-                this.$popover.find('.note-color').removeClass('open');
-                this.$popover.find('.note-fontsize-class').removeClass('open')
-                this.$popover.find('.note-font-family-class').removeClass('open')
-                let winWidth = $(document).width()
-                if (winWidth - x < airPopoverWidth) {
-                    x = winWidth - airPopoverWidth
+            var hasRange = !!(styleInfo && styleInfo.range);
+            try {
+                if (hasRange) {
+                    this.isShowOlUl(styleInfo);
                 }
-                this.$popover.css({
-                    display: 'block',
-                    left: x + $(document).scrollLeft(),
-                    top: y + $(document).scrollTop()
-                });
+            } catch (e) {
+                // isShowOlUl 依赖选区，右键菜单场景下可能无有效 range
+            }
+            this.$popover.find('.note-color').removeClass('open');
+            this.$popover.find('.note-fontsize-class').removeClass('open')
+            this.$popover.find('.note-font-family-class').removeClass('open')
+            let winWidth = $(document).width()
+            if (winWidth - x < airPopoverWidth) {
+                x = winWidth - airPopoverWidth
+            }
+            var finalLeft = x + $(document).scrollLeft();
+            var finalTop = y + $(document).scrollTop();
+            this.$popover.css({
+                display: 'block',
+                left: finalLeft,
+                top: finalTop
+            });
+            this.$popover.show();
+            if (hasRange) {
                 this.context.invoke('buttons.updateCurrentStyle', this.$popover);
             }
-
         };
 
         AirPopover.prototype.hide = function () {


### PR DESCRIPTION
Resolve overlap between the text context menu and air popover on right-click.

修复文本右键时上下文菜单与浮动工具栏重叠遮挡的问题。

Derive menu height from DTK item layout when menu.height is not ready.

在 menu.height 不可靠时，从 DTK 可见菜单项布局计算真实高度并定位工具栏。

Keep the toolbar available after the menu closes instead of hiding it.

菜单关闭后保留工具栏并解除定位锁定，右键后仍可继续格式操作。

Log: 修复文本右键菜单与浮动工具栏重叠、间距异常及菜单关闭后工具栏不可用
PMS: BUG-346989

Influence: 选中文本右键时，浮动工具栏与上下文菜单不再互相遮挡，间距显示正常；关闭菜单后仍可直接使用工具栏进行加粗、改色等操作，其他编辑逻辑不受影响。