### PR TITLE
fix(vnote): add sidebar frosted glass and note card bottom shadow

### DIFF
--- a/src/deepin-voice-note.qrc
+++ b/src/deepin-voice-note.qrc
@@ -15,6 +15,7 @@
         <file>main.qml</file>
         <file>gui/VNoteToolButton.qml</file>
         <file>gui/VNoteButtonBackground.qml</file>
+        <file>gui/SidebarBlurBackground.qml</file>
         <file>gui/VNoteButton.qml</file>
         <file>gui/dialog/MoveDialog.qml</file>
         <file>gui/drag/DragControl.qml</file>

--- a/src/gui/SidebarBlurBackground.qml
+++ b/src/gui/SidebarBlurBackground.qml
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import org.deepin.dtk 1.0 as D
+import org.deepin.dtk.style 1.0 as DS
+
+// 与控制中心 DccWindow.qml 一致的窗口背后毛玻璃混合色
+D.StyledBehindWindowBlur {
+    id: control
+
+    property var windowControl
+
+    anchors.fill: parent
+    control: windowControl
+    blendColor: {
+        if (valid) {
+            return DS.Style.control.selectColor(windowControl ? windowControl.palette.window : undefined,
+                                                Qt.rgba(1, 1, 1, 0.8),
+                                                Qt.rgba(0.06, 0.06, 0.06, 0.8))
+        }
+        return DS.Style.control.selectColor(undefined,
+                                            DS.Style.behindWindowBlur.lightNoBlurColor,
+                                            DS.Style.behindWindowBlur.darkNoBlurColor)
+    }
+}

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -817,6 +817,21 @@ Item {
             radius: 6
             width: itemListView.width
 
+            // 与 DccItemBackground 一致：卡片底部 1px 淡阴影
+            BoxShadow {
+                anchors.fill: parent
+                cornerRadius: rootItemDelegate.radius
+                hollow: true
+                shadowBlur: 0
+                shadowColor: DTK.themeType === ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 0.05)
+                                                                           : Qt.rgba(0, 0, 0, 0.3)
+                shadowOffsetX: 0
+                shadowOffsetY: 1
+                spread: 0
+                visible: !rootItemDelegate.isSelected
+                z: -1
+            }
+
             Keys.onPressed: function(event) {
                 if (isRename) {
                     if (event.key === Qt.Key_Escape) {

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -15,7 +15,7 @@ import org.deepin.dtk 1.0
 ApplicationWindow {
     id: rootWindow
 
-    property int createFolderBtnHeight: 40
+    property int createFolderBtnHeight: 30
     property bool isRecording: webEngineView.isRecording
     property bool isRecordingAudio: false
     property bool isVoiceToText: false
@@ -44,6 +44,7 @@ ApplicationWindow {
 
     DWindow.alphaBufferSize: 8
     DWindow.enabled: true
+    color: "transparent"
     flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
     height: 681
     minimumHeight: windowMiniHeight
@@ -493,18 +494,26 @@ ApplicationWindow {
         }
     }
 
+    // 全窗级毛玻璃：左侧文件夹栏 + 笔记列表区域透明可见，列表项保持实色卡片
+    VNoteComponents.SidebarBlurBackground {
+        anchors.fill: parent
+        windowControl: rootWindow
+        z: 0
+    }
+
     RowLayout {
         id: rowLayout
 
+        z: 1
         anchors.fill: parent
         spacing: 0
 
         Rectangle {
             id: leftBgArea
 
-            Layout.fillHeight: true//#F2F6F8
+            Layout.fillHeight: true
             Layout.preferredWidth: leftViewWidth - leftDragHandle.width
-            color: DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#101010"
+            color: "transparent"
 
             ColumnLayout {
                 id: leftColumnLayout
@@ -622,7 +631,7 @@ ApplicationWindow {
 
             Layout.fillHeight: true
             Layout.preferredWidth: 5
-            color: leftBgArea.color
+            color: "transparent"
 
             Rectangle {
                 anchors.right: parent.right
@@ -665,7 +674,8 @@ ApplicationWindow {
 
             Layout.fillHeight: true
             Layout.preferredWidth: middleViewWidth - rightDragHandle.width
-            color: DTK.themeType === ApplicationHelper.LightType ? "#F8F8F8" : "#181818"
+            color: DTK.themeType === ApplicationHelper.LightType ? Qt.rgba(248 / 255, 248 / 255, 248 / 255, 0.95)
+                                                                   : Qt.rgba(24 / 255, 24 / 255, 24 / 255, 0.95)
 
             onWidthChanged: {
                 if (!leftBgArea.visible) {
@@ -881,18 +891,7 @@ ApplicationWindow {
 
             Layout.fillHeight: true
             Layout.fillWidth: true
-            color: Qt.rgba(0, 0, 0, 0.01)
-
-            BoxShadow {
-                anchors.fill: rightBgArea
-                cornerRadius: rightBgArea.radius
-                hollow: true
-                shadowBlur: 10
-                shadowColor: Qt.rgba(0, 0, 0, 0.05)
-                shadowOffsetX: 0
-                shadowOffsetY: 4
-                spread: 0
-            }
+            color: DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#242424"
 
             ColumnLayout {
                 anchors.fill: parent


### PR DESCRIPTION
Add full-window StyledBehindWindowBlur for folder and note list areas. Keep middle panel at 95% opacity (#F8F8F8/#181818) and restore opaque right editor background. Add 1px bottom shadow on unselected note cards.

新增全窗毛玻璃效果，文件夹栏与笔记列表区域透出模糊背景；中间栏
保持原色 95% 不透明，右侧编辑区恢复实色背景；未选中笔记卡片增加
底部 1px 淡阴影，与控制中心一致。

Log: 左侧毛玻璃与笔记卡片底部阴影
PMS: BUG-277173
Influence: 文件夹栏与笔记列表呈现毛玻璃质感；中间栏视觉与原 #F8F8F8
基本一致；笔记卡片层次更清晰；右侧标题栏与编辑区不再受透明窗口影响。