### PR TITLE
fix: prevent double onSaveAudio dispatch when ctrl+d pressed in editor

### DIFF
--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -201,18 +201,22 @@ ApplicationWindow {
             itemListView.onSaveNote();
         }
         onSaveVoice: {
+            // JS keydown 已处理；避免 async Loader item 尚未就绪时被二次 open()
+            if (webEngineView.activeFocus) {
+                return;
+            }
             // 检查是否有笔记可以保存
             if (initRect.visible) {
                 console.warn("当前没有打开任何笔记本，不执行保存操作");
                 return;
             }
-            
+
             // 检查笔记列表是否为空
             if (itemListView.model.count === 0) {
                 console.warn("当前笔记列表为空，不执行保存操作");
                 return;
             }
-            
+
             // 使用WebEngineView组件提供的方法检查当前笔记是否包含录音条目
             webEngineView.checkHasVoiceContent(function(hasVoice) {
                 if (hasVoice) {


### PR DESCRIPTION
Log: ctrl+d fired both JS keydown and QML Shortcut handlers concurrently; the second onSaveAudio() call hit folderDialogLoader.item.open() before async Loader finished, causing dde-file-manager to open empty. Guard onSaveVoice with webEngineView.activeFocus check to avoid double dispatch.

pms: bug-367137

## Summary by Sourcery

Bug Fixes:
- Avoid triggering onSaveAudio twice when the keyboard shortcut and QML shortcut fire concurrently, preventing the file manager from opening an empty save dialog.