### PR TITLE
fix(editor): align floating toolbar dropdown with DTK menu style

### DIFF
--- a/src/web/css/bootstrapCssReset.css
+++ b/src/web/css/bootstrapCssReset.css
@@ -1,3 +1,11 @@
+/* 对齐 DTK Menu（FlowStyle: radius=12, item.radius=6, padding=6, topPadding=8, item.height=30） */
+:root {
+    --vn-menu-radius: 12px;
+    --vn-menu-item-radius: 6px;
+    --vn-menu-padding: 8px 6px;
+    --vn-menu-item-height: 30px;
+}
+
 /* 浮动工具栏 */
 .popover {
     background-color: transparent;
@@ -26,7 +34,7 @@
     height: auto;
     background: rgba(245, 245, 245, 1);
     border: 1px solid rgba(0, 0, 0, 0.04);
-    border-radius: 12px;
+    border-radius: var(--vn-menu-radius);
     box-shadow: 0px 6px 20px 0px rgba(0, 0, 0, 0.1);
 }
 
@@ -113,7 +121,7 @@ p {
     background: rgba(238, 238, 238, 1);
     width: 153px;
     border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 12px;
+    border-radius: var(--vn-menu-radius);
     box-shadow: 0px 6px 16px 0px rgba(0, 0, 0, 0.20);
     top: 115%;
     left: -12px;
@@ -289,7 +297,9 @@ ul {
 
 .dropdown-fontsize {
     overflow: hidden;
+    overflow-y: auto;
     width: 96px;
+    padding: var(--vn-menu-padding);
 }
 
 .dropdown-fontname {
@@ -297,14 +307,26 @@ ul {
     overflow-y: auto;
     max-height: 300px;
     min-width: 220px !important;
+    padding: var(--vn-menu-padding);
+}
+
+.dropdown-fontsize>li,
+.dropdown-fontname>li {
+    width: 100%;
 }
 
 .dropdown-fontsize>li>a,
 .dropdown-fontname>li>a {
+    display: block;
+    box-sizing: border-box;
     width: 100%;
-    height: 34px;
-    line-height: 30px;
-    max-width: 240px !important;
+    height: var(--vn-menu-item-height);
+    line-height: var(--vn-menu-item-height);
+    max-width: none !important;
+    margin: 0;
+    padding: 0 10px;
+    border-radius: var(--vn-menu-item-radius);
+    color: var(--vn-menu-item-fg, inherit);
 }
 
 .dropdown-fontsize>li:nth-last-child(1) a {
@@ -318,6 +340,11 @@ ul {
 .note-popover .popover-content .dropdown-menu.note-check li a i {
     padding-right: 5px;
     color: inherit;
+    visibility: hidden;
+}
+
+.note-popover .popover-content .dropdown-menu.note-check li a.checked i {
+    visibility: visible;
 }
 
 .note-air-popover {
@@ -325,9 +352,16 @@ ul {
     margin: 0 auto !important;
 }
 
+/* hover / 选中：主题色底 + 白字，对齐 DTK 菜单样式 */
 .dropdown-fontsize>li>a:hover,
-.dropdown-fontname>li>a:hover {
-    background-color: rgba(0, 0, 0, 0.05);
+.dropdown-fontname>li>a:hover,
+.dropdown-fontsize>li>a.checked,
+.dropdown-fontname>li>a.checked,
+.note-popover .popover-content .dropdown-fontsize>li>a:hover,
+.note-popover .popover-content .dropdown-fontname>li>a:hover,
+.note-popover .popover-content .dropdown-fontsize>li>a.checked,
+.note-popover .popover-content .dropdown-fontname>li>a.checked {
+    background-color: var(--vn-menu-hover-bg, rgba(0, 0, 0, 0.08));
     color: #fff !important;
 }
 
@@ -410,19 +444,19 @@ ul {
 .btn-sm,
 .btn-group-sm>.btn {
     padding: 0px !important;
-    border-radius: 6px;
+    border-radius: var(--vn-menu-item-radius);
 }
 
 /* 新UI设计，按钮和下拉菜单均有圆角，覆盖原始样式 */
 .btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle) {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-top-right-radius: var(--vn-menu-item-radius);
+    border-bottom-right-radius: var(--vn-menu-item-radius);
 }
 
 .btn-group>.btn:last-child:not(:first-child),
 .btn-group>.dropdown-toggle:not(:first-child) {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-top-left-radius: var(--vn-menu-item-radius);
+    border-bottom-left-radius: var(--vn-menu-item-radius);
 }
 
 /***** 字体名称/大小按钮 End *****/

--- a/src/web/css/reset.css
+++ b/src/web/css/reset.css
@@ -20,10 +20,17 @@ body::-webkit-scrollbar-thumb,
 .dropdown-fontname::-webkit-scrollbar-thumb {
     border-radius: 5px;
     border-style: dashed;
-    background-color: rgba(255, 255, 255, 0.0);
     border-color: transparent;
     border-width: 2px;
     background-clip: padding-box;
+}
+
+body::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.0);
+}
+
+.dropdown-fontname::-webkit-scrollbar-thumb {
+    background-color: var(--vn-fontlist-scrollbar-thumb, rgba(0, 0, 0, 0.25));
 }
 
 body::-webkit-scrollbar-thumb:hover,

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -30,7 +30,6 @@
 
     <style id="style"></style>
     <style id="scrollStyle"></style>
-    <style id="scrollStyleFont"></style>
 </head>
 
 <body>

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -147,7 +147,6 @@ var global_theme = 1    // theme type 1:light 2:dark
 var global_themeColor = 'transparent'  //主题色
 var global_isRecording = false  // 录音状态标志
 var scrollHide = null  //滚动条隐藏定时器
-var scrollHideFont = null  //字体滚动条定时
 var isUlOrOl = false
 const airPopoverHeight = 44  //悬浮工具栏高度
 const airPopoverWidth = 385  //悬浮工具栏宽度
@@ -1601,32 +1600,15 @@ function changeColor(flag, activeColor, disableColor, backgroundColor) {
         setVoiceButColor(global_activeColor, global_disableColor)
     }
 
-    $('.dropdown-fontsize>li>a').hover(function (e) {
-        $(this).css('background-color', activeColor);
-    }, function () {
-        $('.dropdown-fontsize>li>a').css('background-color', 'transparent');
-        if (flag == 1) {
-            $('.dropdown-fontsize>li>a').css('color', "black");
-        } else {
-            $('.dropdown-fontsize>li>a').css('color', "rgba(197,207,224,1)");
-        }
-    })
-    $('.dropdown-fontname>li>a').hover(function (e) {
-        $(this).css('background-color', activeColor);
-    }, function () {
-        $('.dropdown-fontname>li>a').css('background-color', 'transparent');
-        if (flag == 1) {
-            $('.dropdown-fontname>li>a').css('color', "black");
-        } else {
-            $('.dropdown-fontname>li>a').css('color', "rgba(197,207,224,1)");
-        }
-    })
+    var menuItemFg = flag == 1 ? 'black' : 'rgba(197,207,224,1)';
+    var scrollbarThumb = flag == 1 ? 'rgba(0, 0, 0, 0.30)' : 'rgba(255, 255, 255, 0.20)';
+    document.documentElement.style.setProperty('--vn-menu-hover-bg', activeColor);
+    document.documentElement.style.setProperty('--vn-menu-item-fg', menuItemFg);
+    document.documentElement.style.setProperty('--vn-fontlist-scrollbar-thumb', scrollbarThumb);
 
     if (flag == 1) {
         $('body').removeClass('dark');
         $('#dark').remove()
-        $('.dropdown-fontsize>li>a').css('color', "black");
-        $('.dropdown-fontname>li>a').css('color', "black");
     } else if (flag == 2 && !$('#dark').length) {
         $('body').addClass('dark');
         $("head").append("<link>");
@@ -2165,7 +2147,6 @@ $(document).scroll(function () {
     }, 1500);
 });
 
-// 字体滚动条
 function listenFontnameList() {
     $('.dropdown-fontname ').scroll(function () {
         // 阻止内部滚动条到底后自动触发外部滚动
@@ -2175,24 +2156,6 @@ function listenFontnameList() {
             // 定位到距离底部2px的位置
             scroll.scrollTop = (scroll.scrollHeight - scroll.clientHeight - 2)
         }
-
-        if (scrollHideFont) {
-            clearTimeout(scrollHideFont)
-            $('#scrollStyleFont').html(`
-        .dropdown-fontname::-webkit-scrollbar-thumb {
-        background-color:${global_theme == 1 ? "rgba(0, 0, 0, 0.30)" : "rgba(255, 255, 255, 0.20)"} ;
-        }
-        /* 适配申威，触发重绘 */
-        html {
-            background-color: ${global_themeColor}fe;
-        }
-        `
-            )
-        }
-
-        scrollHideFont = setTimeout(() => {
-            $('#scrollStyleFont').html('')
-        }, 1500);
     });
 }
 


### PR DESCRIPTION
Match font/size dropdown radius, padding, hover and scrollbar with DTK Menu. Replace jQuery hover handlers with CSS variables for theme-aware highlight.

字体/字号下拉样式对齐 DTK 右键菜单圆角、内边距与 hover 效果；滚动条默认可见。

Log: 对齐浮动工具栏字体下拉与 DTK 菜单样式
PMS: BUG-331539
Influence: 富文本字体/字号下拉的 hover、选中态、滚动条与右键菜单视觉一致。

## Summary by Sourcery

Align the floating editor font/size dropdown styling and behavior with DTK menu visuals, including menu radii, padding, hover/selected states, and scrollbar appearance.

Bug Fixes:
- Ensure the font family dropdown scrollbar thumb is visible by default and consistently styled according to the current theme when the dropdown is opened and scrolled.

Enhancements:
- Introduce CSS custom properties to drive menu radius, item radius, padding, item height, hover background, and foreground colors for theme-aware dropdown styling.
- Update font/size dropdown items and buttons to use DTK-aligned layout (full-width items, consistent item height, padding, and rounded corners) and show check icons only for selected entries.
- Replace jQuery-based hover handling on font dropdown items with CSS-driven hover/selected styles using theme-dependent variables.
- Refine dark theme styles for font dropdown hover/selected states to ensure consistent white text on themed backgrounds.