### PR TITLE
fix(vnote): fix title bar background and menu hover at 1.25 scale

### DIFF
--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -891,7 +891,18 @@ ApplicationWindow {
 
             Layout.fillHeight: true
             Layout.fillWidth: true
-            color: DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#242424"
+            color: Qt.rgba(0, 0, 0, 0.01)
+
+            BoxShadow {
+                anchors.fill: rightBgArea
+                cornerRadius: rightBgArea.radius
+                hollow: true
+                shadowBlur: 10
+                shadowColor: Qt.rgba(0, 0, 0, 0.05)
+                shadowOffsetX: 0
+                shadowOffsetY: 4
+                spread: 0
+            }
 
             ColumnLayout {
                 anchors.fill: parent

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -298,6 +298,14 @@ Item {
             Layout.minimumHeight: 50
             Layout.maximumHeight: 50
 
+            // 透明窗口下仅标题栏区域遮挡毛玻璃，沿用窗口 palette 底色（非 TitleBar 强制白底）
+            Rectangle {
+                anchors.fill: parent
+                color: Window.window ? Window.window.palette.window
+                                      : (DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#242424")
+                z: -1
+            }
+
             WindowTitleBar {
                 id: title
 
@@ -337,7 +345,7 @@ Item {
 
             Layout.fillHeight: true
             Layout.fillWidth: true
-            color: "transparent"
+            color: DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#242424"
 
             WebEngineView {
                 id: webView

--- a/src/gui/mainwindow/WindowTitleBar.qml
+++ b/src/gui/mainwindow/WindowTitleBar.qml
@@ -28,6 +28,7 @@ TitleBar {
     signal titleOpenSetting
 
     enableInWindowBlendBlur: false
+    separatorVisible: false
 
     anchors.fill: parent
 


### PR DESCRIPTION
Restore layered right panel background after frosted glass changes. Hide TitleBar separator to fix DTK menu button hover line at 125% scale.

修复毛玻璃改动后右侧标题栏异常纯白，恢复分层背景与阴影。
关闭 TitleBar 底部分隔行，修复 1.25 缩放下菜单按钮 hover 细线。

Log: 修复标题栏背景与 1.25 缩放菜单 hover 细线
PMS: BUG-299407
PMS: BUG-336393
Influence: 透明窗口下右侧标题栏不再整块死白，编辑区保持实色背景；
1.25 缩放下右上角菜单按钮 hover 不再出现多余底边细线。