### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/assets/deepin-voice-note.desktop
+++ b/assets/deepin-voice-note.desktop
@@ -10,6 +10,7 @@ Terminal=false
 TryExec=deepin-voice-note
 Type=Application
 X-Deepin-Vendor=user-custom
+X-Deepin-Singleton=true
 Keywords=deepin-voice-note
 
 # Translations:


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Add the X-Deepin-Singleton=true flag to the deepin-voice-note.desktop file to indicate the app should run as a singleton.