### PR TITLE
fix(vnote): bind note selection state for reliable multi-delete

### DIFF
--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -73,16 +73,8 @@ Item {
         if (index < 0 || index >= itemModel.count)
             return;
 
-        // 清除之前的选中状态
-        for (var m = 0; m < selectedNoteItem.length; m++) {
-            var selectItem = itemListView.itemAtIndex(selectedNoteItem[m]);
-            if (selectItem) selectItem.isSelected = false;
-        }
-        // 设置新的选中状态
         selectedNoteItem = [index];
         selectSize = 1;
-        var newDelegate = itemListView.itemAtIndex(index);
-        if (newDelegate) newDelegate.isSelected = true;
         itemListView.currentIndex = index;
         itemListView.lastCurrentIndex = index;
     }
@@ -121,26 +113,27 @@ Item {
                 return;
             if (!VNoteMainManager.deleteNote(delIdList))
                 return;
-            for (var j = delList.length - 1; j >= 0; j--) {
-                itemModel.remove(delList[j]);
+            var delIdMap = {};
+            for (var k = 0; k < delIdList.length; ++k)
+                delIdMap[delIdList[k]] = true;
+            for (var j = itemModel.count - 1; j >= 0; --j) {
+                var note = itemModel.get(j);
+                if (note && delIdMap[note.noteId])
+                    itemModel.remove(j);
             }
-            deleteNotes(delList.length);
+            deleteNotes(delIdList.length);
             if (itemModel.count === 0) {
                 selectedNoteItem = [];
                 selectSize = 0;
                 emptyItemList();
             } else if (itemModel.count <= deleIndex) {
                 var newIndex = itemModel.count - 1;
-                var newItem = itemListView.itemAtIndex(newIndex);
-                if (newItem) newItem.isSelected = true;
                 selectedNoteItem = [newIndex];
                 selectSize = 1;
                 itemListView.currentIndex = newIndex;
                 itemListView.lastCurrentIndex = newIndex;
                 noteItemChanged(itemModel.get(newIndex).noteId);
             } else {
-                var nextItem = itemListView.itemAtIndex(deleIndex);
-                if (nextItem) nextItem.isSelected = true;
                 selectedNoteItem = [deleIndex];
                 selectSize = 1;
                 itemListView.currentIndex = deleIndex;
@@ -290,47 +283,27 @@ Item {
         switch (event.key) {
          case Qt.Key_Up:
              if (itemListView.count > 0) {
-                // 取消之前选中项的选中状态
-                for (var i = 0; i < selectedNoteItem.length; i++) {
-                    var prevItem = itemListView.itemAtIndex(selectedNoteItem[i]);
-                    if (prevItem) prevItem.isSelected = false;
-                }
-                 // 循环切换：如果在第一项，跳到最后一项；否则向上移动
                  if (itemListView.currentIndex <= 0) {
                      itemListView.currentIndex = itemListView.count - 1;
                  } else {
                      itemListView.currentIndex--;
                  }
-                 var newItem = itemListView.itemAtIndex(itemListView.currentIndex);
-                 if (newItem) {
-                     newItem.isSelected = true;
-                     selectedNoteItem = [itemListView.currentIndex];
-                     selectSize = 1;
-                     noteItemChanged(itemModel.get(itemListView.currentIndex).noteId);
-                 }
+                 selectedNoteItem = [itemListView.currentIndex];
+                 selectSize = 1;
+                 noteItemChanged(itemModel.get(itemListView.currentIndex).noteId);
              }
              event.accepted = true;
              break;
          case Qt.Key_Down:
              if (itemListView.count > 0) {
-                // 取消之前选中项的选中状态
-                for (var j = 0; j < selectedNoteItem.length; j++) {
-                    var prevItem = itemListView.itemAtIndex(selectedNoteItem[j]);
-                    if (prevItem) prevItem.isSelected = false;
-                }
-                 // 循环切换：如果在最后一项，跳到第一项；否则向下移动
                  if (itemListView.currentIndex >= itemListView.count - 1) {
                      itemListView.currentIndex = 0;
                  } else {
                      itemListView.currentIndex++;
                  }
-                 var newItem = itemListView.itemAtIndex(itemListView.currentIndex);
-                 if (newItem) {
-                     newItem.isSelected = true;
-                     selectedNoteItem = [itemListView.currentIndex];
-                     selectSize = 1;
-                     noteItemChanged(itemModel.get(itemListView.currentIndex).noteId);
-                 }
+                 selectedNoteItem = [itemListView.currentIndex];
+                 selectSize = 1;
+                 noteItemChanged(itemModel.get(itemListView.currentIndex).noteId);
              }
              event.accepted = true;
              break;
@@ -821,7 +794,7 @@ Item {
 
             property bool hovered: false
             property bool isRename: false
-            property bool isSelected: false
+            property bool isSelected: selectedNoteItem.indexOf(index) !== -1
             property var startMove: [-1, -1]
 
             color: isSelected ? (rootItem.activeFocus ? palette.highlight : (DTK.themeType === ApplicationHelper.LightType ? "#33000000" : "#33FFFFFF")) : (DTK.themeType === ApplicationHelper.LightType ? "white" : "#0CFFFFFF")
@@ -844,9 +817,6 @@ Item {
             radius: 6
             width: itemListView.width
 
-            Component.onCompleted: {
-                isSelected = (selectedNoteItem.indexOf(index) !== -1);
-            }
             Keys.onPressed: function(event) {
                 if (isRename) {
                     if (event.key === Qt.Key_Escape) {
@@ -1063,19 +1033,10 @@ Item {
                         if (selectedIndexes.length > 1) {
                             ActionManager.visibleMulChoicesActions(false);
                         } else {
-                            if (itemListView.itemAtIndex(itemListView.lastCurrentIndex)) {
-                                var lastItem = itemListView.itemAtIndex(itemListView.lastCurrentIndex);
-                                lastItem.isRename = false;
-                                lastItem.isSelected = false;
-                            }
-                            if (selectedIndexes.length === 1) {
-                                var item = itemListView.itemAtIndex(selectedIndexes[0]);
-                                if (item) item.isSelected = false;
-                            }
+                            if (itemListView.itemAtIndex(itemListView.lastCurrentIndex))
+                                itemListView.itemAtIndex(itemListView.lastCurrentIndex).isRename = false;
                             selectedNoteItem = [index];
                             selectSize = 1;
-                            var currentItem = itemListView.itemAtIndex(index);
-                            if (currentItem) currentItem.isSelected = true;
                             itemListView.currentIndex = index;
                             itemListView.lastCurrentIndex = index;
                             itemListView.contextIndex = index;
@@ -1105,54 +1066,38 @@ Item {
                         }
                         switch (mouse.modifiers) {
                         case Qt.ControlModifier:
-                            if (selectedNoteItem.indexOf(index) != -1) {
-                                var existed = itemListView.itemAtIndex(index);
-                                if (existed) existed.isSelected = false;
-                                selectedNoteItem.splice(selectedNoteItem.indexOf(index), 1);
+                            var nextSelection = selectedNoteItem.slice();
+                            var pos = nextSelection.indexOf(index);
+                            if (pos != -1) {
+                                nextSelection.splice(pos, 1);
                                 selectSize--;
                             } else {
-                                var exist2 = itemListView.itemAtIndex(index);
-                                if (exist2) exist2.isSelected = true;
-                                selectedNoteItem.push(index);
+                                nextSelection.push(index);
                                 selectSize++;
                             }
+                            selectedNoteItem = nextSelection;
                             break;
                         case Qt.ShiftModifier:
-                            for (var n = 0; n < selectedNoteItem.length; n++) {
-                                var oldSelectItem = itemListView.itemAtIndex(selectedNoteItem[n]);
-                                if (oldSelectItem) oldSelectItem.isSelected = false;
-                            }
-                            selectedNoteItem = [];
                             var anchorIndex = Math.max(0, Math.min(itemListView.lastCurrentIndex, itemModel.count - 1));
                             var targetIndex = Math.max(0, Math.min(index, itemModel.count - 1));
                             var startIndex = Math.min(targetIndex, anchorIndex);
                             var endIndex = Math.max(targetIndex, anchorIndex);
-                            for (var i = startIndex; i <= endIndex; i++) {
-                                var d = itemListView.itemAtIndex(i);
-                                if (d) d.isSelected = true;
-                                selectedNoteItem.push(i);
-                            }
+                            var rangeSelection = [];
+                            for (var i = startIndex; i <= endIndex; i++)
+                                rangeSelection.push(i);
+                            selectedNoteItem = rangeSelection;
                             itemListView.lastCurrentIndex = anchorIndex;
-                            selectSize = selectedNoteItem.length;
+                            selectSize = rangeSelection.length;
                             break;
                         default:
-                            if (itemListView.itemAtIndex(itemListView.lastCurrentIndex)) {
-                                var lastSelectItem = itemListView.itemAtIndex(itemListView.lastCurrentIndex);
-                                lastSelectItem.isRename = false;
-                                lastSelectItem.isSelected = false;
-                            }
-                            for (var m = 0; m < selectedNoteItem.length; m++) {
-                                var selectItem = itemListView.itemAtIndex(selectedNoteItem[m]);
-                                if (selectItem) selectItem.isSelected = false;
-                            }
+                            if (itemListView.itemAtIndex(itemListView.lastCurrentIndex))
+                                itemListView.itemAtIndex(itemListView.lastCurrentIndex).isRename = false;
                             selectedNoteItem = [index];
                             selectSize = 1;
-                            var newDelegate = itemListView.itemAtIndex(index);
-                            if (newDelegate) newDelegate.isSelected = true;
                             itemListView.currentIndex = index;
                             itemListView.lastCurrentIndex = index;
                             noteItemChanged(Number(itemModel.get(index).noteId));
-                            
+
                             break;
                         }
                     }

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -314,11 +314,6 @@ ApplicationWindow {
         }
 
         function handleaddNote(noteData) {
-            for (var i = 0; i < itemListView.selectedNoteItem.length; i++) {
-                var item = itemListView.view.itemAtIndex(itemListView.selectedNoteItem[i]);
-                if (item)
-                    item.isSelected = false;
-            }
             var topSize = 0;
             for (var j = 0; j < itemListView.model.count; j++) {
                 var note = itemListView.model.get(j);
@@ -411,9 +406,7 @@ ApplicationWindow {
                 minIndex = count - 1;
                 modelItem = itemListView.model.get(minIndex);
             }
-            itemListView.selectedNoteItem.push(minIndex);
-            var delegate = itemListView.view.itemAtIndex(minIndex);
-            if (delegate) delegate.isSelected = true;
+            itemListView.selectedNoteItem = [minIndex];
             itemListView.selectSize = 1;
             VNoteMainManager.vNoteChanged(modelItem.noteId);
         }


### PR DESCRIPTION
Bind delegate isSelected to selectedNoteItem and reassign selection arrays on Ctrl/Shift multi-select so QML bindings update reliably. Remove deleted notes from the model by noteId instead of index.

将列表项 isSelected 绑定到 selectedNoteItem，多选时复制数组整体赋值
以确保 QML 绑定更新；批量删除后按 noteId 从 model 移除笔记。

Log: 修复多选删除漏删及删除后拖拽样式异常
PMS: BUG-367705
Influence: 多选删除、单选切换和拖拽移动时，左侧选中状态与实际
操作一致，避免漏删笔记和拖拽显示多卡片堆叠样式。

## Summary by Sourcery

Improve note selection binding and deletion logic in the VNote item list to keep UI selection state consistent during single and multi-selection operations.

Bug Fixes:
- Ensure multi-note deletions remove all targeted notes by deleting from the model by noteId instead of relying on indices.
- Prevent stale selection and drag visual glitches by binding delegate selection state to the shared selectedNoteItem array.
- Fix keyboard and mouse navigation so single selection, multi-selection, and range selection keep the left-hand list selection in sync with the active note.
- Correct post-add-note selection so only the newly added or targeted note remains selected.