### PR TITLE
V-245: add envelope validator

### DIFF
--- a/src/importolddata/tiptapmigration/migrationjsonvalidator.cpp
+++ b/src/importolddata/tiptapmigration/migrationjsonvalidator.cpp
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationjsonvalidator.h"
+
+#include <QJsonArray>
+#include <QJsonValue>
+#include <QStringList>
+
+#include <cmath>
+
+namespace {
+constexpr int kSchemaVersion = 1;
+constexpr int kMaxNodeDepth = 100;
+
+const QStringList kSupportedNodes = {
+    QStringLiteral("doc"),
+    QStringLiteral("paragraph"),
+    QStringLiteral("text"),
+    QStringLiteral("hardBreak"),
+    QStringLiteral("heading"),
+    QStringLiteral("blockquote"),
+    QStringLiteral("bulletList"),
+    QStringLiteral("orderedList"),
+    QStringLiteral("listItem"),
+    QStringLiteral("taskList"),
+    QStringLiteral("taskItem"),
+    QStringLiteral("image"),
+    QStringLiteral("voiceBlock"),
+};
+
+const QStringList kSupportedMarks = {
+    QStringLiteral("bold"),
+    QStringLiteral("italic"),
+    QStringLiteral("underline"),
+    QStringLiteral("strike"),
+    QStringLiteral("color"),
+    QStringLiteral("highlight"),
+    QStringLiteral("fontFamily"),
+    QStringLiteral("fontSize"),
+};
+
+void addError(MigrationJsonValidationResult &result,
+              const QString &path,
+              const QString &code,
+              const QString &message)
+{
+    result.errors.append({ path, code, message });
+}
+
+bool hasOwnProperty(const QJsonObject &object, const QString &key)
+{
+    return object.constFind(key) != object.constEnd();
+}
+
+bool isNonEmptyString(const QJsonValue &value)
+{
+    return value.isString() && !value.toString().trimmed().isEmpty();
+}
+
+bool isFiniteNumber(const QJsonValue &value)
+{
+    return value.isDouble() && std::isfinite(value.toDouble());
+}
+
+bool isSchemaVersionV1(const QJsonValue &value)
+{
+    if (!isFiniteNumber(value)) {
+        return false;
+    }
+
+    return value.toDouble() == kSchemaVersion;
+}
+
+bool isAllowedSchemeChar(QChar character)
+{
+    return character.isLetterOrNumber()
+        || character == QLatin1Char('+')
+        || character == QLatin1Char('.')
+        || character == QLatin1Char('-');
+}
+
+QString normalizedUrlForSchemeCheck(const QString &src)
+{
+    QString normalized;
+    normalized.reserve(src.size());
+
+    const QString trimmed = src.trimmed();
+    for (const QChar character : trimmed) {
+        const ushort code = character.unicode();
+        if (code <= 0x20 || code == 0x7f || character.isSpace()) {
+            continue;
+        }
+        normalized.append(character);
+    }
+
+    return normalized;
+}
+
+bool startsWithNetworkPath(const QString &src)
+{
+    return src.startsWith(QStringLiteral("//")) || src.startsWith(QStringLiteral("\\\\"));
+}
+
+QString urlScheme(const QString &src)
+{
+    const int colonIndex = src.indexOf(QLatin1Char(':'));
+    if (colonIndex <= 0) {
+        return QString();
+    }
+
+    const QChar first = src.at(0);
+    if (!first.isLetter()) {
+        return QString();
+    }
+
+    for (int index = 1; index < colonIndex; ++index) {
+        if (!isAllowedSchemeChar(src.at(index))) {
+            return QString();
+        }
+    }
+
+    return src.left(colonIndex).toLower();
+}
+
+bool isSafeImageSrc(const QString &src)
+{
+    const QString normalized = normalizedUrlForSchemeCheck(src);
+    if (normalized.isEmpty() || startsWithNetworkPath(normalized)) {
+        return false;
+    }
+
+    const QString scheme = urlScheme(normalized);
+    return scheme.isEmpty()
+        || scheme == QStringLiteral("http")
+        || scheme == QStringLiteral("https");
+}
+
+void validateMarks(const QJsonObject &node,
+                   const QString &path,
+                   MigrationJsonValidationResult &result)
+{
+    const QJsonValue marksValue = node.value(QStringLiteral("marks"));
+    if (marksValue.isUndefined()) {
+        return;
+    }
+
+    if (!marksValue.isArray()) {
+        addError(result,
+                 path + QStringLiteral(".marks"),
+                 QStringLiteral("invalid-marks"),
+                 QStringLiteral("marks must be an array"));
+        return;
+    }
+
+    const QJsonArray marks = marksValue.toArray();
+    for (int index = 0; index < marks.size(); ++index) {
+        const QString markPath = QStringLiteral("%1.marks[%2]").arg(path).arg(index);
+        const QJsonValue markValue = marks.at(index);
+        if (!markValue.isObject()) {
+            addError(result,
+                     markPath,
+                     QStringLiteral("invalid-mark"),
+                     QStringLiteral("mark must be an object"));
+            continue;
+        }
+
+        const QJsonObject mark = markValue.toObject();
+        const QString markType = mark.value(QStringLiteral("type")).toString();
+        if (!kSupportedMarks.contains(markType)) {
+            addError(result,
+                     markPath + QStringLiteral(".type"),
+                     QStringLiteral("unsupported-mark"),
+                     QStringLiteral("unsupported mark type: %1").arg(markType));
+        }
+    }
+}
+
+void validateImageNode(const QJsonObject &node,
+                       const QString &path,
+                       MigrationJsonValidationResult &result)
+{
+    const QJsonObject attrs = node.value(QStringLiteral("attrs")).toObject();
+    const QJsonValue srcValue = attrs.value(QStringLiteral("src"));
+    if (!srcValue.isString() || srcValue.toString().isEmpty()) {
+        addError(result,
+                 path + QStringLiteral(".attrs.src"),
+                 QStringLiteral("invalid-image-src"),
+                 QStringLiteral("image src is required"));
+        return;
+    }
+
+    if (!isSafeImageSrc(srcValue.toString())) {
+        addError(result,
+                 path + QStringLiteral(".attrs.src"),
+                 QStringLiteral("unsafe-image-src"),
+                 QStringLiteral("image src uses an unsafe URL scheme"));
+    }
+}
+
+void validateVoiceBlockNode(const QJsonObject &node,
+                            const QString &path,
+                            MigrationJsonValidationResult &result)
+{
+    const QJsonObject attrs = node.value(QStringLiteral("attrs")).toObject();
+    if (!isNonEmptyString(attrs.value(QStringLiteral("voiceId")))) {
+        addError(result,
+                 path + QStringLiteral(".attrs.voiceId"),
+                 QStringLiteral("invalid-voice-id"),
+                 QStringLiteral("voiceId is required"));
+    }
+
+    if (!isNonEmptyString(attrs.value(QStringLiteral("voicePath")))) {
+        addError(result,
+                 path + QStringLiteral(".attrs.voicePath"),
+                 QStringLiteral("invalid-voice-path"),
+                 QStringLiteral("voicePath is required"));
+    }
+
+    const QJsonValue voiceSize = attrs.value(QStringLiteral("voiceSize"));
+    if (!isFiniteNumber(voiceSize) || voiceSize.toDouble() < 0) {
+        addError(result,
+                 path + QStringLiteral(".attrs.voiceSize"),
+                 QStringLiteral("invalid-voice-size"),
+                 QStringLiteral("voiceSize must be a non-negative number"));
+    }
+
+    if (hasOwnProperty(attrs, QStringLiteral("translating"))) {
+        addError(result,
+                 path + QStringLiteral(".attrs.translating"),
+                 QStringLiteral("runtime-state-persisted"),
+                 QStringLiteral("translating is runtime state and is not part of Schema V1 persistence"));
+    }
+}
+
+void validateNode(const QJsonValue &nodeValue,
+                  const QString &path,
+                  MigrationJsonValidationResult &result,
+                  int depth = 0)
+{
+    if (depth > kMaxNodeDepth) {
+        addError(result,
+                 path,
+                 QStringLiteral("max-node-depth-exceeded"),
+                 QStringLiteral("node depth must not exceed %1").arg(kMaxNodeDepth));
+        return;
+    }
+
+    if (!nodeValue.isObject()) {
+        addError(result, path, QStringLiteral("invalid-node"), QStringLiteral("node must be an object"));
+        return;
+    }
+
+    const QJsonObject node = nodeValue.toObject();
+    const QString nodeType = node.value(QStringLiteral("type")).toString();
+    if (!kSupportedNodes.contains(nodeType)) {
+        addError(result,
+                 path + QStringLiteral(".type"),
+                 QStringLiteral("unsupported-node"),
+                 QStringLiteral("unsupported node type: %1").arg(nodeType));
+    }
+
+    if (nodeType == QStringLiteral("text") && !node.value(QStringLiteral("text")).isString()) {
+        addError(result,
+                 path + QStringLiteral(".text"),
+                 QStringLiteral("invalid-text"),
+                 QStringLiteral("text node requires string text"));
+    }
+
+    if (nodeType == QStringLiteral("heading")) {
+        const QJsonValue level = node.value(QStringLiteral("attrs")).toObject().value(QStringLiteral("level"));
+        if (!isFiniteNumber(level) || std::floor(level.toDouble()) != level.toDouble()
+            || level.toInt() < 1 || level.toInt() > 6) {
+            addError(result,
+                     path + QStringLiteral(".attrs.level"),
+                     QStringLiteral("invalid-heading-level"),
+                     QStringLiteral("heading level must be 1..6"));
+        }
+    }
+
+    if (nodeType == QStringLiteral("image")) {
+        validateImageNode(node, path, result);
+    }
+
+    if (nodeType == QStringLiteral("voiceBlock")) {
+        validateVoiceBlockNode(node, path, result);
+    }
+
+    validateMarks(node, path, result);
+
+    const QJsonValue contentValue = node.value(QStringLiteral("content"));
+    if (contentValue.isUndefined()) {
+        return;
+    }
+
+    if (!contentValue.isArray()) {
+        addError(result,
+                 path + QStringLiteral(".content"),
+                 QStringLiteral("invalid-content-array"),
+                 QStringLiteral("node content must be an array"));
+        return;
+    }
+
+    const QJsonArray content = contentValue.toArray();
+    for (int index = 0; index < content.size(); ++index) {
+        validateNode(content.at(index),
+                     QStringLiteral("%1.content[%2]").arg(path).arg(index),
+                     result,
+                     depth + 1);
+    }
+}
+
+void validateDocumentContent(const QJsonObject &content, MigrationJsonValidationResult &result)
+{
+    if (content.value(QStringLiteral("type")).toString() != QStringLiteral("doc")) {
+        return;
+    }
+
+    const QJsonValue docContent = content.value(QStringLiteral("content"));
+    if (!docContent.isArray()) {
+        addError(result,
+                 QStringLiteral("content.content"),
+                 QStringLiteral("invalid-content-array"),
+                 QStringLiteral("doc content must be an array"));
+        return;
+    }
+
+    if (docContent.toArray().isEmpty()) {
+        addError(result,
+                 QStringLiteral("content.content"),
+                 QStringLiteral("empty-doc-content"),
+                 QStringLiteral("empty documents must be persisted as one empty paragraph"));
+    }
+}
+
+} // namespace
+
+bool MigrationJsonValidationResult::ok() const
+{
+    return errors.isEmpty();
+}
+
+MigrationJsonValidationResult MigrationJsonValidator::validateEnvelope(const QJsonObject &envelope)
+{
+    MigrationJsonValidationResult result;
+
+    if (envelope.value(QStringLiteral("format")).toString() != QStringLiteral("tiptap")) {
+        addError(result,
+                 QStringLiteral("format"),
+                 QStringLiteral("invalid-format"),
+                 QStringLiteral("format must be tiptap"));
+    }
+
+    if (!isSchemaVersionV1(envelope.value(QStringLiteral("schemaVersion")))) {
+        addError(result,
+                 QStringLiteral("schemaVersion"),
+                 QStringLiteral("unsupported-schema-version"),
+                 QStringLiteral("schemaVersion must be 1"));
+    }
+
+    const QJsonValue contentValue = envelope.value(QStringLiteral("content"));
+    if (!contentValue.isObject()) {
+        addError(result,
+                 QStringLiteral("content"),
+                 QStringLiteral("invalid-content"),
+                 QStringLiteral("content must be a ProseMirror document object"));
+        return result;
+    }
+
+    const QJsonObject content = contentValue.toObject();
+    if (content.value(QStringLiteral("type")).toString() != QStringLiteral("doc")) {
+        addError(result,
+                 QStringLiteral("content.type"),
+                 QStringLiteral("invalid-root"),
+                 QStringLiteral("content.type must be doc"));
+    }
+
+    validateDocumentContent(content, result);
+    validateNode(contentValue, QStringLiteral("content"), result);
+
+    return result;
+}

