### PR TITLE
fix(vnote): overlay note list scrollbar like folder list

### DIFF
--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -34,6 +34,8 @@ Item {
     property int topSize: 0
     property alias view: itemListView
     property bool webVisible: true
+    property Item scrollBarParent: null
+    property int scrollBarRightOffset: 0
 
     signal deleteFinished
     signal deleteNotes(int number)
@@ -787,6 +789,57 @@ Item {
         visible: true
 
         ScrollBar.vertical: ScrollBar {
+            id: verticalScrollBar
+
+            function updateGeometry() {
+                if (!parent)
+                    return;
+
+                x = rootItem.mapToItem(parent, rootItem.width + rootItem.scrollBarRightOffset - width, 0).x;
+                y = rootItem.scrollBarParent ? 0 : rootItem.mapToItem(parent, 0, 0).y;
+                height = rootItem.scrollBarParent ? parent.height : itemListView.height;
+            }
+
+            parent: rootItem.scrollBarParent ? rootItem.scrollBarParent : itemListView
+
+            Component.onCompleted: Qt.callLater(updateGeometry)
+            onParentChanged: Qt.callLater(updateGeometry)
+            onWidthChanged: Qt.callLater(updateGeometry)
+
+            Connections {
+                target: rootItem
+
+                function onHeightChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onWidthChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onXChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onYChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+            }
+
+            Connections {
+                enabled: !!rootItem.scrollBarParent
+                target: rootItem.scrollBarParent
+
+                function onHeightChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onWidthChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onXChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+                function onYChanged() {
+                    Qt.callLater(verticalScrollBar.updateGeometry);
+                }
+            }
         }
 
         delegate: Rectangle {

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -692,6 +692,8 @@ ApplicationWindow {
             }
 
             ColumnLayout {
+                id: middleColumnLayout
+
                 Layout.topMargin: 7
                 anchors.fill: parent
                 anchors.leftMargin: 10
@@ -821,6 +823,8 @@ ApplicationWindow {
                     Layout.fillWidth: true
                     enabled: !rootWindow.isVoiceToText
                     opacity: enabled ? 1.0 : 0.4
+                    scrollBarParent: itemScrollBarOverlay
+                    scrollBarRightOffset: 10
                     sourceFolderModel: folderListView.model
                     currentFolderIndex: folderListView.currentFolderIndex
                     webVisible: initRect.visible
@@ -985,6 +989,52 @@ ApplicationWindow {
 
             function onYChanged() {
                 Qt.callLater(scrollBarOverlay.updateGeometry);
+            }
+        }
+    }
+
+    Item {
+        id: itemScrollBarOverlay
+
+        function updateGeometry() {
+            y = itemListView.mapToItem(parent, 0, 0).y;
+        }
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        clip: true
+        height: itemListView.height
+        visible: middleBgArea.visible
+        z: 50
+
+        Component.onCompleted: Qt.callLater(updateGeometry)
+        onHeightChanged: Qt.callLater(updateGeometry)
+        onVisibleChanged: Qt.callLater(updateGeometry)
+
+        Connections {
+            target: itemListView
+
+            function onHeightChanged() {
+                Qt.callLater(itemScrollBarOverlay.updateGeometry);
+            }
+            function onYChanged() {
+                Qt.callLater(itemScrollBarOverlay.updateGeometry);
+            }
+        }
+
+        Connections {
+            target: middleBgArea
+
+            function onYChanged() {
+                Qt.callLater(itemScrollBarOverlay.updateGeometry);
+            }
+        }
+
+        Connections {
+            target: middleColumnLayout
+
+            function onYChanged() {
+                Qt.callLater(itemScrollBarOverlay.updateGeometry);
             }
         }
     }


### PR DESCRIPTION
Mount note list ScrollBar on itemScrollBarOverlay instead of inline layout, matching FolderListView scrollBarParent pattern.

笔记列表滚动条改为外挂 overlay 渲染，与左侧文件夹列表处理方式一致，
避免占用列表内容宽度导致左右边距视觉不一致。

Log: 笔记列表滚动条改为 overlay 外挂
PMS: BUG-299399
Influence: 笔记列表滚动条不再挤占 item 右侧空间，左右边距视觉一致，
滚动交互与文件夹列表保持一致。