### PR TITLE
feat(migration): convert noteDatas text blocks

### DIFF
--- a/src/importolddata/tiptapmigration/migrationnotedataconverter.cpp
+++ b/src/importolddata/tiptapmigration/migrationnotedataconverter.cpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationnotedataconverter.h"
+
+#include "migrationjsonbuilder.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QStringList>
+
+namespace {
+constexpr int kTextBlockType = 1;
+
+void addError(MigrationNoteDataConversionResult &result,
+              const QString &path,
+              const QString &code,
+              const QString &message)
+{
+    result.errors.append({ path, code, message });
+}
+
+void addWarning(MigrationNoteDataConversionResult &result,
+                const QString &path,
+                const QString &code,
+                const QString &message)
+{
+    result.warnings.append({ path, code, message });
+}
+
+QString blockPath(int index)
+{
+    return QStringLiteral("noteDatas[%1]").arg(index);
+}
+
+QString normalizedNewlines(QString text)
+{
+    text.replace(QStringLiteral("\r\n"), QStringLiteral("\n"));
+    text.replace(QLatin1Char('\r'), QLatin1Char('\n'));
+    return text;
+}
+
+QJsonObject paragraphFromText(const QString &text)
+{
+    if (text.isEmpty()) {
+        return MigrationJsonBuilder::makeParagraph();
+    }
+
+    QJsonArray content;
+    QStringList lines = normalizedNewlines(text).split(QLatin1Char('\n'), Qt::KeepEmptyParts);
+    while (lines.size() > 1 && lines.constLast().isEmpty()) {
+        lines.removeLast();
+    }
+
+    for (int index = 0; index < lines.size(); ++index) {
+        if (!lines.at(index).isEmpty()) {
+            content.append(MigrationJsonBuilder::makeText(lines.at(index)));
+        }
+
+        if (index != lines.size() - 1) {
+            content.append(MigrationJsonBuilder::makeHardBreak());
+        }
+    }
+
+    return MigrationJsonBuilder::makeParagraph(content);
+}
+
+} // namespace
+
+bool MigrationNoteDataConversionResult::ok() const
+{
+    return errors.isEmpty();
+}
+
+MigrationNoteDataConversionResult MigrationNoteDataConverter::convertTextBlocks(const QString &metadataJson)
+{
+    MigrationNoteDataConversionResult result;
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(metadataJson.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        addError(result,
+                 QStringLiteral("/"),
+                 QStringLiteral("invalid-json"),
+                 QStringLiteral("legacy noteDatas metadata must be a JSON object"));
+        return result;
+    }
+
+    return convertTextBlocks(document.object());
+}
+
+MigrationNoteDataConversionResult MigrationNoteDataConverter::convertTextBlocks(const QJsonObject &metadata)
+{
+    MigrationNoteDataConversionResult result;
+
+    const QJsonValue noteDatasValue = metadata.value(QStringLiteral("noteDatas"));
+    if (!noteDatasValue.isArray()) {
+        addError(result,
+                 QStringLiteral("noteDatas"),
+                 QStringLiteral("invalid-note-datas"),
+                 QStringLiteral("legacy noteDatas metadata requires a noteDatas array"));
+        return result;
+    }
+
+    QJsonArray docContent;
+    const QJsonArray noteDatas = noteDatasValue.toArray();
+    for (int index = 0; index < noteDatas.size(); ++index) {
+        const QString path = blockPath(index);
+        const QJsonValue blockValue = noteDatas.at(index);
+        if (!blockValue.isObject()) {
+            addWarning(result,
+                       path,
+                       QStringLiteral("invalid-note-data-block"),
+                       QStringLiteral("legacy noteDatas block must be an object and was skipped"));
+            continue;
+        }
+
+        const QJsonObject block = blockValue.toObject();
+        const QJsonValue typeValue = block.value(QStringLiteral("type"));
+        if (!typeValue.isDouble() || typeValue.toInt() != kTextBlockType) {
+            addWarning(result,
+                       path,
+                       QStringLiteral("skipped-non-text-block"),
+                       QStringLiteral("non-text noteDatas block is reserved for later migration steps"));
+            continue;
+        }
+
+        const QJsonValue textValue = block.value(QStringLiteral("text"));
+        if (!textValue.isString()) {
+            addWarning(result,
+                       path + QStringLiteral(".text"),
+                       QStringLiteral("missing-text"),
+                       QStringLiteral("text noteDatas block has no string text and was converted as empty paragraph"));
+        }
+
+        docContent.append(paragraphFromText(textValue.toString()));
+    }
+
+    result.envelope = MigrationJsonBuilder::makeEnvelope(MigrationJsonBuilder::makeDoc(docContent));
+    return result;
+}

