### PR TITLE
fix(editor): hide floating toolbar when switching notes

### DIFF
--- a/assets/web/js/summernote_v9_2.js
+++ b/assets/web/js/summernote_v9_2.js
@@ -7303,6 +7303,8 @@
 
         AirPopover.prototype.hide = function () {
             this.$popover.find('.note-color').removeClass('open')
+            this.$popover.find('.note-fontsize-class').removeClass('open')
+            this.$popover.find('.note-font-family-class').removeClass('open')
             this.$popover.hide();
         };
         return AirPopover;

--- a/src/views/webrichtexteditor.cpp
+++ b/src/views/webrichtexteditor.cpp
@@ -741,10 +741,8 @@ void WebRichTextEditor::onLoadFinsh()
 
 void WebRichTextEditor::setData(VNoteItem *data, const QString &reg)
 {
-    //有焦点先隐藏编辑工具栏
-    if (hasFocus()) {
-        emit JsContent::instance()->callJsHideEditToolbar();
-    }
+    //切换笔记时隐藏编辑工具栏，避免下拉状态残留
+    emit JsContent::instance()->callJsHideEditToolbar();
 
     if (nullptr == data) {
         this->setVisible(false);


### PR DESCRIPTION
fix(editor): hide floating toolbar when switching notes

Hide the editor floating toolbar unconditionally when note data changes.
切换笔记内容时无条件隐藏编辑区悬浮工具栏。
Also clear font and font-size dropdown open states when hiding air popover
隐藏气泡工具栏时同步清理字体和字号下拉展开状态。

Log：修复切换笔记后字体气泡工具栏残留
Bug: https://pms.uniontech.com/bug-view-365817.html
Influence:修复展开字体下拉栏后切换笔记时悬浮气泡工具栏未消失的问题。
