### PR TITLE
V-244: add migration json builder

### DIFF
--- a/src/importolddata/tiptapmigration/migrationjsonbuilder.cpp
+++ b/src/importolddata/tiptapmigration/migrationjsonbuilder.cpp
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationjsonbuilder.h"
+
+#include <QJsonDocument>
+#include <QJsonValue>
+
+namespace {
+constexpr int kSchemaVersion = 1;
+}
+
+QJsonObject MigrationJsonBuilder::makeEnvelope()
+{
+    return makeEnvelope(makeDoc());
+}
+
+QJsonObject MigrationJsonBuilder::makeEnvelope(const QJsonObject &content)
+{
+    QJsonObject envelope;
+    envelope.insert(QStringLiteral("format"), QStringLiteral("tiptap"));
+    envelope.insert(QStringLiteral("schemaVersion"), kSchemaVersion);
+    envelope.insert(QStringLiteral("content"), content.isEmpty() ? makeDoc() : content);
+    return envelope;
+}
+
+QJsonObject MigrationJsonBuilder::makeDoc(const QJsonArray &content)
+{
+    QJsonObject doc;
+    doc.insert(QStringLiteral("type"), QStringLiteral("doc"));
+    doc.insert(QStringLiteral("content"), normalizedDocContent(content));
+    return doc;
+}
+
+QJsonObject MigrationJsonBuilder::makeParagraph(const QJsonArray &content)
+{
+    return makeContainerNode(QStringLiteral("paragraph"), content);
+}
+
+QJsonObject MigrationJsonBuilder::makeText(const QString &text, const QJsonArray &marks)
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("text"));
+    node.insert(QStringLiteral("text"), text);
+    if (!marks.isEmpty()) {
+        node.insert(QStringLiteral("marks"), marks);
+    }
+    return node;
+}
+
+QJsonObject MigrationJsonBuilder::makeHardBreak()
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("hardBreak"));
+    return node;
+}
+
+QJsonObject MigrationJsonBuilder::makeHeading(int level, const QJsonArray &content)
+{
+    QJsonObject node = makeContainerNode(QStringLiteral("heading"), content);
+    node.insert(QStringLiteral("attrs"), QJsonObject { { QStringLiteral("level"), level } });
+    return node;
+}
+
+QJsonObject MigrationJsonBuilder::makeMark(const QString &type, const QJsonObject &attrs)
+{
+    QJsonObject mark;
+    mark.insert(QStringLiteral("type"), type);
+    if (!attrs.isEmpty()) {
+        mark.insert(QStringLiteral("attrs"), attrs);
+    }
+    return mark;
+}
+
+QJsonObject MigrationJsonBuilder::makeImage(const QString &src,
+                                         const QString &relPath,
+                                         const QString &alt,
+                                         const QString &title)
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("src"), src);
+    attrs.insert(QStringLiteral("relPath"), nullableString(relPath));
+    attrs.insert(QStringLiteral("alt"), alt);
+    attrs.insert(QStringLiteral("title"), nullableString(title));
+
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("image"));
+    node.insert(QStringLiteral("attrs"), attrs);
+    return node;
+}
+
+QJsonObject MigrationJsonBuilder::makeVoiceBlock(const QString &voiceId,
+                                              const QString &voicePath,
+                                              qint64 voiceSize,
+                                              const QString &createTime,
+                                              const QString &title,
+                                              const QString &text,
+                                              bool translateUnfold)
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("voiceId"), voiceId);
+    attrs.insert(QStringLiteral("voicePath"), voicePath);
+    attrs.insert(QStringLiteral("voiceSize"), static_cast<double>(voiceSize));
+    attrs.insert(QStringLiteral("createTime"), nullableString(createTime));
+    attrs.insert(QStringLiteral("title"), nullableString(title));
+    attrs.insert(QStringLiteral("text"), nullableString(text));
+    attrs.insert(QStringLiteral("translateUnfold"), translateUnfold);
+
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("voiceBlock"));
+    node.insert(QStringLiteral("attrs"), attrs);
+    return node;
+}
+
+QJsonObject MigrationJsonBuilder::makeBulletList(const QJsonArray &content)
+{
+    return makeContainerNode(QStringLiteral("bulletList"), content);
+}
+
+QJsonObject MigrationJsonBuilder::makeOrderedList(const QJsonArray &content)
+{
+    return makeContainerNode(QStringLiteral("orderedList"), content);
+}
+
+QJsonObject MigrationJsonBuilder::makeListItem(const QJsonArray &content)
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("listItem"));
+    node.insert(QStringLiteral("content"), normalizedListItemContent(content));
+    return node;
+}
+
+QJsonObject MigrationJsonBuilder::makeTaskList(const QJsonArray &content)
+{
+    return makeContainerNode(QStringLiteral("taskList"), content);
+}
+
+QJsonObject MigrationJsonBuilder::makeTaskItem(bool checked, const QJsonArray &content)
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("taskItem"));
+    node.insert(QStringLiteral("attrs"), QJsonObject { { QStringLiteral("checked"), checked } });
+    node.insert(QStringLiteral("content"), normalizedListItemContent(content));
+    return node;
+}
+
+QString MigrationJsonBuilder::toCompactJson(const QJsonObject &object)
+{
+    return QString::fromUtf8(QJsonDocument(object).toJson(QJsonDocument::Compact));
+}
+
+QJsonValue MigrationJsonBuilder::nullableString(const QString &value)
+{
+    return value.isNull() || value.isEmpty() ? QJsonValue(QJsonValue::Null) : QJsonValue(value);
+}
+
+QJsonArray MigrationJsonBuilder::normalizedDocContent(const QJsonArray &content)
+{
+    if (!content.isEmpty()) {
+        return content;
+    }
+
+    return QJsonArray { makeParagraph() };
+}
+
+QJsonArray MigrationJsonBuilder::normalizedListItemContent(const QJsonArray &content)
+{
+    if (!content.isEmpty()) {
+        return content;
+    }
+
+    return QJsonArray { makeParagraph() };
+}
+
+QJsonObject MigrationJsonBuilder::makeContainerNode(const QString &type, const QJsonArray &content)
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), type);
+    if (!content.isEmpty()) {
+        node.insert(QStringLiteral("content"), content);
+    }
+    return node;
+}

