### PR TITLE
fix: remove yaml literal block scalar in linglong.yaml description

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -3,8 +3,7 @@ package:
   name: deepin-voice.note
   version: 5.10.11
   kind: app
-  description: |
-    voice note for deepin os
+  description: voice note for deepin os
 
 runtime:
   id: org.deepin.Runtime


### PR DESCRIPTION
## Summary

- 修复 `linglong.yaml` 中 `description` 字段使用 YAML `|` 块标量语法导致 `ll-cli list` 命令下描述信息显示异常的问题
- 将 `description` 从多行块标量格式改为普通字符串格式，去掉 4 空格缩进

## Bug

PMS: BUG-370559

通过 `ll-cli list` 命令查看语音记事本信息时，描述信息显示有多余前导空格。

## Test plan

- [ ] 执行 `ll-cli list` 确认语音记事本描述信息显示正常，无多余空格

## Summary by Sourcery

Bug Fixes:
- Correct leading whitespace in the ll-cli list description output by removing YAML block scalar usage for the description field.