### PR TITLE
fix(MoveDialog): exclude current notebook from move dialog list

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -807,9 +807,17 @@ void VNoteMainManager::moveNotes(const QVariantList &index, const int &folderInd
     VNoteItemOper noteOper;
     VNOTE_ITEMS_MAP *srcNotes = noteOper.getFolderNotes(item->folderId);
     VNOTE_ITEMS_MAP *destNotes = noteOper.getFolderNotes(folder->id);
+    if (!srcNotes || !destNotes) {
+        qWarning() << "Invalid move operation, source or destination notes map is null";
+        return;
+    }
     int srcIndex = getFloderIndexById(item->folderId);
     foreach (auto i, index) {
         VNoteItem *note = getNoteById(i.toInt());
+        if (!note) {
+            qWarning() << "Skipping invalid note during move, note ID:" << i.toInt();
+            continue;
+        }
         m_noteItems.removeOne(note);
         if (note->isTop)
             m_currentHasTop--;

--- a/src/gui/dialog/MoveDialog.qml
+++ b/src/gui/dialog/MoveDialog.qml
@@ -59,7 +59,6 @@ DialogWindow {
                 radius: 6
                 width: 336
 
-                // text: model.name
                 RowLayout {
                     anchors.fill: parent
                     anchors.leftMargin: 8
@@ -83,7 +82,6 @@ DialogWindow {
                         }
 
                         Rectangle {
-                            //矩形
                             id: _mask
 
                             antialiasing: true
@@ -91,7 +89,7 @@ DialogWindow {
                             height: 16
                             radius: 8
                             smooth: true
-                            visible: false  //不可见
+                            visible: false
                             width: 16
                         }
 
@@ -100,7 +98,7 @@ DialogWindow {
 
                             anchors.fill: _image
                             antialiasing: true
-                            maskSource: _mask    //用作遮罩的项目
+                            maskSource: _mask
                             source: _image
                             visible: true
                         }

--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -23,6 +23,7 @@ Item {
     property int listHeight: 700
     property int listWidth: 200
     property alias model: folderListView.model
+    property alias currentFolderIndex: folderListView.currentIndex
     property Item scrollBarParent: null
     property int scrollBarRightOffset: 0
     property bool webVisible: true

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -25,6 +25,8 @@ Item {
     property int itemSpacing: 6
     property alias model: itemModel
     property alias moveToFolderDialog: dialogWindow
+    property var sourceFolderModel
+    property int currentFolderIndex: -1
     property var saveFilters: ["TXT(*.txt);;HTML(*.html)", "TXT(*.txt)", "HTML(*.html)", "MP3(*.mp3)"]
     property alias searchLoader: noSearchResultsLoader
     property int selectSize: 0
@@ -56,6 +58,15 @@ Item {
             }
         }
         return indexes;
+    }
+
+    function clearRenameState() {
+        forceActiveFocus();
+        for (var i = 0; i < itemModel.count; i++) {
+            var item = itemListView.itemAtIndex(i);
+            if (item)
+                item.isRename = false;
+        }
     }
 
     function selectNoteItem(index) {
@@ -94,17 +105,23 @@ Item {
             if (!ret) {
                 return;
             }
+            clearRenameState();
             var delList = itemListView.sortAndDeduplicate(validSelectedNoteIndexes());
             var delIdList = [];
             var deleIndex = Number.MAX_SAFE_INTEGER;
             for (var i = 0; i < delList.length; i++) {
-                delIdList.push(itemModel.get(delList[i]).noteId);
+                var deleteItem = itemModel.get(delList[i]);
+                if (!deleteItem)
+                    continue;
+                delIdList.push(deleteItem.noteId);
                 if (delList[i] < deleIndex)
                     deleIndex = delList[i];
             }
+            if (delIdList.length === 0)
+                return;
             if (!VNoteMainManager.deleteNote(delIdList))
                 return;
-            for (var j = 0; j < delList.length; j++) {
+            for (var j = delList.length - 1; j >= 0; j--) {
                 itemModel.remove(delList[j]);
             }
             deleteNotes(delList.length);
@@ -135,6 +152,24 @@ Item {
         });
     }
 
+    function refreshMoveFolderModel() {
+        moveFolderModel.clear();
+        if (!sourceFolderModel)
+            return;
+
+        for (var i = 0; i < sourceFolderModel.count; i++) {
+            if (i === currentFolderIndex)
+                continue;
+
+            var folder = sourceFolderModel.get(i);
+            moveFolderModel.append({
+                name: folder.name,
+                icon: folder.icon,
+                folderIndex: i
+            });
+        }
+    }
+
     function onMoveNote() {
         if (webVisible || isVoiceToText) {
             console.log("No notes available, cannot move");
@@ -144,6 +179,13 @@ Item {
         var validIndexes = validSelectedNoteIndexes();
         if (validIndexes.length === 0)
             return;
+
+        refreshMoveFolderModel();
+        if (moveFolderModel.count === 0) {
+            console.log("No other notebook available to move to");
+            return;
+        }
+        clearRenameState();
         
         var desText = "";
         if (validIndexes.length > 1) {
@@ -328,8 +370,15 @@ Item {
 
     }
 
+    ListModel {
+        id: moveFolderModel
+
+    }
+
     MoveDialog {
         id: dialogWindow
+
+        folderModel: moveFolderModel
 
         onMoveToFolder: {
             if (isVoiceToText) {
@@ -339,9 +388,14 @@ Item {
             var indexList = [];
             var validIndexes = validSelectedNoteIndexes();
             for (var i = 0; i < validIndexes.length; i++) {
-                indexList.push(itemModel.get(validIndexes[i]).noteId);
+                var moveItem = itemModel.get(validIndexes[i]);
+                if (moveItem)
+                    indexList.push(moveItem.noteId);
             }
-            VNoteMainManager.moveNotes(indexList, index);
+            if (indexList.length === 0)
+                return;
+            var folderIndex = moveFolderModel.get(index).folderIndex;
+            VNoteMainManager.moveNotes(indexList, folderIndex);
         }
     }
 
@@ -1105,7 +1159,9 @@ Item {
                 }
                 onDoubleClicked: {
                     // 录音时允许双击重命名
-                    itemListView.itemAtIndex(index).isRename = true;
+                    var renameItem = itemListView.itemAtIndex(index);
+                    if (renameItem)
+                        renameItem.isRename = true;
                 }
                 onEntered: {
                     if (noteNameLabel.implicitWidth > noteNameLabel.width)

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -812,7 +812,8 @@ ApplicationWindow {
                     Layout.fillWidth: true
                     enabled: !rootWindow.isVoiceToText
                     opacity: enabled ? 1.0 : 0.4
-                    moveToFolderDialog.folderModel: folderListView.model
+                    sourceFolderModel: folderListView.model
+                    currentFolderIndex: folderListView.currentFolderIndex
                     webVisible: initRect.visible
                     isRecordingAudio: rootWindow.isRecordingAudio
                     isVoiceToText: rootWindow.isVoiceToText


### PR DESCRIPTION
    Move filteredModel and buildFilteredModel to ItemListView.qml to
    avoid Qt6 DialogWindow "Cannot assign object to list property
    content" error. MoveDialog receives filteredModel and
    indexToOriginalIndex via property bindings from its parent.

    移动笔记时，不再显示当前笔记所在的记事本。

    Log: 移动笔记时隐藏当前笔记所在记事本
    PMS: BUG-367593
    Influence: 移动笔记弹窗的记事本列表不再包含当前笔记所在记事本。