--- a/src/importolddata/tiptapmigration/migrationjsonbuilder.h
+++ b/src/importolddata/tiptapmigration/migrationjsonbuilder.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONJSONBUILDER_H
+#define MIGRATIONJSONBUILDER_H
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QString>
+
+class MigrationJsonBuilder
+{
+public:
+    static QJsonObject makeEnvelope();
+    static QJsonObject makeEnvelope(const QJsonObject &content);
+    static QJsonObject makeDoc(const QJsonArray &content = QJsonArray());
+    static QJsonObject makeParagraph(const QJsonArray &content = QJsonArray());
+    static QJsonObject makeText(const QString &text, const QJsonArray &marks = QJsonArray());
+    static QJsonObject makeHardBreak();
+    static QJsonObject makeHeading(int level, const QJsonArray &content = QJsonArray());
+    static QJsonObject makeMark(const QString &type, const QJsonObject &attrs = QJsonObject());
+    static QJsonObject makeImage(const QString &src,
+                                 const QString &relPath = QString(),
+                                 const QString &alt = QString(),
+                                 const QString &title = QString());
+    static QJsonObject makeVoiceBlock(const QString &voiceId,
+                                      const QString &voicePath,
+                                      qint64 voiceSize,
+                                      const QString &createTime = QString(),
+                                      const QString &title = QString(),
+                                      const QString &text = QString(),
+                                      bool translateUnfold = true);
+    static QJsonObject makeBulletList(const QJsonArray &content = QJsonArray());
+    static QJsonObject makeOrderedList(const QJsonArray &content = QJsonArray());
+    static QJsonObject makeListItem(const QJsonArray &content = QJsonArray());
+    static QJsonObject makeTaskList(const QJsonArray &content = QJsonArray());
+    static QJsonObject makeTaskItem(bool checked, const QJsonArray &content = QJsonArray());
+    static QString toCompactJson(const QJsonObject &object);
+
+private:
+    static QJsonValue nullableString(const QString &value);
+    static QJsonArray normalizedDocContent(const QJsonArray &content);
+    static QJsonArray normalizedListItemContent(const QJsonArray &content);
+    static QJsonObject makeContainerNode(const QString &type, const QJsonArray &content);
+};
+
+#endif // MIGRATIONJSONBUILDER_H

