### PR TITLE
fix(editor): add synthetic bold via text-shadow for bitmap fonts

### DIFF
--- a/src/web/index.css
+++ b/src/web/index.css
@@ -191,6 +191,9 @@ strike[style="text-decoration-line: underline;"] {
     border-bottom: 1px solid rgba(65, 77, 104, 1);
 }
 
+/* 位图字体（如文泉驿点阵正黑、Unifont）无粗体变体，font-weight:bold 不产生视觉变化。
+   使用零模糊 text-shadow 偏移像素合成加粗效果，不影响矢量字体的正常粗体渲染。
+   注意：此规则仅限编辑器内容区域，零模糊不产生额外合成层，无性能影响。 */
 .note-editable b, .note-editable strong {
     text-shadow: 0.5px 0 0 currentColor;
 }

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -190,3 +190,7 @@ strike[style="text-decoration-line: underline;"] {
     text-decoration-color: transparent !important;
     border-bottom: 1px solid rgba(65, 77, 104, 1);
 }
+
+.note-editable b, .note-editable strong {
+    text-shadow: 0.5px 0 0 currentColor;
+}


### PR DESCRIPTION
Fonts without a bold variant (e.g. WenQuanYi bitmap, Unifont) could not be visually bolded because Chromium cannot synthesize bold from bitmap glyphs. Apply a subtle text-shadow on <b>/<strong> elements in the editor content area so all fonts display a visible bold effect.

PMS: bug-277319

