### PR TITLE
fix(vnote): unify toolbar button hover style with control center

### DIFF
--- a/src/deepin-voice-note.qrc
+++ b/src/deepin-voice-note.qrc
@@ -14,6 +14,7 @@
         <file>icon/no_content.dci</file>
         <file>main.qml</file>
         <file>gui/VNoteToolButton.qml</file>
+        <file>gui/VNoteButtonBackground.qml</file>
         <file>gui/VNoteButton.qml</file>
         <file>gui/dialog/MoveDialog.qml</file>
         <file>gui/drag/DragControl.qml</file>

--- a/src/gui/VNoteButtonBackground.qml
+++ b/src/gui/VNoteButtonBackground.qml
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
+
+Rectangle {
+    id: control
+
+    property Item button
+
+    readonly property color pressedFill: DTK.themeType === ApplicationHelper.LightType
+        ? Qt.rgba(0, 0, 0, 0.2) : Qt.rgba(1, 1, 1, 0.25)
+    readonly property color hoveredFill: DTK.themeType === ApplicationHelper.LightType
+        ? Qt.rgba(0, 0, 0, 0.1) : Qt.rgba(1, 1, 1, 0.1)
+
+    radius: DS.Style.control.radius
+    color: !button ? "transparent"
+         : button.pressed ? pressedFill
+         : button.hovered ? hoveredFill
+         : "transparent"
+    border.color: button ? button.palette.highlight : "transparent"
+    border.width: button && button.visualFocus ? DS.Style.control.focusBorderWidth : 0
+}