--- a/src/importolddata/tiptapmigration/migrationnotedataconverter.h
+++ b/src/importolddata/tiptapmigration/migrationnotedataconverter.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONNOTEDATACONVERTER_H
+#define MIGRATIONNOTEDATACONVERTER_H
+
+#include <QJsonObject>
+#include <QString>
+#include <QVector>
+
+struct MigrationNoteDataConversionIssue {
+    QString path;
+    QString code;
+    QString message;
+};
+
+struct MigrationNoteDataConversionResult {
+    QJsonObject envelope;
+    QVector<MigrationNoteDataConversionIssue> errors;
+    QVector<MigrationNoteDataConversionIssue> warnings;
+
+    bool ok() const;
+};
+
+class MigrationNoteDataConverter
+{
+public:
+    static MigrationNoteDataConversionResult convertTextBlocks(const QString &metadataJson);
+    static MigrationNoteDataConversionResult convertTextBlocks(const QJsonObject &metadata);
+};
+
+#endif // MIGRATIONNOTEDATACONVERTER_H

--- a/tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "importolddata/tiptapmigration/migrationjsonbuilder.h"
+#include "importolddata/tiptapmigration/migrationjsonvalidator.h"
+#include "importolddata/tiptapmigration/migrationnotedataconverter.h"
+
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QProcess>
+#include <QTemporaryFile>
+
+namespace {
+
+bool hasWarningCode(const MigrationNoteDataConversionResult &result, const QString &code)
+{
+    for (const MigrationNoteDataConversionIssue &warning : result.warnings) {
+        if (warning.code == code) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool hasErrorCode(const MigrationNoteDataConversionResult &result, const QString &code)
+{
+    for (const MigrationNoteDataConversionIssue &error : result.errors) {
+        if (error.code == code) {
+            return true;
+        }
+    }
+    return false;
+}
+
+QJsonArray docContent(const MigrationNoteDataConversionResult &result)
+{
+    return result.envelope.value(QStringLiteral("content"))
+        .toObject()
+        .value(QStringLiteral("content"))
+        .toArray();
+}
+
+QJsonArray paragraphContent(const QJsonObject &paragraph)
+{
+    return paragraph.value(QStringLiteral("content")).toArray();
+}
+
+void expectNodeType(const QJsonObject &node, const QString &type)
+{
+    EXPECT_EQ(type, node.value(QStringLiteral("type")).toString());
+}
+
+QString findRepoRoot()
+{
+    QDir dir(QDir::currentPath());
+    for (int depth = 0; depth < 8; ++depth) {
+        if (QFile::exists(dir.filePath(QStringLiteral("web-editor/scripts/validate-envelope.mjs")))) {
+            return dir.absolutePath();
+        }
+        if (!dir.cdUp()) {
+            break;
+        }
+    }
+
+    return QString();
+}
+
+} // namespace
+
+TEST(UT_MigrationNoteDataConverter, ConvertsUnicodeAndSpecialCharacters)
+{
+    const QString metadata = QStringLiteral(
+        R"({"dataCount":1,"noteDatas":[{"text":"Hello 中文🙂 <>&","type":1}],"voiceMaxId":0})");
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertTextBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(result.warnings.isEmpty());
+    const QJsonArray content = docContent(result);
+    ASSERT_EQ(1, content.size());
+    expectNodeType(content.at(0).toObject(), QStringLiteral("paragraph"));
+    const QJsonArray paragraph = paragraphContent(content.at(0).toObject());
+    ASSERT_EQ(1, paragraph.size());
+    expectNodeType(paragraph.at(0).toObject(), QStringLiteral("text"));
+    EXPECT_EQ(QStringLiteral("Hello 中文🙂 <>&"), paragraph.at(0).toObject().value(QStringLiteral("text")).toString());
+}
+
+TEST(UT_MigrationNoteDataConverter, ConvertsNewlinesToHardBreaksInsideParagraph)
+{
+    QJsonObject textBlock;
+    textBlock.insert(QStringLiteral("type"), 1);
+    textBlock.insert(QStringLiteral("text"), QStringLiteral("A\nB\r\nC\rD"));
+    const QJsonObject metadata { { QStringLiteral("noteDatas"), QJsonArray { textBlock } } };
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertTextBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    const QJsonArray content = docContent(result);
+    ASSERT_EQ(1, content.size());
+    const QJsonArray paragraph = paragraphContent(content.at(0).toObject());
+    ASSERT_EQ(7, paragraph.size());
+    EXPECT_EQ(QStringLiteral("A"), paragraph.at(0).toObject().value(QStringLiteral("text")).toString());
+    expectNodeType(paragraph.at(1).toObject(), QStringLiteral("hardBreak"));
+    EXPECT_EQ(QStringLiteral("B"), paragraph.at(2).toObject().value(QStringLiteral("text")).toString());
+    expectNodeType(paragraph.at(3).toObject(), QStringLiteral("hardBreak"));
+    EXPECT_EQ(QStringLiteral("C"), paragraph.at(4).toObject().value(QStringLiteral("text")).toString());
+    expectNodeType(paragraph.at(5).toObject(), QStringLiteral("hardBreak"));
+    EXPECT_EQ(QStringLiteral("D"), paragraph.at(6).toObject().value(QStringLiteral("text")).toString());
+}
+
+TEST(UT_MigrationNoteDataConverter, TrimsTrailingNewlineWithoutDroppingInnerBlankLines)
+{
+    QJsonObject textBlock;
+    textBlock.insert(QStringLiteral("type"), 1);
+    textBlock.insert(QStringLiteral("text"), QStringLiteral("A\n\nB\n"));
+    const QJsonObject metadata { { QStringLiteral("noteDatas"), QJsonArray { textBlock } } };
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertTextBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    const QJsonArray content = docContent(result);
+    ASSERT_EQ(1, content.size());
+    const QJsonArray paragraph = paragraphContent(content.at(0).toObject());
+    ASSERT_EQ(4, paragraph.size());
+    EXPECT_EQ(QStringLiteral("A"), paragraph.at(0).toObject().value(QStringLiteral("text")).toString());
+    expectNodeType(paragraph.at(1).toObject(), QStringLiteral("hardBreak"));
+    expectNodeType(paragraph.at(2).toObject(), QStringLiteral("hardBreak"));
+    EXPECT_EQ(QStringLiteral("B"), paragraph.at(3).toObject().value(QStringLiteral("text")).toString());
+}
+
+TEST(UT_MigrationNoteDataConverter, HandlesEmptyTextAsEmptyParagraph)
+{
+    const QString metadata = QStringLiteral(R"({"noteDatas":[{"text":"","type":1}]})");
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertTextBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    const QJsonArray content = docContent(result);
+    ASSERT_EQ(1, content.size());
+    expectNodeType(content.at(0).toObject(), QStringLiteral("paragraph"));
+    EXPECT_TRUE(content.at(0).toObject().value(QStringLiteral("content")).isUndefined());
+}
+
+TEST(UT_MigrationNoteDataConverter, HandlesEmptyNoteDatasAsEmptyParagraph)
+{
+    const QString metadata = QStringLiteral(R"({"noteDatas":[]})");
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertTextBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(result.warnings.isEmpty());
+    const QJsonArray content = docContent(result);
+    ASSERT_EQ(1, content.size());
+    expectNodeType(content.at(0).toObject(), QStringLiteral("paragraph"));
+    EXPECT_TRUE(content.at(0).toObject().value(QStringLiteral("content")).isUndefined());
+}
+
+TEST(UT_MigrationNoteDataConverter, SkipsNonTextBlocksWithWarning)
+{
+    const QString metadata = QStringLiteral(
+        R"({"noteDatas":[{"text":"first","type":1},{"text":"","title":"voice","type":2,"voicePath":"voicenote/a.mp3"},{"text":"second","type":1}]})");
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertTextBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("skipped-non-text-block")));
+    const QJsonArray content = docContent(result);
+    ASSERT_EQ(2, content.size());
+    EXPECT_EQ(QStringLiteral("first"), paragraphContent(content.at(0).toObject()).at(0).toObject().value(QStringLiteral("text")).toString());
+    EXPECT_EQ(QStringLiteral("second"), paragraphContent(content.at(1).toObject()).at(0).toObject().value(QStringLiteral("text")).toString());
+}
+
+TEST(UT_MigrationNoteDataConverter, RejectsInvalidInputShape)
+{
+    const MigrationNoteDataConversionResult invalidJson = MigrationNoteDataConverter::convertTextBlocks(QStringLiteral("{"));
+    EXPECT_FALSE(invalidJson.ok());
+    EXPECT_TRUE(hasErrorCode(invalidJson, QStringLiteral("invalid-json")));
+
+    const MigrationNoteDataConversionResult missingNoteDatas = MigrationNoteDataConverter::convertTextBlocks(QJsonObject());
+    EXPECT_FALSE(missingNoteDatas.ok());
+    EXPECT_TRUE(hasErrorCode(missingNoteDatas, QStringLiteral("invalid-note-datas")));
+}
+
+TEST(UT_MigrationNoteDataConverter, ComparesGoldenJsonAndPassesValidators)
+{
+    const QString metadata = QStringLiteral(R"({"noteDatas":[{"text":"第一行\n第二行","type":1},{"text":"","type":1}]})");
+    const QString golden = QStringLiteral(
+        R"({"content":{"content":[{"content":[{"text":"第一行","type":"text"},{"type":"hardBreak"},{"text":"第二行","type":"text"}],"type":"paragraph"},{"type":"paragraph"}],"type":"doc"},"format":"tiptap","schemaVersion":1})");
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertTextBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_EQ(golden, MigrationJsonBuilder::toCompactJson(result.envelope));
+    const MigrationJsonValidationResult validation = MigrationJsonValidator::validateEnvelope(result.envelope);
+    EXPECT_TRUE(validation.ok()) << validation.errors.value(0).code.toStdString();
+
+    const QString repoRoot = findRepoRoot();
+    if (repoRoot.isEmpty()) {
+        GTEST_SKIP() << "web-editor/scripts/validate-envelope.mjs not found";
+    }
+
+    QTemporaryFile envelopeFile(QDir::tempPath() + QStringLiteral("/note-data-text-envelope-XXXXXX.json"));
+    ASSERT_TRUE(envelopeFile.open());
+    ASSERT_NE(-1, envelopeFile.write(MigrationJsonBuilder::toCompactJson(result.envelope).toUtf8()));
+    ASSERT_TRUE(envelopeFile.flush());
+
+    QProcess validator;
+    validator.setWorkingDirectory(repoRoot);
+    validator.start(QStringLiteral("node"), { QStringLiteral("web-editor/scripts/validate-envelope.mjs"), envelopeFile.fileName() });
+    ASSERT_TRUE(validator.waitForFinished(30000));
+    EXPECT_EQ(0, validator.exitCode()) << validator.readAllStandardError().toStdString();
+}


### PR DESCRIPTION
## Summary

- Add `MigrationNoteDataConverter` for legacy `noteDatas` text block migration.
- Convert `type == 1` text blocks to Tiptap paragraphs and paragraph-internal `hardBreak` nodes.
- Preserve Chinese text, Emoji, special characters, empty text, and newline semantics.
- Record warnings for skipped non-text blocks, invalid blocks, or missing text without migrating voice blocks.

## Scope

- TTP-006 only.
- No voice block migration.
- No HTML / `htmlCode` migration.
- No database writes or startup migration wiring.
- No `src/web`, QRC, bundle, or docs changes.

## Validation

- `git diff --check`
- Independent g++ build of `UT_MigrationNoteDataConverter`
- `/tmp/ut_migrationnotedataconverter --gtest_filter='UT_MigrationNoteDataConverter.*'` passed 6/6
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target deepin-voice-note -j2`
- `npm test --prefix web-editor` passed 18/18
