### PR TITLE
fix(vnote): fix Tibetan text overflow in notebook list headers

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -9,6 +9,7 @@ import VNote 1.0
 import "../drag/"
 import "../dialog/"
 import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
 
 Item {
     id: root
@@ -18,7 +19,8 @@ Item {
     property bool isPlay: false
     property bool isRecordingAudio: false
     property bool isVoiceToText: false
-    property int itemHeight: 30
+    readonly property int itemVerticalPadding: (DS.Style.control.padding - DS.Style.control.borderWidth) * 2
+    property int itemHeight: Math.max(30, folderItemFontMetrics.height + itemVerticalPadding)
     property int lastDropIndex: -1
     property int listHeight: 700
     property int listWidth: 200
@@ -33,6 +35,10 @@ Item {
     signal itemChanged(int index, string name)
     signal mouseChanged(int mousePosX, int mousePosY)
     signal updateFolderName(string name)
+
+    FontMetrics {
+        id: folderItemFontMetrics
+    }
 
     function addFolder() {
         VNoteMainManager.vNoteCreateFolder();
@@ -451,6 +457,7 @@ Item {
             opacity: (isRecordingAudio && index !== folderListView.currentIndex) ? 0.5 : 1.0
 
             color: index === folderListView.currentIndex ? (root.activeFocus ? palette.highlight : DTK.themeType === ApplicationHelper.LightType ? "#33000000" : "#33FFFFFF") : (folderListView.hoverIndex === index || isHovered ? (DTK.themeType === ApplicationHelper.LightType ? "#1A000000" : "#1AFFFFFF") : "transparent")
+            clip: true
             enabled: !isPlay || index === folderListView.currentIndex
             height: itemHeight
             radius: 6
@@ -582,6 +589,8 @@ Item {
                     id: folderNameLabel
 
                     Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Layout.alignment: Qt.AlignVCenter
                     color: index === folderListView.currentIndex ? (root.activeFocus ? palette.highlightedText : (DTK.themeType === ApplicationHelper.LightType ? "black" : "#B2FFFFFF")) : (DTK.themeType === ApplicationHelper.LightType ? "black" : "#B2FFFFFF")
                     elide: Text.ElideRight
                     horizontalAlignment: Text.AlignLeft
@@ -593,6 +602,7 @@ Item {
                 Label {
                     id: folderCountLabel
 
+                    Layout.alignment: Qt.AlignVCenter
                     Layout.rightMargin: 10
                     color: folderNameLabel.color
                     font.pixelSize: 12

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -1222,12 +1222,17 @@ Item {
 
             delegate: Rectangle {
                 color: "transparent"
-                height: section == "top" ? (18) : 16
+                height: section == "top" ? Math.max(18, Math.ceil(sectionStickyFontMetrics.height) + 6) : 16
                 width: parent.width
+
+                FontMetrics {
+                    id: sectionStickyFontMetrics
+                    font.pixelSize: 12
+                }
 
                 RowLayout {
                     anchors.left: parent.left
-                    anchors.top: parent.top
+                    anchors.verticalCenter: parent.verticalCenter
                     spacing: 4
                     visible: section == "top" && !isSearch
                     
@@ -1246,6 +1251,7 @@ Item {
                     Text {
                         color: "#b3000000"
                         font.pixelSize: 12
+                        verticalAlignment: Text.AlignVCenter
                         text: qsTr("Sticky Notes")
                     }
                 }


### PR DESCRIPTION
Keep original font sizes and design specs, and make list section header height adapt to actual glyph metrics to prevent clipping of Tibetan text in "Sticky Notes" and notebook header rendering.

保持原有字号与设计规格不变，通过字体度量驱动分组头高度自适应，
修复藏语环境下“已置顶”和记事本标题出现重叠、裁切和出格问题。

Log: 修复藏语下置顶分组与记事本标题显示异常
PMS: BUG-290741
Influence: 藏语切换后列表标题与置顶分组显示恢复正常，且不影响
中文场景下的既有字号和30px设计基线。

## Summary by Sourcery

Adapt list headers and folder list items to font metrics to prevent Tibetan text clipping while preserving existing design baselines.

Bug Fixes:
- Prevent clipping and overlap of Tibetan text in folder list headers and sticky notes section headers by making their heights depend on font metrics.

Enhancements:
- Align folder and sticky notes labels vertically within their containers and enable clipping on folder list item backgrounds to improve visual consistency across locales.