### PR TITLE
fix(player): reset m_isChangePlayFile in play() for same-file scenario

### DIFF
--- a/src/common/vlcpalyer.cpp
+++ b/src/common/vlcpalyer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2019 UnionTech Software Technology Co.,Ltd.
+// Copyright (C) 2019 - 2026 UnionTech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -158,6 +158,14 @@ void VlcPalyer::play()
         qInfo() << "Play new audio: " << videoUrl;
         player->addPlayFile(videoUrl);
         player->playByName(videoUrl);
+        //同一文件场景：MPV 不重新进入 Playing 状态（已经在 Playing），
+        //onGetState 中的 Playing && m_isChangePlayFile 分支不会被触发，
+        //需在此处直接重置标志，否则播放结束时 playEnd 不发出
+        if (m_isChangePlayFile && player->state() == PlayerEngine::CoreState::Playing) {
+            m_isChangePlayFile = false;
+            //同一文件 MPV 不会从头播放，需显式 seek 到起始位置
+            player->seekAbsolute(0);
+        }
     }
 #endif
 }


### PR DESCRIPTION
Fix by directly resetting m_isChangePlayFile in VlcPalyer::play() when MPV is already in Playing state after playByName(), rather than relying on onGetState() which is never triggered for the same file.

切换到同一文件的语音（如复制的语音笔记）时，MPV 不重新进入 Playing
状态（已经在 Playing），导致 onGetState 中 Playing && m_isChangePlayFile 分支不被触发，m_isChangePlayFile 保持 true。播放结束时 Idle && !m_isChangePlayFile 为 false，playEnd 不发出，进度条不消失。

在 VlcPalyer::play() 的 playByName 之后，若 MPV 已处于 Playing 状态， 直接重置 m_isChangePlayFile 标志，不依赖 onGetState 触发。

Log: 修复复制语音切换播放后进度条不消失的问题
Bug: https://pms.uniontech.com/bug-view-365835.html
Influence: 修复后切换播放同一语音文件时进度条正常更新且播放结束后正常消失，不影响不同语音文件的正常播放。