--- a/src/gui/VNoteToolButton.qml
+++ b/src/gui/VNoteToolButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,14 +7,37 @@ import org.deepin.dtk 1.0
 
 /**
  * VNoteToolButton - 修复 MIPS 平台键盘事件的 ToolButton
- * 
+ *
  * Qt5 的 ToolButton 不会自动响应 Enter/Return 键，需要显式处理
  * Qt6 已修复此问题，但此代码在两个版本上都能正常工作
+ *
+ * hover 风格与控制中心 ActionButton 一致：用 VNoteButtonBackground 替换默认
+ * ButtonPanel，并禁用 ToolButton 自带的 hover 缩放动画。
  */
 ToolButton {
     id: root
-    
+
     activeFocusOnTab: true
+    flat: true
+    hoverEnabled: enabled
+
+    background: VNoteButtonBackground {
+        button: root
+    }
+
+    function resetContentScale() {
+        if (contentItem)
+            contentItem.scale = 1;
+    }
+
+    Component.onCompleted: {
+        if (contentItem)
+            contentItem.smooth = false;
+        resetContentScale();
+    }
+
+    onHoveredChanged: resetContentScale()
+    onPressedChanged: resetContentScale()
 
     Keys.onReturnPressed: function(event) {
         if (enabled) {

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -480,12 +480,12 @@ ApplicationWindow {
             left: appImage.right
             leftMargin: 19
         }
-        height: 30
         icon.height: 16
         icon.name: "sidebar"
         icon.width: 16
-        visible: !(needHideSearch && search.visible) || leftBgArea.visible
+        height: 30
         width: 30
+        visible: !(needHideSearch && search.visible) || leftBgArea.visible
         z: 100
 
         onClicked: {
@@ -692,10 +692,12 @@ ApplicationWindow {
                     Layout.alignment: Text.AlignRight
                     Layout.rightMargin: 10
                     Layout.topMargin: 10
-                    height: 30
+                    icon.height: 16
                     icon.name: "search"
-                    visible: !search.visible
+                    icon.width: 16
+                    height: 30
                     width: 30
+                    visible: !search.visible
 
                     onClicked: {
                         search.visible = true;

--- a/src/gui/mainwindow/RecordingView.qml
+++ b/src/gui/mainwindow/RecordingView.qml
@@ -77,8 +77,8 @@ FocusScope {
             icon.height: iconSize
             icon.name: isRecording ? "recording_pause" : "recording_start"
             icon.width: iconSize
-            implicitHeight: btnSize
-            implicitWidth: btnSize
+            height: btnSize
+            width: btnSize
             KeyNavigation.tab: stopBtn
             KeyNavigation.backtab: stopBtn
 
@@ -111,8 +111,8 @@ FocusScope {
             icon.height: iconSize
             icon.name: "recording_stop"
             icon.width: iconSize
-            implicitHeight: btnSize
-            implicitWidth: btnSize
+            height: btnSize
+            width: btnSize
             KeyNavigation.tab: pauseBtn
             KeyNavigation.backtab: pauseBtn
 

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -291,17 +291,25 @@ Item {
         anchors.fill: parent
         spacing: 0
 
-        WindowTitleBar {
-            id: title
+        Item {
+            id: titleBarHost
 
             Layout.fillWidth: true
-            imageBtnEnable: webVisible
-            isInitialInterface: initialVisible
-            isRecordingAudio: rootItem.isRecordingAudio 
-            isVoiceToText: rootItem.isVoiceToText
+            Layout.minimumHeight: 50
+            Layout.maximumHeight: 50
 
-            onTitleOpenSetting: {
-                rootItem.openSetting();
+            WindowTitleBar {
+                id: title
+
+                anchors.fill: parent
+                imageBtnEnable: webVisible
+                isInitialInterface: initialVisible
+                isRecordingAudio: rootItem.isRecordingAudio
+                isVoiceToText: rootItem.isVoiceToText
+
+                onTitleOpenSetting: {
+                    rootItem.openSetting();
+                }
             }
         }
 

--- a/src/gui/mainwindow/WindowTitleBar.qml
+++ b/src/gui/mainwindow/WindowTitleBar.qml
@@ -28,8 +28,8 @@ TitleBar {
     signal titleOpenSetting
 
     enableInWindowBlendBlur: false
-    height: 50
-    width: 0
+
+    anchors.fill: parent
 
     background: Rectangle {
         color: DTK.themeType === ApplicationHelper.LightType ? "white" : "#242424"
@@ -58,7 +58,11 @@ TitleBar {
         anchors.verticalCenter: titleBar.verticalCenter
         enabled: !isPlaying && !isSearching && !isRecordingAudio && !isVoiceToText
         hoverEnabled: !isInitialInterface
+        icon.height: 16
         icon.name: "new_note"
+        icon.width: 16
+        height: 30
+        width: 30
 
         onClicked: {
             createNote();
@@ -97,7 +101,11 @@ TitleBar {
         anchors.verticalCenter: titleBar.verticalCenter
         enabled: recorderBtnEnable && imageBtnEnable && !isPlaying && !isSearching
         hoverEnabled: !isInitialInterface
+        icon.height: 16
         icon.name: "record"
+        icon.width: 16
+        height: 30
+        width: 30
 
         onClicked: {
             startRecording();
@@ -116,7 +124,11 @@ TitleBar {
         anchors.verticalCenter: titleBar.verticalCenter
         enabled: imageBtnEnable
         hoverEnabled: !isInitialInterface
+        icon.height: 16
         icon.name: "img"
+        icon.width: 16
+        height: 30
+        width: 30
         x: titleBar.__includedAreaX - recordBtn.width - 10
 
         onClicked: {


### PR DESCRIPTION
Replace ToolButton ButtonPanel with VNoteButtonBackground to match control center ActionButton hover/pressed visuals. Disable hover scale animation and stabilize title bar height with a fixed 50px container.

用 VNoteButtonBackground 替换默认 ButtonPanel，工具栏按钮 hover 风格与控制中心一致；禁用缩放动画，固定标题栏容器高度避免跳动。

Log: 统一顶部工具栏按钮 hover 样式并修复标题栏高度跳动
PMS: BUG-277167
Influence: 折叠、新建笔记、录音、插入图片、搜索等工具按钮 hover
样式与控制中心一致；