### PR TITLE
V-246: add HTML parser adapter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ else()
 endif()
 
 find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
 
 # 保证 src 目录下头文件全局可见
 include_directories(src)
@@ -39,6 +40,7 @@ include_directories(./importolddata/tiptapmigration)
 include_directories(./db)
 include_directories(./handler)
 include_directories(./audio)
+include_directories(${LIBXML2_INCLUDE_DIRS})
 
 aux_source_directory(./ ALLSOURCE)
 aux_source_directory(./dbusservice ALLSOURCE)
@@ -97,6 +99,7 @@ endif()
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
 include_directories(${GSTREAMER_INCLUDE_DIRS})
 target_link_libraries(${BIN_NAME} PRIVATE ${GSTREAMER_LIBRARIES})
+target_link_libraries(${BIN_NAME} PRIVATE ${LIBXML2_LIBRARIES})
 
 # Add install rule
 install(TARGETS ${BIN_NAME} DESTINATION ${APP_BIN_INSTALL_DIR})

--- a/src/importolddata/tiptapmigration/migrationhtmlparser.cpp
+++ b/src/importolddata/tiptapmigration/migrationhtmlparser.cpp
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationhtmlparser.h"
+
+#include <libxml/HTMLparser.h>
+#include <libxml/tree.h>
+
+#include <QByteArray>
+#include <QRegularExpression>
+#include <QSet>
+#include <QStringList>
+
+#include <memory>
+
+namespace {
+constexpr int kMaxHtmlNodeDepth = 100;
+
+struct HtmlDocDeleter {
+    void operator()(htmlDocPtr doc) const
+    {
+        if (doc) {
+            xmlFreeDoc(doc);
+        }
+    }
+};
+
+using HtmlDocPtr = std::unique_ptr<xmlDoc, HtmlDocDeleter>;
+
+const QSet<QString> &dangerousTags()
+{
+    static const QSet<QString> tags {
+        QStringLiteral("script"),
+        QStringLiteral("iframe"),
+        QStringLiteral("object"),
+        QStringLiteral("embed")
+    };
+    return tags;
+}
+
+QString xmlStringToQString(const xmlChar *value)
+{
+    if (!value) {
+        return QString();
+    }
+
+    return QString::fromUtf8(reinterpret_cast<const char *>(value));
+}
+
+QString nodeName(xmlNodePtr node)
+{
+    if (!node || !node->name) {
+        return QString();
+    }
+
+    return xmlStringToQString(node->name).toLower();
+}
+
+QString nodeContent(xmlNodePtr node)
+{
+    xmlChar *content = xmlNodeGetContent(node);
+    const QString result = xmlStringToQString(content);
+    if (content) {
+        xmlFree(content);
+    }
+    return result;
+}
+
+QString attributeValue(xmlNodePtr node, xmlAttrPtr attribute)
+{
+    if (!node || !attribute || !attribute->children) {
+        return QString();
+    }
+
+    xmlChar *value = xmlNodeListGetString(node->doc, attribute->children, 1);
+    const QString result = xmlStringToQString(value);
+    if (value) {
+        xmlFree(value);
+    }
+    return result;
+}
+
+QMap<QString, QString> attributesFor(xmlNodePtr node)
+{
+    QMap<QString, QString> attributes;
+    for (xmlAttrPtr attribute = node->properties; attribute; attribute = attribute->next) {
+        if (!attribute->name) {
+            continue;
+        }
+
+        const QString name = xmlStringToQString(attribute->name).toLower();
+        attributes.insert(name, attributeValue(node, attribute));
+    }
+    return attributes;
+}
+
+QString childPath(const QString &parentPath, const QString &name, int index)
+{
+    return parentPath + QStringLiteral("/") + name + QStringLiteral("[") + QString::number(index) + QStringLiteral("]");
+}
+
+bool isBlockElement(const QString &tagName)
+{
+    static const QSet<QString> blockTags {
+        QStringLiteral("address"),
+        QStringLiteral("article"),
+        QStringLiteral("aside"),
+        QStringLiteral("blockquote"),
+        QStringLiteral("dd"),
+        QStringLiteral("div"),
+        QStringLiteral("dl"),
+        QStringLiteral("dt"),
+        QStringLiteral("figcaption"),
+        QStringLiteral("figure"),
+        QStringLiteral("footer"),
+        QStringLiteral("h1"),
+        QStringLiteral("h2"),
+        QStringLiteral("h3"),
+        QStringLiteral("h4"),
+        QStringLiteral("h5"),
+        QStringLiteral("h6"),
+        QStringLiteral("header"),
+        QStringLiteral("hr"),
+        QStringLiteral("li"),
+        QStringLiteral("main"),
+        QStringLiteral("ol"),
+        QStringLiteral("p"),
+        QStringLiteral("pre"),
+        QStringLiteral("section"),
+        QStringLiteral("table"),
+        QStringLiteral("td"),
+        QStringLiteral("th"),
+        QStringLiteral("tr"),
+        QStringLiteral("ul")
+    };
+    return blockTags.contains(tagName);
+}
+
+void appendLineBreak(QString *plainText)
+{
+    while (plainText->endsWith(QLatin1Char(' '))) {
+        plainText->chop(1);
+    }
+
+    if (!plainText->isEmpty() && !plainText->endsWith(QLatin1Char('\n'))) {
+        plainText->append(QLatin1Char('\n'));
+    }
+}
+
+void appendText(const QString &text, QString *plainText)
+{
+    bool pendingSpace = false;
+    for (const QChar &character : text) {
+        if (character.isSpace()) {
+            pendingSpace = true;
+            continue;
+        }
+
+        if (pendingSpace && !plainText->isEmpty()
+            && !plainText->endsWith(QLatin1Char(' '))
+            && !plainText->endsWith(QLatin1Char('\n'))) {
+            plainText->append(QLatin1Char(' '));
+        }
+
+        plainText->append(character);
+        pendingSpace = false;
+    }
+
+    if (pendingSpace && !plainText->isEmpty()
+        && !plainText->endsWith(QLatin1Char(' '))
+        && !plainText->endsWith(QLatin1Char('\n'))) {
+        plainText->append(QLatin1Char(' '));
+    }
+}
+
+void appendPlainText(const MigrationHtmlNode &node, QString *plainText, int depth = 0)
+{
+    if (depth > kMaxHtmlNodeDepth) {
+        return;
+    }
+
+    if (node.type == MigrationHtmlNodeType::Text) {
+        appendText(node.text, plainText);
+        return;
+    }
+
+    if (node.type == MigrationHtmlNodeType::Element && dangerousTags().contains(node.tagName)) {
+        return;
+    }
+
+    if (node.type == MigrationHtmlNodeType::Element && node.tagName == QStringLiteral("br")) {
+        appendLineBreak(plainText);
+        return;
+    }
+
+    const bool block = node.type == MigrationHtmlNodeType::Element && isBlockElement(node.tagName);
+    if (block) {
+        appendLineBreak(plainText);
+    }
+
+    for (const MigrationHtmlNode &child : node.children) {
+        appendPlainText(child, plainText, depth + 1);
+    }
+
+    if (block) {
+        appendLineBreak(plainText);
+    }
+}
+
+MigrationHtmlNode convertNode(xmlNodePtr node,
+                              const QString &path,
+                              QVector<MigrationHtmlParseWarning> *warnings,
+                              int depth = 0)
+{
+    MigrationHtmlNode converted;
+
+    if (node->type == XML_TEXT_NODE || node->type == XML_CDATA_SECTION_NODE) {
+        converted.type = MigrationHtmlNodeType::Text;
+        converted.text = nodeContent(node);
+        return converted;
+    }
+
+    converted.type = MigrationHtmlNodeType::Element;
+    converted.tagName = nodeName(node);
+    converted.attributes = attributesFor(node);
+
+    if (depth > kMaxHtmlNodeDepth) {
+        warnings->append(MigrationHtmlParseWarning {
+            path,
+            QStringLiteral("depth-exceeded"),
+            QStringLiteral("HTML node depth must not exceed %1.").arg(kMaxHtmlNodeDepth)
+        });
+        return converted;
+    }
+
+    if (dangerousTags().contains(converted.tagName)) {
+        warnings->append(MigrationHtmlParseWarning {
+            path,
+            QStringLiteral("dangerous-html-node"),
+            QStringLiteral("Dangerous HTML node should be downgraded by migration converter.")
+        });
+    }
+
+    int elementIndex = 0;
+    for (xmlNodePtr child = node->children; child; child = child->next) {
+        if (child->type == XML_TEXT_NODE || child->type == XML_CDATA_SECTION_NODE) {
+            MigrationHtmlNode textNode;
+            textNode.type = MigrationHtmlNodeType::Text;
+            textNode.text = nodeContent(child);
+            converted.children.append(textNode);
+            continue;
+        }
+
+        if (child->type != XML_ELEMENT_NODE) {
+            continue;
+        }
+
+        const QString tagName = nodeName(child);
+        converted.children.append(convertNode(child, childPath(path, tagName, elementIndex), warnings, depth + 1));
+        ++elementIndex;
+    }
+
+    return converted;
+}
+
+xmlNodePtr firstElementChildByName(xmlNodePtr node, const QString &name)
+{
+    for (xmlNodePtr child = node ? node->children : nullptr; child; child = child->next) {
+        if (child->type == XML_ELEMENT_NODE && nodeName(child) == name) {
+            return child;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+bool MigrationHtmlParseResult::ok() const
+{
+    for (const MigrationHtmlParseWarning &warning : warnings) {
+        if (warning.code == QStringLiteral("parse-failed")) {
+            return false;
+        }
+    }
+    return true;
+}
+
+MigrationHtmlParseResult MigrationHtmlParser::parse(const QString &html)
+{
+    MigrationHtmlParseResult result;
+    result.root.type = MigrationHtmlNodeType::Document;
+    result.root.tagName = QStringLiteral("#document");
+
+    if (html.isEmpty()) {
+        return result;
+    }
+
+    const QByteArray bytes = html.toUtf8();
+    HtmlDocPtr doc(htmlReadMemory(bytes.constData(),
+                                  bytes.size(),
+                                  "migration-html.html",
+                                  "UTF-8",
+                                  HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET));
+    if (!doc) {
+        result.warnings.append(MigrationHtmlParseWarning {
+            QStringLiteral("/"),
+            QStringLiteral("parse-failed"),
+            QStringLiteral("Failed to parse legacy HTML.")
+        });
+        result.plainText = html;
+        return result;
+    }
+
+    xmlNodePtr root = xmlDocGetRootElement(doc.get());
+    xmlNodePtr body = firstElementChildByName(root, QStringLiteral("body"));
+    xmlNodePtr parseRoot = body ? body : root;
+
+    int elementIndex = 0;
+    for (xmlNodePtr child = parseRoot ? parseRoot->children : nullptr; child; child = child->next) {
+        if (child->type == XML_TEXT_NODE || child->type == XML_CDATA_SECTION_NODE) {
+            MigrationHtmlNode textNode;
+            textNode.type = MigrationHtmlNodeType::Text;
+            textNode.text = nodeContent(child);
+            result.root.children.append(textNode);
+            continue;
+        }
+
+        if (child->type != XML_ELEMENT_NODE) {
+            continue;
+        }
+
+        const QString tagName = nodeName(child);
+        result.root.children.append(convertNode(
+            child, childPath(QStringLiteral("/document"), tagName, elementIndex), &result.warnings));
+        ++elementIndex;
+    }
+
+    appendPlainText(result.root, &result.plainText);
+    return result;
+}
+
+QString MigrationHtmlParser::attribute(const MigrationHtmlNode &node, const QString &name)
+{
+    return node.attributes.value(name.toLower());
+}
+
+bool MigrationHtmlParser::hasClass(const MigrationHtmlNode &node, const QString &className)
+{
+    static const QRegularExpression classSeparator(QStringLiteral("\\s+"));
+    const QStringList classes = attribute(node, QStringLiteral("class")).split(classSeparator, Qt::SkipEmptyParts);
+    return classes.contains(className, Qt::CaseInsensitive);
+}

--- a/src/importolddata/tiptapmigration/migrationhtmlparser.h
+++ b/src/importolddata/tiptapmigration/migrationhtmlparser.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONHTMLPARSER_H
+#define MIGRATIONHTMLPARSER_H
+
+#include <QMap>
+#include <QString>
+#include <QVector>
+
+enum class MigrationHtmlNodeType {
+    Document,
+    Element,
+    Text
+};
+
+struct MigrationHtmlAttribute {
+    QString name;
+    QString value;
+};
+
+struct MigrationHtmlNode {
+    MigrationHtmlNodeType type = MigrationHtmlNodeType::Document;
+    QString tagName;
+    QString text;
+    QMap<QString, QString> attributes;
+    QVector<MigrationHtmlNode> children;
+};
+
+// Dangerous nodes are kept in the parsed tree for converter-level downgrade
+// decisions, while fallback plain text deliberately skips their content.
+struct MigrationHtmlParseWarning {
+    QString path;
+    QString code;
+    QString message;
+};
+
+struct MigrationHtmlParseResult {
+    MigrationHtmlNode root;
+    QString plainText;
+    QVector<MigrationHtmlParseWarning> warnings;
+
+    bool ok() const;
+};
+
+class MigrationHtmlParser
+{
+public:
+    static MigrationHtmlParseResult parse(const QString &html);
+    static QString attribute(const MigrationHtmlNode &node, const QString &name);
+    static bool hasClass(const MigrationHtmlNode &node, const QString &className);
+};
+
+#endif // MIGRATIONHTMLPARSER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,10 @@ find_package(Qt5Test REQUIRED)
 find_package(GTest REQUIRED)
 find_package(Qt5Svg REQUIRED)
 find_package(Qt5Xml REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
 include_directories(${GTEST_INCLUDE_DIRS})
+include_directories(${LIBXML2_INCLUDE_DIRS})
 include_directories(src)
 
 set(PROJECT_NAME_TEST
@@ -93,6 +96,7 @@ target_link_libraries(${PROJECT_NAME_TEST}
     Qt5::WebEngineWidgets
     ${Qt5Svg_LIBRARIES}
     ${Qt5Xml_LIBRARIES}
+    ${LIBXML2_LIBRARIES}
 )
 
 ##------------------------------ 创建'make test'指令---------------------------------------
@@ -104,4 +108,3 @@ add_custom_target(test
 
 ##'make test'命令依赖与我们的测试程序
 add_dependencies(test ${PROJECT_NAME_TEST})
-

--- a/tests/src/importolddata/tiptapmigration/ut_migrationhtmlparser.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationhtmlparser.cpp
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "importolddata/tiptapmigration/migrationhtmlparser.h"
+
+#include <gtest/gtest.h>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace {
+
+const MigrationHtmlNode *findFirstByTag(const MigrationHtmlNode &node, const QString &tagName)
+{
+    if (node.type == MigrationHtmlNodeType::Element && node.tagName == tagName) {
+        return &node;
+    }
+
+    for (const MigrationHtmlNode &child : node.children) {
+        const MigrationHtmlNode *found = findFirstByTag(child, tagName);
+        if (found) {
+            return found;
+        }
+    }
+
+    return nullptr;
+}
+
+int countByTag(const MigrationHtmlNode &node, const QString &tagName)
+{
+    int count = node.type == MigrationHtmlNodeType::Element && node.tagName == tagName ? 1 : 0;
+    for (const MigrationHtmlNode &child : node.children) {
+        count += countByTag(child, tagName);
+    }
+    return count;
+}
+
+bool hasWarningCode(const MigrationHtmlParseResult &result, const QString &code)
+{
+    for (const MigrationHtmlParseWarning &warning : result.warnings) {
+        if (warning.code == code) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int countTextNodes(const MigrationHtmlNode &node)
+{
+    int count = node.type == MigrationHtmlNodeType::Text ? 1 : 0;
+    for (const MigrationHtmlNode &child : node.children) {
+        count += countTextNodes(child);
+    }
+    return count;
+}
+
+} // namespace
+
+TEST(UT_MigrationHtmlParser, PreservesStyleEntityAndUnicodeText)
+{
+    const MigrationHtmlParseResult result = MigrationHtmlParser::parse(
+        QStringLiteral("<p style=\"font-weight:bold;color:#ff0000\">"
+                       "<span style=\"font-size:18px\">Hello&nbsp;中文🙂</span></p>"));
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(result.warnings.isEmpty());
+    EXPECT_TRUE(result.plainText.contains(QStringLiteral("Hello")));
+    EXPECT_TRUE(result.plainText.contains(QStringLiteral("中文🙂")));
+
+    const MigrationHtmlNode *paragraph = findFirstByTag(result.root, QStringLiteral("p"));
+    ASSERT_NE(nullptr, paragraph);
+    EXPECT_EQ(QStringLiteral("font-weight:bold;color:#ff0000"),
+              MigrationHtmlParser::attribute(*paragraph, QStringLiteral("style")));
+
+    const MigrationHtmlNode *span = findFirstByTag(result.root, QStringLiteral("span"));
+    ASSERT_NE(nullptr, span);
+    EXPECT_EQ(QStringLiteral("font-size:18px"), MigrationHtmlParser::attribute(*span, QStringLiteral("style")));
+}
+
+TEST(UT_MigrationHtmlParser, PreservesImageAttributes)
+{
+    const MigrationHtmlParseResult result = MigrationHtmlParser::parse(
+        QStringLiteral("<p><img src=\"/home/u/images/a.png\" data-rel-path=\"images/a.png\" "
+                       "alt=\"preview\" title=\"photo\"></p>"));
+
+    EXPECT_TRUE(result.ok());
+    const MigrationHtmlNode *image = findFirstByTag(result.root, QStringLiteral("img"));
+    ASSERT_NE(nullptr, image);
+    EXPECT_EQ(QStringLiteral("/home/u/images/a.png"), MigrationHtmlParser::attribute(*image, QStringLiteral("src")));
+    EXPECT_EQ(QStringLiteral("images/a.png"), MigrationHtmlParser::attribute(*image, QStringLiteral("data-rel-path")));
+    EXPECT_EQ(QStringLiteral("preview"), MigrationHtmlParser::attribute(*image, QStringLiteral("alt")));
+    EXPECT_EQ(QStringLiteral("photo"), MigrationHtmlParser::attribute(*image, QStringLiteral("title")));
+}
+
+TEST(UT_MigrationHtmlParser, PreservesVoiceBoxJsonKeyCaseInsensitively)
+{
+    const QString jsonKey = QStringLiteral(
+        "{&quot;voiceId&quot;:&quot;v1&quot;,&quot;voicePath&quot;:&quot;voicenote/a.mp3&quot;,&quot;text&quot;:&quot;你好&quot;}");
+    const MigrationHtmlParseResult result = MigrationHtmlParser::parse(
+        QStringLiteral("<div class=\"li voiceBox\" contenteditable=\"false\" jsonKey=\"%1\">"
+                       "<span>00:01</span></div>")
+            .arg(jsonKey));
+
+    EXPECT_TRUE(result.ok());
+    const MigrationHtmlNode *voiceBox = findFirstByTag(result.root, QStringLiteral("div"));
+    ASSERT_NE(nullptr, voiceBox);
+    EXPECT_TRUE(MigrationHtmlParser::hasClass(*voiceBox, QStringLiteral("voiceBox")));
+    EXPECT_FALSE(MigrationHtmlParser::hasClass(*voiceBox, QStringLiteral("missingClass")));
+    EXPECT_EQ(QStringLiteral("false"), MigrationHtmlParser::attribute(*voiceBox, QStringLiteral("contentEditable")));
+    EXPECT_TRUE(MigrationHtmlParser::attribute(*voiceBox, QStringLiteral("missing-attr")).isEmpty());
+
+    const QString storedJsonKey = MigrationHtmlParser::attribute(*voiceBox, QStringLiteral("jsonKey"));
+    EXPECT_TRUE(storedJsonKey.contains(QStringLiteral("\"voiceId\":\"v1\"")));
+    EXPECT_TRUE(storedJsonKey.contains(QStringLiteral("\"voicePath\":\"voicenote/a.mp3\"")));
+
+    const QJsonDocument parsed = QJsonDocument::fromJson(storedJsonKey.toUtf8());
+    ASSERT_TRUE(parsed.isObject());
+    EXPECT_EQ(QStringLiteral("你好"), parsed.object().value(QStringLiteral("text")).toString());
+}
+
+TEST(UT_MigrationHtmlParser, PreservesNestedListHierarchy)
+{
+    const MigrationHtmlParseResult result = MigrationHtmlParser::parse(
+        QStringLiteral("<ol><li>one<ul><li>child</li></ul></li><li>two</li></ol>"));
+
+    EXPECT_TRUE(result.ok());
+    const MigrationHtmlNode *orderedList = findFirstByTag(result.root, QStringLiteral("ol"));
+    ASSERT_NE(nullptr, orderedList);
+    EXPECT_EQ(3, countByTag(*orderedList, QStringLiteral("li")));
+
+    const MigrationHtmlNode *nestedList = findFirstByTag(*orderedList, QStringLiteral("ul"));
+    ASSERT_NE(nullptr, nestedList);
+    EXPECT_EQ(1, countByTag(*nestedList, QStringLiteral("li")));
+    EXPECT_TRUE(result.plainText.contains(QStringLiteral("one")));
+    EXPECT_TRUE(result.plainText.contains(QStringLiteral("child")));
+    EXPECT_TRUE(result.plainText.contains(QStringLiteral("two")));
+}
+
+TEST(UT_MigrationHtmlParser, PreservesInlineWhitespaceAndBlockPlainTextBoundaries)
+{
+    const MigrationHtmlParseResult inlineResult = MigrationHtmlParser::parse(
+        QStringLiteral("<span>A</span> <span>B</span>"));
+
+    EXPECT_TRUE(inlineResult.ok());
+    EXPECT_EQ(QStringLiteral("A B"), inlineResult.plainText);
+    EXPECT_EQ(3, countTextNodes(inlineResult.root));
+
+    const MigrationHtmlParseResult blockResult = MigrationHtmlParser::parse(
+        QStringLiteral("<p>C</p><p>D</p><div>E<br>F</div>"));
+
+    EXPECT_TRUE(blockResult.ok());
+    EXPECT_EQ(QStringLiteral("C\nD\nE\nF\n"), blockResult.plainText);
+}
+
+TEST(UT_MigrationHtmlParser, RecoversInvalidHtmlAndWarnsDangerousNodes)
+{
+    const MigrationHtmlParseResult result = MigrationHtmlParser::parse(
+        QStringLiteral("<div><p>broken<span>still text</div><script>alert(1)</script>tail"));
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(result.plainText.contains(QStringLiteral("broken")));
+    EXPECT_TRUE(result.plainText.contains(QStringLiteral("still text")));
+    EXPECT_TRUE(result.plainText.contains(QStringLiteral("tail")));
+    EXPECT_FALSE(result.plainText.contains(QStringLiteral("alert(1)")));
+    EXPECT_NE(nullptr, findFirstByTag(result.root, QStringLiteral("script")));
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("dangerous-html-node")));
+}
+
+TEST(UT_MigrationHtmlParser, WarnsAndStopsAtExcessiveDepth)
+{
+    QString html;
+    for (int index = 0; index < 105; ++index) {
+        html.append(QStringLiteral("<div>"));
+    }
+    html.append(QStringLiteral("leaf"));
+    for (int index = 0; index < 105; ++index) {
+        html.append(QStringLiteral("</div>"));
+    }
+
+    const MigrationHtmlParseResult result = MigrationHtmlParser::parse(html);
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("depth-exceeded")));
+}
+
+TEST(UT_MigrationHtmlParser, HandlesEmptyAndPlainTextInputs)
+{
+    const MigrationHtmlParseResult empty = MigrationHtmlParser::parse(QString());
+    EXPECT_TRUE(empty.ok());
+    EXPECT_TRUE(empty.root.children.isEmpty());
+    EXPECT_TRUE(empty.plainText.isEmpty());
+
+    const MigrationHtmlParseResult plain = MigrationHtmlParser::parse(QStringLiteral("plain 中文🙂"));
+    EXPECT_TRUE(plain.ok());
+    EXPECT_TRUE(plain.plainText.contains(QStringLiteral("plain 中文🙂")));
+}


### PR DESCRIPTION
## Summary
- Add a libxml2 based HTML parser adapter for legacy note migration.
- Preserve DOM structure, attributes, whitespace, block boundaries, image paths and voice jsonkey.
- Add parser tests covering entities, images, voiceBox/jsonKey, nested lists, invalid HTML, dangerous nodes and whitespace boundaries.
- Wire libxml2 include/link settings for application and test builds.

## Validation
- `UT_MigrationHtmlParser.*`: 7/7 passed
- `UT_MigrationJsonBuilder.*:UT_MigrationJsonValidator.*:UT_MigrationHtmlParser.*`: 24/24 passed
- `cmake --build build --target deepin-voice-note -j2`: passed
- `npm test --prefix web-editor`: 18/18 passed

Closes V-246
