### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file

### DIFF
--- a/assets/deepin-voice-note.desktop
+++ b/assets/deepin-voice-note.desktop
@@ -11,6 +11,7 @@ TryExec=deepin-voice-note
 Type=Application
 X-Deepin-Vendor=user-custom
 Keywords=deepin-voice-note;
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app.

为单例应用的desktop文件添加X-Deepin-Singleton=true标识。

Log: 添加单例应用标识
PMS: TASK-392841
Influence: AM能识别单例应用，Treeland不再为单例应用显示快速启动画面

## Summary by Sourcery

Enhancements:
- Add X-Deepin-Singleton=true to the deepin-voice-note.desktop file to declare the app as a singleton to the desktop environment.