--- a/tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "importolddata/tiptapmigration/migrationjsonbuilder.h"
+
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QProcess>
+#include <QTemporaryFile>
+
+namespace {
+QJsonArray arrayOf(const QJsonObject &object)
+{
+    return QJsonArray { object };
+}
+
+QJsonObject attrsOf(const QJsonObject &node)
+{
+    return node.value(QStringLiteral("attrs")).toObject();
+}
+
+void expectNodeType(const QJsonObject &node, const QString &type)
+{
+    EXPECT_EQ(type, node.value(QStringLiteral("type")).toString());
+}
+
+QString findRepoRoot()
+{
+    QDir dir(QDir::currentPath());
+    for (int depth = 0; depth < 8; ++depth) {
+        if (QFile::exists(dir.filePath(QStringLiteral("web-editor/scripts/validate-envelope.mjs")))) {
+            return dir.absolutePath();
+        }
+        if (!dir.cdUp()) {
+            break;
+        }
+    }
+
+    return QDir::currentPath();
+}
+
+QString writeTempEnvelope(const QJsonObject &envelope)
+{
+    QTemporaryFile file(QDir::tempPath() + QStringLiteral("/migration-envelope-XXXXXX.json"));
+    file.setAutoRemove(false);
+    EXPECT_TRUE(file.open());
+    file.write(MigrationJsonBuilder::toCompactJson(envelope).toUtf8());
+    const QString path = file.fileName();
+    file.close();
+    return path;
+}
+} // namespace
+
+TEST(UT_MigrationJsonBuilder, CreatesEnvelopeWithEmptyDoc)
+{
+    const QJsonObject envelope = MigrationJsonBuilder::makeEnvelope();
+    const QJsonObject content = envelope.value(QStringLiteral("content")).toObject();
+
+    EXPECT_EQ(QStringLiteral("tiptap"), envelope.value(QStringLiteral("format")).toString());
+    EXPECT_EQ(1, envelope.value(QStringLiteral("schemaVersion")).toInt());
+    expectNodeType(content, QStringLiteral("doc"));
+    ASSERT_EQ(1, content.value(QStringLiteral("content")).toArray().size());
+    expectNodeType(content.value(QStringLiteral("content")).toArray().at(0).toObject(), QStringLiteral("paragraph"));
+}
+
+TEST(UT_MigrationJsonBuilder, CreatesTextWithMarks)
+{
+    const QJsonArray marks {
+        MigrationJsonBuilder::makeMark(QStringLiteral("bold")),
+        MigrationJsonBuilder::makeMark(QStringLiteral("color"), QJsonObject { { QStringLiteral("color"), QStringLiteral("#ff0000") } })
+    };
+    const QJsonObject text = MigrationJsonBuilder::makeText(QStringLiteral("重点内容"), marks);
+    const QJsonObject paragraph = MigrationJsonBuilder::makeParagraph(arrayOf(text));
+
+    expectNodeType(paragraph, QStringLiteral("paragraph"));
+    const QJsonObject textNode = paragraph.value(QStringLiteral("content")).toArray().at(0).toObject();
+    expectNodeType(textNode, QStringLiteral("text"));
+    EXPECT_EQ(QStringLiteral("重点内容"), textNode.value(QStringLiteral("text")).toString());
+    EXPECT_EQ(2, textNode.value(QStringLiteral("marks")).toArray().size());
+}
+
+TEST(UT_MigrationJsonBuilder, CreatesHeadingAndHardBreak)
+{
+    const QJsonObject heading = MigrationJsonBuilder::makeHeading(
+        2, QJsonArray { MigrationJsonBuilder::makeText(QStringLiteral("标题")) });
+    const QJsonObject hardBreak = MigrationJsonBuilder::makeHardBreak();
+
+    expectNodeType(heading, QStringLiteral("heading"));
+    EXPECT_EQ(2, attrsOf(heading).value(QStringLiteral("level")).toInt());
+    expectNodeType(hardBreak, QStringLiteral("hardBreak"));
+}
+
+TEST(UT_MigrationJsonBuilder, CreatesImageAndVoiceBlock)
+{
+    const QJsonObject image = MigrationJsonBuilder::makeImage(
+        QStringLiteral("images/photo.png"),
+        QStringLiteral("images/photo.png"),
+        QString(),
+        QString());
+    const QJsonObject voiceBlock = MigrationJsonBuilder::makeVoiceBlock(
+        QStringLiteral("voice-uuid"),
+        QStringLiteral("voicenote/20260717-100000.mp3"),
+        120000,
+        QStringLiteral("2026-07-17 10:00:00"),
+        QStringLiteral("录音"),
+        QStringLiteral("转写文本"),
+        true);
+
+    expectNodeType(image, QStringLiteral("image"));
+    EXPECT_EQ(QStringLiteral("images/photo.png"), attrsOf(image).value(QStringLiteral("src")).toString());
+    EXPECT_EQ(QStringLiteral("images/photo.png"), attrsOf(image).value(QStringLiteral("relPath")).toString());
+    EXPECT_EQ(QString(), attrsOf(image).value(QStringLiteral("alt")).toString());
+    EXPECT_TRUE(attrsOf(image).value(QStringLiteral("title")).isNull());
+
+    expectNodeType(voiceBlock, QStringLiteral("voiceBlock"));
+    EXPECT_EQ(QStringLiteral("voice-uuid"), attrsOf(voiceBlock).value(QStringLiteral("voiceId")).toString());
+    EXPECT_EQ(QStringLiteral("voicenote/20260717-100000.mp3"), attrsOf(voiceBlock).value(QStringLiteral("voicePath")).toString());
+    EXPECT_EQ(120000, attrsOf(voiceBlock).value(QStringLiteral("voiceSize")).toInt());
+    EXPECT_TRUE(attrsOf(voiceBlock).value(QStringLiteral("translateUnfold")).toBool());
+    EXPECT_FALSE(attrsOf(voiceBlock).contains(QStringLiteral("translating")));
+}
+
+TEST(UT_MigrationJsonBuilder, CreatesListsAndTaskItems)
+{
+    const QJsonObject listItem = MigrationJsonBuilder::makeListItem(
+        arrayOf(MigrationJsonBuilder::makeParagraph(arrayOf(MigrationJsonBuilder::makeText(QStringLiteral("列表"))))));
+    const QJsonObject bulletList = MigrationJsonBuilder::makeBulletList(arrayOf(listItem));
+    const QJsonObject orderedList = MigrationJsonBuilder::makeOrderedList(arrayOf(listItem));
+    const QJsonObject taskItem = MigrationJsonBuilder::makeTaskItem(
+        false,
+        arrayOf(MigrationJsonBuilder::makeParagraph(arrayOf(MigrationJsonBuilder::makeText(QStringLiteral("待办"))))));
+    const QJsonObject taskList = MigrationJsonBuilder::makeTaskList(arrayOf(taskItem));
+
+    expectNodeType(bulletList, QStringLiteral("bulletList"));
+    expectNodeType(orderedList, QStringLiteral("orderedList"));
+    expectNodeType(taskList, QStringLiteral("taskList"));
+    EXPECT_FALSE(attrsOf(taskItem).value(QStringLiteral("checked")).toBool());
+}
+
+TEST(UT_MigrationJsonBuilder, NormalizesEmptyListItems)
+{
+    const QJsonObject listItem = MigrationJsonBuilder::makeListItem();
+    const QJsonObject taskItem = MigrationJsonBuilder::makeTaskItem(true);
+
+    ASSERT_EQ(1, listItem.value(QStringLiteral("content")).toArray().size());
+    expectNodeType(listItem.value(QStringLiteral("content")).toArray().at(0).toObject(), QStringLiteral("paragraph"));
+    ASSERT_EQ(1, taskItem.value(QStringLiteral("content")).toArray().size());
+    expectNodeType(taskItem.value(QStringLiteral("content")).toArray().at(0).toObject(), QStringLiteral("paragraph"));
+}
+
+TEST(UT_MigrationJsonBuilder, OutputsCompactJson)
+{
+    const QString json = MigrationJsonBuilder::toCompactJson(MigrationJsonBuilder::makeEnvelope());
+    QJsonParseError error;
+    const QJsonDocument document = QJsonDocument::fromJson(json.toUtf8(), &error);
+
+    EXPECT_EQ(QJsonParseError::NoError, error.error);
+    EXPECT_TRUE(document.isObject());
+    EXPECT_FALSE(json.contains(QLatin1Char('\n')));
+}
+
+TEST(UT_MigrationJsonBuilder, GeneratedEnvelopePassesSchemaValidator)
+{
+    const QJsonObject paragraph = MigrationJsonBuilder::makeParagraph(
+        QJsonArray { MigrationJsonBuilder::makeText(QStringLiteral("重点内容")) });
+    const QJsonObject image = MigrationJsonBuilder::makeImage(
+        QStringLiteral("images/photo.png"),
+        QStringLiteral("images/photo.png"),
+        QString(),
+        QString());
+    const QJsonObject voiceBlock = MigrationJsonBuilder::makeVoiceBlock(
+        QStringLiteral("voice-uuid"),
+        QStringLiteral("voicenote/20260717-100000.mp3"),
+        120000,
+        QStringLiteral("2026-07-17 10:00:00"),
+        QStringLiteral("录音"),
+        QStringLiteral("转写文本"),
+        true);
+    const QJsonObject taskItem = MigrationJsonBuilder::makeTaskItem(
+        false,
+        arrayOf(MigrationJsonBuilder::makeParagraph(arrayOf(MigrationJsonBuilder::makeText(QStringLiteral("待办"))))));
+    const QJsonObject envelope = MigrationJsonBuilder::makeEnvelope(
+        MigrationJsonBuilder::makeDoc(QJsonArray { paragraph, image, voiceBlock, MigrationJsonBuilder::makeTaskList(arrayOf(taskItem)) }));
+
+    const QString path = writeTempEnvelope(envelope);
+    QProcess validator;
+    validator.setWorkingDirectory(findRepoRoot());
+    validator.start(QStringLiteral("node"), { QStringLiteral("web-editor/scripts/validate-envelope.mjs"), path });
+    ASSERT_TRUE(validator.waitForFinished(30000));
+    EXPECT_EQ(0, validator.exitCode()) << validator.readAllStandardError().toStdString();
+    QFile::remove(path);
+}


### PR DESCRIPTION
## Summary
- Add `MigrationJsonBuilder` for constructing Schema V1 envelope and nodes.
- Normalize empty documents and list items to contain one empty paragraph.
- Add unit tests covering JSON node construction and validator compatibility.

## Validation
- `npm test` in `web-editor`: passed, 18/18.
- `g++ ... ut_migrationjsonbuilder.cpp ... && /tmp/ut_migrationjsonbuilder --gtest_filter=UT_MigrationJsonBuilder.*`: passed, 8/8.
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target deepin-voice-note -j2`: passed.

## Scope
- No database access changes.
- No HTML parser changes.
- No editor UI or WebView changes.
- No unrelated untracked files included.

Closes V-244
