### PR TITLE
fix(vnote): keep ctrl multi-selection count in sync

### DIFF
--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -1091,14 +1091,12 @@ Item {
                         case Qt.ControlModifier:
                             var nextSelection = selectedNoteItem.slice();
                             var pos = nextSelection.indexOf(index);
-                            if (pos != -1) {
+                            if (pos != -1)
                                 nextSelection.splice(pos, 1);
-                                selectSize--;
-                            } else {
+                            else
                                 nextSelection.push(index);
-                                selectSize++;
-                            }
                             selectedNoteItem = nextSelection;
+                            selectSize = validSelectedNoteIndexes().length;
                             break;
                         case Qt.ShiftModifier:
                             var anchorIndex = Math.max(0, Math.min(itemListView.lastCurrentIndex, itemModel.count - 1));


### PR DESCRIPTION
Update selected note indexes before selectSize on Ctrl+click so onSelectSizeChanged reads the latest selection and multi-choice count matches highlighted items.

Ctrl+点击多选时先更新 selectedNoteItem，再同步 selectSize，
避免 onSelectSizeChanged 读取旧选中状态导致右侧统计数量错误。

Log: 修复Ctrl多选笔记后右侧统计数量与实际选中数量不一致
PMS: BUG-369995
Influence: Ctrl多选和取消选中时，左侧列表选中状态与右侧多选统计保持一致。

## Summary by Sourcery

Bug Fixes:
- Fix mismatch between the right-side multi-selection count and the actual notes selected when using Ctrl to add or remove selections.