### PR TITLE
fix: resolve image path before right-click save as

### DIFF
--- a/src/handler/web_engine_handler.cpp
+++ b/src/handler/web_engine_handler.cpp
@@ -904,7 +904,14 @@ bool WebEngineHandler::saveMP3()
 void WebEngineHandler::savePictureAs()
 {
     qInfo() << "Saving picture as";
-    QString originalPath = menuJson.toString();  // 获取原图片路径
+    // web端图片src为相对/web路径，需先解析为磁盘真实路径，否则复制失败
+    QString originalPath = normalizePicturePath(menuJson.toString());
+    if (originalPath.isEmpty()) {
+        // 路径无法解析，提示保存失败，避免执行注定失败的复制
+        qWarning() << "Failed to normalize picture path:" << menuJson.toString();
+        Q_EMIT requestMessageDialog(VNoteMessageDialogHandler::SaveFailed);
+        return;
+    }
     saveAsFile(originalPath, QStandardPaths::writableLocation(QStandardPaths::PicturesLocation), "image");
     qInfo() << "Picture saving finished";
 }


### PR DESCRIPTION
log: right-click "save as" used the web-side relative path directly so the copy failed; resolve it to the real disk path via normalizePicturePath before saving.

pms: bug-367489

## Summary by Sourcery

Bug Fixes:
- Fix right-click picture "Save As" failing when using web-side relative image paths by resolving them to real disk paths and handling normalization errors with a user-facing failure message.