### PR TITLE
fix: remove yaml literal block scalar in linglong.yaml

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -9,7 +9,7 @@ package:
   name: deepin-voice-note
   version: 6.5.62.1
   kind: app
-  description: 4
+  description: |
     voice note for deepin os
 
 command:


### PR DESCRIPTION
Use plain string format for description field to fix incorrect display in ll-cli list output.

移除 linglong.yaml description 的 YAML 块标量语法，修复 ll-cli list 命令下描述信息显示异常。

Log: 修复 linglong.yaml 描述信息显示有误
PMS: BUG-370559
Influence: ll-cli list 命令查看语音记事本描述信息时显示正常。