### PR TITLE
chore: Update version to 6.5.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-voice-note (6.5.62) unstable; urgency=medium
+
+  * fix(vnote): use folder ids for notebook operations
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 09 Jul 2026 20:51:14 +0800
+
 deepin-voice-note (6.5.61) unstable; urgency=medium
 
   * chore: Update version to 6.5.61

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.61.1
+  version: 6.5.62.1
   kind: app
   description: 4
     voice note for deepin os


### PR DESCRIPTION
- update version to 6.5.62

log: update version to 6.5.62

## Summary by Sourcery

Build:
- Update linglong package configuration to reference application version 6.5.62.1.