--- a/src/importolddata/tiptapmigration/migrationjsonvalidator.h
+++ b/src/importolddata/tiptapmigration/migrationjsonvalidator.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONJSONVALIDATOR_H
+#define MIGRATIONJSONVALIDATOR_H
+
+#include <QJsonObject>
+#include <QString>
+#include <QVector>
+
+struct MigrationJsonValidationError {
+    QString path;
+    QString code;
+    QString message;
+};
+
+struct MigrationJsonValidationResult {
+    QVector<MigrationJsonValidationError> errors;
+
+    bool ok() const;
+};
+
+class MigrationJsonValidator
+{
+public:
+    static MigrationJsonValidationResult validateEnvelope(const QJsonObject &envelope);
+};
+
+#endif // MIGRATIONJSONVALIDATOR_H

--- a/tests/src/importolddata/tiptapmigration/ut_migrationjsonvalidator.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationjsonvalidator.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "importolddata/tiptapmigration/migrationjsonbuilder.h"
+#include "importolddata/tiptapmigration/migrationjsonvalidator.h"
+
+#include "gtest/gtest.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+
+namespace {
+
+QJsonArray arrayOf(const QJsonObject &object)
+{
+    return QJsonArray { object };
+}
+
+bool hasErrorCode(const MigrationJsonValidationResult &result, const QString &code)
+{
+    for (const MigrationJsonValidationError &error : result.errors) {
+        if (error.code == code) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool hasError(const MigrationJsonValidationResult &result, const QString &path, const QString &code)
+{
+    for (const MigrationJsonValidationError &error : result.errors) {
+        if (error.path == path && error.code == code) {
+            return true;
+        }
+    }
+    return false;
+}
+
+QJsonObject envelopeWithSingleNode(const QJsonObject &node)
+{
+    return MigrationJsonBuilder::makeEnvelope(MigrationJsonBuilder::makeDoc(arrayOf(node)));
+}
+
+QJsonObject imageNode(const QString &src)
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("src"), src);
+
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("image"));
+    node.insert(QStringLiteral("attrs"), attrs);
+    return node;
+}
+
+} // namespace
+
+TEST(UT_MigrationJsonValidator, AcceptsBuilderGeneratedEnvelope)
+{
+    const QJsonObject paragraph = MigrationJsonBuilder::makeParagraph(
+        arrayOf(MigrationJsonBuilder::makeText(QStringLiteral("重点内容"),
+                                               QJsonArray { MigrationJsonBuilder::makeMark(QStringLiteral("bold")) })));
+    const QJsonObject image = MigrationJsonBuilder::makeImage(QStringLiteral("images/photo.png"),
+                                                              QStringLiteral("images/photo.png"));
+    const QJsonObject voiceBlock = MigrationJsonBuilder::makeVoiceBlock(
+        QStringLiteral("voice-uuid"),
+        QStringLiteral("voicenote/20260717-100000.mp3"),
+        120000,
+        QStringLiteral("2026-07-17 10:00:00"),
+        QStringLiteral("录音"),
+        QStringLiteral("转写文本"));
+    const QJsonObject taskItem = MigrationJsonBuilder::makeTaskItem(
+        false,
+        arrayOf(MigrationJsonBuilder::makeParagraph(arrayOf(MigrationJsonBuilder::makeText(QStringLiteral("待办"))))));
+    const QJsonObject envelope = MigrationJsonBuilder::makeEnvelope(
+        MigrationJsonBuilder::makeDoc(QJsonArray { paragraph, image, voiceBlock, MigrationJsonBuilder::makeTaskList(arrayOf(taskItem)) }));
+
+    const MigrationJsonValidationResult result = MigrationJsonValidator::validateEnvelope(envelope);
+
+    EXPECT_TRUE(result.ok()) << result.errors.value(0).code.toStdString();
+}
+
+TEST(UT_MigrationJsonValidator, RejectsInvalidEnvelopeFields)
+{
+    QJsonObject envelope = MigrationJsonBuilder::makeEnvelope();
+    envelope.insert(QStringLiteral("format"), QStringLiteral("tiptap-json"));
+    envelope.insert(QStringLiteral("schemaVersion"), 2);
+    envelope.insert(QStringLiteral("content"), QStringLiteral("not-doc"));
+
+    const MigrationJsonValidationResult result = MigrationJsonValidator::validateEnvelope(envelope);
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(hasError(result, QStringLiteral("format"), QStringLiteral("invalid-format")));
+    EXPECT_TRUE(hasError(result, QStringLiteral("schemaVersion"), QStringLiteral("unsupported-schema-version")));
+    EXPECT_TRUE(hasError(result, QStringLiteral("content"), QStringLiteral("invalid-content")));
+}
+
+TEST(UT_MigrationJsonValidator, RejectsInvalidRootAndEmptyDocContent)
+{
+    const MigrationJsonValidationResult invalidRoot = MigrationJsonValidator::validateEnvelope(
+        MigrationJsonBuilder::makeEnvelope(MigrationJsonBuilder::makeParagraph()));
+
+    QJsonObject emptyDoc;
+    emptyDoc.insert(QStringLiteral("type"), QStringLiteral("doc"));
+    emptyDoc.insert(QStringLiteral("content"), QJsonArray());
+    const MigrationJsonValidationResult emptyDocResult = MigrationJsonValidator::validateEnvelope(
+        MigrationJsonBuilder::makeEnvelope(emptyDoc));
+
+    EXPECT_FALSE(invalidRoot.ok());
+    EXPECT_TRUE(hasError(invalidRoot, QStringLiteral("content.type"), QStringLiteral("invalid-root")));
+    EXPECT_FALSE(emptyDocResult.ok());
+    EXPECT_TRUE(hasError(emptyDocResult, QStringLiteral("content.content"), QStringLiteral("empty-doc-content")));
+}
+
+TEST(UT_MigrationJsonValidator, RejectsUnsupportedNodesAndMarks)
+{
+    QJsonObject unknownMark;
+    unknownMark.insert(QStringLiteral("type"), QStringLiteral("blink"));
+
+    QJsonObject text = MigrationJsonBuilder::makeText(QStringLiteral("文本"), QJsonArray { unknownMark });
+    QJsonObject unknownNode;
+    unknownNode.insert(QStringLiteral("type"), QStringLiteral("unknownNode"));
+
+    const QJsonObject envelope = MigrationJsonBuilder::makeEnvelope(
+        MigrationJsonBuilder::makeDoc(QJsonArray { text, unknownNode }));
+    const MigrationJsonValidationResult result = MigrationJsonValidator::validateEnvelope(envelope);
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[0].marks[0].type"), QStringLiteral("unsupported-mark")));
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[1].type"), QStringLiteral("unsupported-node")));
+}
+
+TEST(UT_MigrationJsonValidator, RejectsInvalidVoiceBlockPersistence)
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("voiceId"), QStringLiteral("  "));
+    attrs.insert(QStringLiteral("voicePath"), QStringLiteral(""));
+    attrs.insert(QStringLiteral("voiceSize"), -1);
+    attrs.insert(QStringLiteral("translating"), false);
+
+    QJsonObject voiceBlock;
+    voiceBlock.insert(QStringLiteral("type"), QStringLiteral("voiceBlock"));
+    voiceBlock.insert(QStringLiteral("attrs"), attrs);
+
+    const MigrationJsonValidationResult result = MigrationJsonValidator::validateEnvelope(envelopeWithSingleNode(voiceBlock));
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[0].attrs.voiceId"), QStringLiteral("invalid-voice-id")));
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[0].attrs.voicePath"), QStringLiteral("invalid-voice-path")));
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[0].attrs.voiceSize"), QStringLiteral("invalid-voice-size")));
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[0].attrs.translating"), QStringLiteral("runtime-state-persisted")));
+}
+
+TEST(UT_MigrationJsonValidator, RejectsUnsafeImageSrcs)
+{
+    const QStringList unsafeSrcs = {
+        QStringLiteral(""),
+        QStringLiteral("javascript:alert(1)"),
+        QStringLiteral("java\tscript:alert(1)"),
+        QStringLiteral("data \n:text/html,<script>alert(1)</script>"),
+        QStringLiteral("vbscript\r:msgbox(1)"),
+        QStringLiteral("file:///etc/passwd"),
+        QStringLiteral("mailto:test@example.com"),
+        QStringLiteral("//example.com/protocol-relative.png"),
+        QStringLiteral("\\\\example.com\\share.png"),
+    };
+
+    for (const QString &src : unsafeSrcs) {
+        const MigrationJsonValidationResult result = MigrationJsonValidator::validateEnvelope(envelopeWithSingleNode(imageNode(src)));
+        EXPECT_FALSE(result.ok()) << src.toStdString();
+        EXPECT_TRUE(hasErrorCode(result, src.isEmpty() ? QStringLiteral("invalid-image-src") : QStringLiteral("unsafe-image-src")))
+            << src.toStdString();
+    }
+}
+
+TEST(UT_MigrationJsonValidator, AcceptsSafeImageSrcs)
+{
+    const QStringList safeSrcs = {
+        QStringLiteral("https://example.com/photo.png"),
+        QStringLiteral("http://example.com/photo.png"),
+        QStringLiteral(" HTTP ://example.com/photo.png"),
+        QStringLiteral("images/photo.png"),
+        QStringLiteral("./images/photo.png"),
+    };
+
+    for (const QString &src : safeSrcs) {
+        const MigrationJsonValidationResult result = MigrationJsonValidator::validateEnvelope(envelopeWithSingleNode(imageNode(src)));
+        EXPECT_TRUE(result.ok()) << src.toStdString();
+    }
+}
+
+TEST(UT_MigrationJsonValidator, RejectsInvalidNodeShapes)
+{
+    QJsonObject text;
+    text.insert(QStringLiteral("type"), QStringLiteral("text"));
+
+    QJsonObject heading;
+    heading.insert(QStringLiteral("type"), QStringLiteral("heading"));
+    heading.insert(QStringLiteral("attrs"), QJsonObject { { QStringLiteral("level"), 7 } });
+
+    QJsonObject paragraph;
+    paragraph.insert(QStringLiteral("type"), QStringLiteral("paragraph"));
+    paragraph.insert(QStringLiteral("content"), QStringLiteral("not-array"));
+
+    const MigrationJsonValidationResult result = MigrationJsonValidator::validateEnvelope(
+        MigrationJsonBuilder::makeEnvelope(MigrationJsonBuilder::makeDoc(QJsonArray { text, heading, paragraph })));
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[0].text"), QStringLiteral("invalid-text")));
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[1].attrs.level"), QStringLiteral("invalid-heading-level")));
+    EXPECT_TRUE(hasError(result, QStringLiteral("content.content[2].content"), QStringLiteral("invalid-content-array")));
+}
+
+TEST(UT_MigrationJsonValidator, RejectsDocumentsBeyondMaximumNodeDepth)
+{
+    QJsonObject node = MigrationJsonBuilder::makeParagraph();
+    for (int index = 0; index < 120; ++index) {
+        QJsonObject wrapper;
+        wrapper.insert(QStringLiteral("type"), QStringLiteral("blockquote"));
+        wrapper.insert(QStringLiteral("content"), QJsonArray { node });
+        node = wrapper;
+    }
+
+    const MigrationJsonValidationResult result = MigrationJsonValidator::validateEnvelope(envelopeWithSingleNode(node));
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(hasErrorCode(result, QStringLiteral("max-node-depth-exceeded")));
+}


### PR DESCRIPTION
## Summary
- Add `MigrationJsonValidator` for Schema V1 envelope validation in C++.
- Validate envelope fields, document root/content, node and mark names.
- Reject invalid voiceBlock persistence fields and unsafe image src schemes.
- Add focused unit tests for valid builder output and invalid payloads.

## Validation
- `UT_MigrationJsonBuilder.*:UT_MigrationJsonValidator.*`: 17/17 passed
- `npm test --prefix web-editor`: 18/18 passed

Closes V-245
