### PR TITLE
fix(vnote): set notebook list count label font size to 12px

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -640,6 +640,7 @@ Item {
 
                     Layout.rightMargin: 10
                     color: folderNameLabel.color
+                    font.pixelSize: 12
                     horizontalAlignment: Text.AlignRight
                     text: model.count
                     verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
Set folderCountLabel font.pixelSize to 12 to match design spec.

笔记本列表数量文字设为 12px，与设计稿及 H5 辅助文字一致。

Log: 笔记本列表数量字号改为 12px
PMS: BUG-277169
Influence: 左侧笔记本列表右侧数量文字由默认 T6 改为 12px，
与笔记本名称形成层级区分，视觉更符合设计规范。

## Summary by Sourcery

Enhancements:
- Set the notebook list count label font size to 12px to align with design specs and improve visual hierarchy with the notebook name.