### PR TITLE
V-240: convert noteDatas voice and basic HTML blocks

### DIFF
--- a/src/importolddata/tiptapmigration/migrationhtmlconverter.cpp
+++ b/src/importolddata/tiptapmigration/migrationhtmlconverter.cpp
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationhtmlconverter.h"
+
+#include "migrationhtmlparser.h"
+#include "migrationjsonbuilder.h"
+
+#include <QJsonArray>
+#include <QJsonValue>
+#include <QSet>
+
+namespace {
+
+const QSet<QString> &dangerousTags()
+{
+    static const QSet<QString> tags {
+        QStringLiteral("script"),
+        QStringLiteral("iframe"),
+        QStringLiteral("object"),
+        QStringLiteral("embed")
+    };
+    return tags;
+}
+
+const QSet<QString> &blockTags()
+{
+    static const QSet<QString> tags {
+        QStringLiteral("address"),
+        QStringLiteral("article"),
+        QStringLiteral("aside"),
+        QStringLiteral("blockquote"),
+        QStringLiteral("dd"),
+        QStringLiteral("div"),
+        QStringLiteral("dl"),
+        QStringLiteral("dt"),
+        QStringLiteral("figcaption"),
+        QStringLiteral("figure"),
+        QStringLiteral("footer"),
+        QStringLiteral("h1"),
+        QStringLiteral("h2"),
+        QStringLiteral("h3"),
+        QStringLiteral("h4"),
+        QStringLiteral("h5"),
+        QStringLiteral("h6"),
+        QStringLiteral("header"),
+        QStringLiteral("hr"),
+        QStringLiteral("li"),
+        QStringLiteral("main"),
+        QStringLiteral("ol"),
+        QStringLiteral("p"),
+        QStringLiteral("pre"),
+        QStringLiteral("section"),
+        QStringLiteral("table"),
+        QStringLiteral("td"),
+        QStringLiteral("th"),
+        QStringLiteral("tr"),
+        QStringLiteral("ul")
+    };
+    return tags;
+}
+
+void addIssue(QVector<MigrationHtmlConversionIssue> &issues,
+              const QString &path,
+              const QString &code,
+              const QString &message)
+{
+    issues.append({ path, code, message });
+}
+
+void addWarning(MigrationHtmlConversionResult &result,
+                const QString &path,
+                const QString &code,
+                const QString &message)
+{
+    addIssue(result.warnings, path, code, message);
+}
+
+void copyParseIssues(const MigrationHtmlParseResult &parsed, MigrationHtmlConversionResult &result)
+{
+    for (const MigrationHtmlParseWarning &warning : parsed.warnings) {
+        if (warning.code == QStringLiteral("parse-failed")) {
+            addIssue(result.errors, warning.path, warning.code, warning.message);
+            continue;
+        }
+
+        addWarning(result, warning.path, warning.code, warning.message);
+    }
+}
+
+bool isDangerousElement(const MigrationHtmlNode &node)
+{
+    return node.type == MigrationHtmlNodeType::Element && dangerousTags().contains(node.tagName);
+}
+
+bool isBlockElement(const MigrationHtmlNode &node)
+{
+    return node.type == MigrationHtmlNodeType::Element && blockTags().contains(node.tagName);
+}
+
+bool isHeadingElement(const MigrationHtmlNode &node)
+{
+    if (node.type != MigrationHtmlNodeType::Element || node.tagName.size() != 2 || node.tagName.at(0) != QLatin1Char('h')) {
+        return false;
+    }
+
+    const QChar level = node.tagName.at(1);
+    return level >= QLatin1Char('1') && level <= QLatin1Char('6');
+}
+
+int headingLevel(const MigrationHtmlNode &node)
+{
+    return node.tagName.right(1).toInt();
+}
+
+bool isTextNode(const QJsonValue &value)
+{
+    return value.isObject() && value.toObject().value(QStringLiteral("type")).toString() == QStringLiteral("text");
+}
+
+bool isHardBreakNode(const QJsonValue &value)
+{
+    return value.isObject() && value.toObject().value(QStringLiteral("type")).toString() == QStringLiteral("hardBreak");
+}
+
+bool contentEndsWithSpace(const QJsonArray &content)
+{
+    if (content.isEmpty() || !isTextNode(content.at(content.size() - 1))) {
+        return false;
+    }
+
+    return content.at(content.size() - 1).toObject().value(QStringLiteral("text")).toString().endsWith(QLatin1Char(' '));
+}
+
+void appendTextNode(QJsonArray &content, const QString &text)
+{
+    if (text.isEmpty()) {
+        return;
+    }
+
+    if (!content.isEmpty() && isTextNode(content.at(content.size() - 1))) {
+        QJsonObject last = content.at(content.size() - 1).toObject();
+        last.insert(QStringLiteral("text"), last.value(QStringLiteral("text")).toString() + text);
+        content.replace(content.size() - 1, last);
+        return;
+    }
+
+    content.append(MigrationJsonBuilder::makeText(text));
+}
+
+void appendVisibleText(QJsonArray &content, const QString &text)
+{
+    QString normalized;
+    bool pendingSpace = false;
+
+    for (const QChar &character : text) {
+        if (character.isSpace()) {
+            pendingSpace = true;
+            continue;
+        }
+
+        if (pendingSpace && (!normalized.isEmpty()
+                             || (!content.isEmpty() && !isHardBreakNode(content.at(content.size() - 1)) && !contentEndsWithSpace(content)))) {
+            normalized.append(QLatin1Char(' '));
+        }
+
+        normalized.append(character);
+        pendingSpace = false;
+    }
+
+    if (pendingSpace && (!normalized.isEmpty()
+                         || (!content.isEmpty() && !isHardBreakNode(content.at(content.size() - 1)) && !contentEndsWithSpace(content)))) {
+        normalized.append(QLatin1Char(' '));
+    }
+
+    appendTextNode(content, normalized);
+}
+
+void trimTrailingTextSpace(QJsonArray &content)
+{
+    if (content.isEmpty() || !isTextNode(content.at(content.size() - 1))) {
+        return;
+    }
+
+    QJsonObject last = content.at(content.size() - 1).toObject();
+    QString text = last.value(QStringLiteral("text")).toString();
+    while (text.endsWith(QLatin1Char(' '))) {
+        text.chop(1);
+    }
+
+    if (text.isEmpty()) {
+        content.removeAt(content.size() - 1);
+        return;
+    }
+
+    last.insert(QStringLiteral("text"), text);
+    content.replace(content.size() - 1, last);
+}
+
+void appendHardBreak(QJsonArray &content)
+{
+    content.append(MigrationJsonBuilder::makeHardBreak());
+}
+
+void appendInlineNode(const MigrationHtmlNode &node, QJsonArray &content, MigrationHtmlConversionResult &result);
+
+void appendInlineChildren(const MigrationHtmlNode &node, QJsonArray &content, MigrationHtmlConversionResult &result)
+{
+    for (const MigrationHtmlNode &child : node.children) {
+        appendInlineNode(child, content, result);
+    }
+}
+
+void appendInlineNode(const MigrationHtmlNode &node, QJsonArray &content, MigrationHtmlConversionResult &result)
+{
+    if (node.type == MigrationHtmlNodeType::Text) {
+        appendVisibleText(content, node.text);
+        return;
+    }
+
+    if (node.type != MigrationHtmlNodeType::Element) {
+        appendInlineChildren(node, content, result);
+        return;
+    }
+
+    if (isDangerousElement(node)) {
+        return;
+    }
+
+    if (node.tagName == QStringLiteral("br")) {
+        appendHardBreak(content);
+        return;
+    }
+
+    if (isBlockElement(node) && !content.isEmpty() && !isHardBreakNode(content.at(content.size() - 1))) {
+        appendHardBreak(content);
+    }
+
+    appendInlineChildren(node, content, result);
+}
+
+void appendParagraphIfContent(QJsonArray &inlineContent, QJsonArray &blocks)
+{
+    trimTrailingTextSpace(inlineContent);
+    if (!inlineContent.isEmpty()) {
+        blocks.append(MigrationJsonBuilder::makeParagraph(inlineContent));
+    }
+    inlineContent = QJsonArray();
+}
+
+QJsonArray inlineContentFrom(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+{
+    QJsonArray content;
+    appendInlineChildren(node, content, result);
+    trimTrailingTextSpace(content);
+    return content;
+}
+
+QJsonObject blockFromElement(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result);
+
+void appendBlocksFromChildren(const MigrationHtmlNode &node, QJsonArray &blocks, MigrationHtmlConversionResult &result)
+{
+    QJsonArray inlineContent;
+    for (const MigrationHtmlNode &child : node.children) {
+        if (isDangerousElement(child)) {
+            continue;
+        }
+
+        if (isBlockElement(child)) {
+            if (!inlineContent.isEmpty()) {
+                appendParagraphIfContent(inlineContent, blocks);
+            }
+            blocks.append(blockFromElement(child, result));
+            continue;
+        }
+
+        appendInlineNode(child, inlineContent, result);
+    }
+
+    if (!inlineContent.isEmpty()) {
+        appendParagraphIfContent(inlineContent, blocks);
+    }
+}
+
+QJsonObject downgradedParagraphFromBlock(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+{
+    if (node.tagName != QStringLiteral("p") && node.tagName != QStringLiteral("div")) {
+        addWarning(result,
+                   QStringLiteral("/%1").arg(node.tagName),
+                   QStringLiteral("downgraded-html-block"),
+                   QStringLiteral("HTML block <%1> was downgraded to paragraph").arg(node.tagName));
+    }
+
+    return MigrationJsonBuilder::makeParagraph(inlineContentFrom(node, result));
+}
+
+QJsonObject blockquoteFromElement(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+{
+    QJsonArray content;
+    appendBlocksFromChildren(node, content, result);
+    return MigrationJsonBuilder::makeBlockquote(content);
+}
+
+QJsonObject blockFromElement(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+{
+    if (isHeadingElement(node)) {
+        return MigrationJsonBuilder::makeHeading(headingLevel(node), inlineContentFrom(node, result));
+    }
+
+    if (node.tagName == QStringLiteral("blockquote")) {
+        return blockquoteFromElement(node, result);
+    }
+
+    return downgradedParagraphFromBlock(node, result);
+}
+
+QJsonObject envelopeFromParsed(const MigrationHtmlParseResult &parsed, MigrationHtmlConversionResult &result)
+{
+    QJsonArray docContent;
+    appendBlocksFromChildren(parsed.root, docContent, result);
+    return MigrationJsonBuilder::makeEnvelope(MigrationJsonBuilder::makeDoc(docContent));
+}
+
+} // namespace
+
+bool MigrationHtmlConversionResult::ok() const
+{
+    return errors.isEmpty();
+}
+
+MigrationHtmlConversionResult MigrationHtmlConverter::convert(const QString &htmlCode)
+{
+    MigrationHtmlConversionResult result;
+    const MigrationHtmlParseResult parsed = MigrationHtmlParser::parse(htmlCode);
+    copyParseIssues(parsed, result);
+    result.envelope = envelopeFromParsed(parsed, result);
+    return result;
+}

--- a/src/importolddata/tiptapmigration/migrationhtmlconverter.h
+++ b/src/importolddata/tiptapmigration/migrationhtmlconverter.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONHTMLCONVERTER_H
+#define MIGRATIONHTMLCONVERTER_H
+
+#include <QJsonObject>
+#include <QString>
+#include <QVector>
+
+struct MigrationHtmlConversionIssue {
+    QString path;
+    QString code;
+    QString message;
+};
+
+struct MigrationHtmlConversionResult {
+    QJsonObject envelope;
+    QVector<MigrationHtmlConversionIssue> errors;
+    QVector<MigrationHtmlConversionIssue> warnings;
+
+    bool ok() const;
+};
+
+class MigrationHtmlConverter
+{
+public:
+    static MigrationHtmlConversionResult convert(const QString &htmlCode);
+};
+
+#endif // MIGRATIONHTMLCONVERTER_H

--- a/src/importolddata/tiptapmigration/migrationjsonbuilder.cpp
+++ b/src/importolddata/tiptapmigration/migrationjsonbuilder.cpp
@@ -62,6 +62,14 @@ QJsonObject MigrationJsonBuilder::makeHeading(int level, const QJsonArray &conte
     return node;
 }
 
+QJsonObject MigrationJsonBuilder::makeBlockquote(const QJsonArray &content)
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("blockquote"));
+    node.insert(QStringLiteral("content"), normalizedDocContent(content));
+    return node;
+}
+
 QJsonObject MigrationJsonBuilder::makeMark(const QString &type, const QJsonObject &attrs)
 {
     QJsonObject mark;

--- a/src/importolddata/tiptapmigration/migrationjsonbuilder.h
+++ b/src/importolddata/tiptapmigration/migrationjsonbuilder.h
@@ -18,6 +18,7 @@ public:
     static QJsonObject makeText(const QString &text, const QJsonArray &marks = QJsonArray());
     static QJsonObject makeHardBreak();
     static QJsonObject makeHeading(int level, const QJsonArray &content = QJsonArray());
+    static QJsonObject makeBlockquote(const QJsonArray &content = QJsonArray());
     static QJsonObject makeMark(const QString &type, const QJsonObject &attrs = QJsonObject());
     static QJsonObject makeImage(const QString &src,
                                  const QString &relPath = QString(),

--- a/src/importolddata/tiptapmigration/migrationnotedataconverter.cpp
+++ b/src/importolddata/tiptapmigration/migrationnotedataconverter.cpp
@@ -5,14 +5,26 @@
 
 #include "migrationjsonbuilder.h"
 
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QJsonValue>
 #include <QStringList>
 
+#include <cmath>
+#include <limits>
+
 namespace {
 constexpr int kTextBlockType = 1;
+constexpr int kVoiceBlockType = 2;
+
+enum class ConversionMode {
+    TextOnly,
+    TextAndVoice,
+};
 
 void addError(MigrationNoteDataConversionResult &result,
               const QString &path,
@@ -67,30 +79,245 @@ QJsonObject paragraphFromText(const QString &text)
     return MigrationJsonBuilder::makeParagraph(content);
 }
 
-} // namespace
-
-bool MigrationNoteDataConversionResult::ok() const
+QString stringField(const QJsonObject &block,
+                    const QString &field,
+                    const QString &path,
+                    MigrationNoteDataConversionResult &result)
 {
-    return errors.isEmpty();
-}
-
-MigrationNoteDataConversionResult MigrationNoteDataConverter::convertTextBlocks(const QString &metadataJson)
-{
-    MigrationNoteDataConversionResult result;
-    QJsonParseError parseError;
-    const QJsonDocument document = QJsonDocument::fromJson(metadataJson.toUtf8(), &parseError);
-    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
-        addError(result,
-                 QStringLiteral("/"),
-                 QStringLiteral("invalid-json"),
-                 QStringLiteral("legacy noteDatas metadata must be a JSON object"));
-        return result;
+    const QJsonValue value = block.value(field);
+    if (value.isUndefined() || value.isNull()) {
+        return QString();
     }
 
-    return convertTextBlocks(document.object());
+    if (value.isString()) {
+        return value.toString();
+    }
+
+    addWarning(result,
+               path + QLatin1Char('.') + field,
+               QStringLiteral("invalid-voice-string-field"),
+               QStringLiteral("voice block string field was ignored because it is not a string"));
+    return QString();
 }
 
-MigrationNoteDataConversionResult MigrationNoteDataConverter::convertTextBlocks(const QJsonObject &metadata)
+QString normalizedPathSeparators(QString path)
+{
+    path = path.trimmed();
+    path.replace(QLatin1Char('\\'), QLatin1Char('/'));
+    return path;
+}
+
+bool isUnsafePathSegment(const QString &segment)
+{
+    return segment.isEmpty()
+        || segment == QStringLiteral(".")
+        || segment == QStringLiteral("..")
+        || segment.contains(QLatin1Char(':'));
+}
+
+bool hasUnsafeInputPathSegments(const QString &path)
+{
+    const QStringList segments = path.split(QLatin1Char('/'), Qt::KeepEmptyParts);
+    for (int index = 0; index < segments.size(); ++index) {
+        if (index == 0 && segments.at(index).isEmpty() && path.startsWith(QLatin1Char('/'))) {
+            continue;
+        }
+
+        if (isUnsafePathSegment(segments.at(index))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool isSafeVoicenoteRelativePath(const QString &path)
+{
+    if (!path.startsWith(QStringLiteral("voicenote/")) || QDir::isAbsolutePath(path)) {
+        return false;
+    }
+
+    const QStringList segments = path.split(QLatin1Char('/'), Qt::KeepEmptyParts);
+    for (const QString &segment : segments) {
+        if (isUnsafePathSegment(segment)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void addInvalidVoicePathError(MigrationNoteDataConversionResult &result, const QString &path)
+{
+    addError(result,
+             path + QStringLiteral(".voicePath"),
+             QStringLiteral("invalid-voice-path"),
+             QStringLiteral("voicePath could not be normalized to a safe voicenote relative path"));
+}
+
+QString normalizeVoicePath(const QJsonObject &block,
+                           const QString &path,
+                           MigrationNoteDataConversionResult &result,
+                           bool *ok)
+{
+    *ok = false;
+    const QJsonValue value = block.value(QStringLiteral("voicePath"));
+    if (!value.isString() || value.toString().trimmed().isEmpty()) {
+        addError(result,
+                 path + QStringLiteral(".voicePath"),
+                 QStringLiteral("missing-voice-path"),
+                 QStringLiteral("voice noteDatas block requires a non-empty voicePath"));
+        return QString();
+    }
+
+    const QString voicePath = normalizedPathSeparators(value.toString());
+    const int voicenoteIndex = voicePath.indexOf(QStringLiteral("voicenote/"));
+    if (voicenoteIndex >= 0) {
+        const QString candidate = voicePath.mid(voicenoteIndex);
+        if (!isSafeVoicenoteRelativePath(candidate)) {
+            addInvalidVoicePathError(result, path);
+            return QString();
+        }
+
+        *ok = true;
+        return candidate;
+    }
+
+    if (hasUnsafeInputPathSegments(voicePath)) {
+        addInvalidVoicePathError(result, path);
+        return QString();
+    }
+
+    const QString fileName = QFileInfo(voicePath).fileName();
+    if (fileName.isEmpty() || isUnsafePathSegment(fileName)) {
+        addInvalidVoicePathError(result, path);
+        return QString();
+    }
+
+    addWarning(result,
+               path + QStringLiteral(".voicePath"),
+               QStringLiteral("normalized-voice-path"),
+               QStringLiteral("voicePath was normalized to voicenote/<fileName>"));
+    *ok = true;
+    return QStringLiteral("voicenote/") + fileName;
+}
+
+qint64 sanitizedVoiceSize(double size,
+                          const QString &path,
+                          MigrationNoteDataConversionResult &result)
+{
+    if (!std::isfinite(size)) {
+        addWarning(result,
+                   path + QStringLiteral(".voiceSize"),
+                   QStringLiteral("invalid-voice-size"),
+                   QStringLiteral("voiceSize is not finite and was converted to 0"));
+        return 0;
+    }
+
+    if (size < 0) {
+        addWarning(result,
+                   path + QStringLiteral(".voiceSize"),
+                   QStringLiteral("negative-voice-size"),
+                   QStringLiteral("negative voiceSize was converted to 0"));
+        return 0;
+    }
+
+    const double maxSize = static_cast<double>(std::numeric_limits<qint64>::max());
+    if (size > maxSize) {
+        addWarning(result,
+                   path + QStringLiteral(".voiceSize"),
+                   QStringLiteral("oversized-voice-size"),
+                   QStringLiteral("voiceSize is too large and was clamped"));
+        return std::numeric_limits<qint64>::max();
+    }
+
+    return static_cast<qint64>(size);
+}
+
+qint64 voiceSizeFromBlock(const QJsonObject &block, const QString &path, MigrationNoteDataConversionResult &result)
+{
+    const QJsonValue value = block.value(QStringLiteral("voiceSize"));
+    if (value.isUndefined() || value.isNull()) {
+        addWarning(result,
+                   path + QStringLiteral(".voiceSize"),
+                   QStringLiteral("missing-voice-size"),
+                   QStringLiteral("missing voiceSize was converted to 0"));
+        return 0;
+    }
+
+    if (value.isDouble()) {
+        return sanitizedVoiceSize(value.toDouble(), path, result);
+    }
+
+    if (value.isString()) {
+        bool parsed = false;
+        const double size = value.toString().trimmed().toDouble(&parsed);
+        if (parsed) {
+            return sanitizedVoiceSize(size, path, result);
+        }
+    }
+
+    addWarning(result,
+               path + QStringLiteral(".voiceSize"),
+               QStringLiteral("invalid-voice-size"),
+               QStringLiteral("invalid voiceSize was converted to 0"));
+    return 0;
+}
+
+QString generatedVoiceId(int index, const QString &voicePath, const QString &createTime, const QString &title)
+{
+    const QString seed = QStringLiteral("%1\n%2\n%3\n%4")
+                             .arg(index)
+                             .arg(voicePath, createTime, title);
+    const QByteArray hash = QCryptographicHash::hash(seed.toUtf8(), QCryptographicHash::Sha1).toHex();
+    return QStringLiteral("legacy-voice-") + QString::fromLatin1(hash.left(16));
+}
+
+QString voiceIdFromBlock(const QJsonObject &block,
+                         int index,
+                         const QString &voicePath,
+                         const QString &createTime,
+                         const QString &title,
+                         const QString &path,
+                         MigrationNoteDataConversionResult &result)
+{
+    const QJsonValue value = block.value(QStringLiteral("voiceId"));
+    if (value.isString() && !value.toString().trimmed().isEmpty()) {
+        return value.toString().trimmed();
+    }
+
+    addWarning(result,
+               path + QStringLiteral(".voiceId"),
+               QStringLiteral("generated-voice-id"),
+               QStringLiteral("voiceId was missing or invalid and a stable legacy id was generated"));
+    return generatedVoiceId(index, voicePath, createTime, title);
+}
+
+QJsonObject voiceBlockFromBlock(const QJsonObject &block,
+                                int index,
+                                const QString &path,
+                                MigrationNoteDataConversionResult &result,
+                                bool *ok)
+{
+    *ok = false;
+
+    bool voicePathOk = false;
+    const QString voicePath = normalizeVoicePath(block, path, result, &voicePathOk);
+    if (!voicePathOk) {
+        return QJsonObject();
+    }
+
+    const QString createTime = stringField(block, QStringLiteral("createTime"), path, result);
+    const QString title = stringField(block, QStringLiteral("title"), path, result);
+    const QString text = stringField(block, QStringLiteral("text"), path, result);
+    const qint64 voiceSize = voiceSizeFromBlock(block, path, result);
+    const QString voiceId = voiceIdFromBlock(block, index, voicePath, createTime, title, path, result);
+
+    *ok = true;
+    return MigrationJsonBuilder::makeVoiceBlock(voiceId, voicePath, voiceSize, createTime, title, text);
+}
+
+MigrationNoteDataConversionResult convertNoteDataBlocks(const QJsonObject &metadata, ConversionMode mode)
 {
     MigrationNoteDataConversionResult result;
 
@@ -118,7 +345,7 @@ MigrationNoteDataConversionResult MigrationNoteDataConverter::convertTextBlocks(
 
         const QJsonObject block = blockValue.toObject();
         const QJsonValue typeValue = block.value(QStringLiteral("type"));
-        if (!typeValue.isDouble() || typeValue.toInt() != kTextBlockType) {
+        if (!typeValue.isDouble()) {
             addWarning(result,
                        path,
                        QStringLiteral("skipped-non-text-block"),
@@ -126,17 +353,78 @@ MigrationNoteDataConversionResult MigrationNoteDataConverter::convertTextBlocks(
             continue;
         }
 
-        const QJsonValue textValue = block.value(QStringLiteral("text"));
-        if (!textValue.isString()) {
-            addWarning(result,
-                       path + QStringLiteral(".text"),
-                       QStringLiteral("missing-text"),
-                       QStringLiteral("text noteDatas block has no string text and was converted as empty paragraph"));
+        const int type = typeValue.toInt();
+        if (type == kTextBlockType) {
+            const QJsonValue textValue = block.value(QStringLiteral("text"));
+            if (!textValue.isString()) {
+                addWarning(result,
+                           path + QStringLiteral(".text"),
+                           QStringLiteral("missing-text"),
+                           QStringLiteral("text noteDatas block has no string text and was converted as empty paragraph"));
+            }
+
+            docContent.append(paragraphFromText(textValue.toString()));
+            continue;
         }
 
-        docContent.append(paragraphFromText(textValue.toString()));
+        if (mode == ConversionMode::TextAndVoice && type == kVoiceBlockType) {
+            bool voiceBlockOk = false;
+            const QJsonObject voiceBlock = voiceBlockFromBlock(block, index, path, result, &voiceBlockOk);
+            if (voiceBlockOk) {
+                docContent.append(voiceBlock);
+            }
+            continue;
+        }
+
+        addWarning(result,
+                   path,
+                   QStringLiteral("skipped-non-text-block"),
+                   QStringLiteral("non-text noteDatas block is reserved for later migration steps"));
     }
 
     result.envelope = MigrationJsonBuilder::makeEnvelope(MigrationJsonBuilder::makeDoc(docContent));
     return result;
+}
+
+MigrationNoteDataConversionResult convertNoteDataBlocks(const QString &metadataJson, ConversionMode mode)
+{
+    MigrationNoteDataConversionResult result;
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(metadataJson.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        addError(result,
+                 QStringLiteral("/"),
+                 QStringLiteral("invalid-json"),
+                 QStringLiteral("legacy noteDatas metadata must be a JSON object"));
+        return result;
+    }
+
+    return convertNoteDataBlocks(document.object(), mode);
+}
+
+} // namespace
+
+bool MigrationNoteDataConversionResult::ok() const
+{
+    return errors.isEmpty();
+}
+
+MigrationNoteDataConversionResult MigrationNoteDataConverter::convertTextBlocks(const QString &metadataJson)
+{
+    return convertNoteDataBlocks(metadataJson, ConversionMode::TextOnly);
+}
+
+MigrationNoteDataConversionResult MigrationNoteDataConverter::convertTextBlocks(const QJsonObject &metadata)
+{
+    return convertNoteDataBlocks(metadata, ConversionMode::TextOnly);
+}
+
+MigrationNoteDataConversionResult MigrationNoteDataConverter::convertBlocks(const QString &metadataJson)
+{
+    return convertNoteDataBlocks(metadataJson, ConversionMode::TextAndVoice);
+}
+
+MigrationNoteDataConversionResult MigrationNoteDataConverter::convertBlocks(const QJsonObject &metadata)
+{
+    return convertNoteDataBlocks(metadata, ConversionMode::TextAndVoice);
 }

--- a/src/importolddata/tiptapmigration/migrationnotedataconverter.h
+++ b/src/importolddata/tiptapmigration/migrationnotedataconverter.h
@@ -27,6 +27,8 @@ class MigrationNoteDataConverter
 public:
     static MigrationNoteDataConversionResult convertTextBlocks(const QString &metadataJson);
     static MigrationNoteDataConversionResult convertTextBlocks(const QJsonObject &metadata);
+    static MigrationNoteDataConversionResult convertBlocks(const QString &metadataJson);
+    static MigrationNoteDataConversionResult convertBlocks(const QJsonObject &metadata);
 };
 
 #endif // MIGRATIONNOTEDATACONVERTER_H

--- a/tests/src/importolddata/tiptapmigration/ut_migrationhtmlconverter.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationhtmlconverter.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "importolddata/tiptapmigration/migrationhtmlconverter.h"
+#include "importolddata/tiptapmigration/migrationjsonvalidator.h"
+
+#include <gtest/gtest.h>
+
+#include <QJsonArray>
+#include <QJsonObject>
+
+namespace {
+
+QJsonArray docContentOf(const MigrationHtmlConversionResult &result)
+{
+    return result.envelope.value(QStringLiteral("content")).toObject().value(QStringLiteral("content")).toArray();
+}
+
+QJsonArray nodeContentOf(const QJsonObject &node)
+{
+    return node.value(QStringLiteral("content")).toArray();
+}
+
+QJsonObject attrsOf(const QJsonObject &node)
+{
+    return node.value(QStringLiteral("attrs")).toObject();
+}
+
+QString nodeTypeOf(const QJsonObject &node)
+{
+    return node.value(QStringLiteral("type")).toString();
+}
+
+QString textOf(const QJsonObject &node)
+{
+    return node.value(QStringLiteral("text")).toString();
+}
+
+bool hasWarningCode(const MigrationHtmlConversionResult &result, const QString &code)
+{
+    for (const MigrationHtmlConversionIssue &warning : result.warnings) {
+        if (warning.code == code) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void expectEnvelopeValid(const MigrationHtmlConversionResult &result)
+{
+    const MigrationJsonValidationResult validation = MigrationJsonValidator::validateEnvelope(result.envelope);
+    EXPECT_TRUE(validation.ok()) << (validation.errors.isEmpty()
+                                        ? std::string()
+                                        : validation.errors.constFirst().message.toStdString());
+}
+
+} // namespace
+
+TEST(UT_MigrationHtmlConverter, ConvertsParagraphDivAndHardBreaks)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("\n  <p>Hello<br>World</p>\n  <div>Second</div>\n"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(2, blocks.size());
+
+    const QJsonObject firstParagraph = blocks.at(0).toObject();
+    EXPECT_EQ(QStringLiteral("paragraph"), nodeTypeOf(firstParagraph));
+    const QJsonArray firstContent = nodeContentOf(firstParagraph);
+    ASSERT_EQ(3, firstContent.size());
+    EXPECT_EQ(QStringLiteral("Hello"), textOf(firstContent.at(0).toObject()));
+    EXPECT_EQ(QStringLiteral("hardBreak"), nodeTypeOf(firstContent.at(1).toObject()));
+    EXPECT_EQ(QStringLiteral("World"), textOf(firstContent.at(2).toObject()));
+
+    const QJsonObject secondParagraph = blocks.at(1).toObject();
+    EXPECT_EQ(QStringLiteral("paragraph"), nodeTypeOf(secondParagraph));
+    ASSERT_EQ(1, nodeContentOf(secondParagraph).size());
+    EXPECT_EQ(QStringLiteral("Second"), textOf(nodeContentOf(secondParagraph).at(0).toObject()));
+}
+
+TEST(UT_MigrationHtmlConverter, ConvertsHeadingsAndBlockquotes)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<h2>Title</h2><blockquote><p>Quote</p><h3>Nested</h3></blockquote>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(2, blocks.size());
+
+    const QJsonObject heading = blocks.at(0).toObject();
+    EXPECT_EQ(QStringLiteral("heading"), nodeTypeOf(heading));
+    EXPECT_EQ(2, attrsOf(heading).value(QStringLiteral("level")).toInt());
+    ASSERT_EQ(1, nodeContentOf(heading).size());
+    EXPECT_EQ(QStringLiteral("Title"), textOf(nodeContentOf(heading).at(0).toObject()));
+
+    const QJsonObject blockquote = blocks.at(1).toObject();
+    EXPECT_EQ(QStringLiteral("blockquote"), nodeTypeOf(blockquote));
+    const QJsonArray quoteBlocks = nodeContentOf(blockquote);
+    ASSERT_EQ(2, quoteBlocks.size());
+    EXPECT_EQ(QStringLiteral("paragraph"), nodeTypeOf(quoteBlocks.at(0).toObject()));
+    EXPECT_EQ(QStringLiteral("Quote"), textOf(nodeContentOf(quoteBlocks.at(0).toObject()).at(0).toObject()));
+    EXPECT_EQ(QStringLiteral("heading"), nodeTypeOf(quoteBlocks.at(1).toObject()));
+    EXPECT_EQ(3, attrsOf(quoteBlocks.at(1).toObject()).value(QStringLiteral("level")).toInt());
+}
+
+TEST(UT_MigrationHtmlConverter, KeepsTopLevelInlineTextInOneParagraph)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("Hello <span>world</span><br>next"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(1, blocks.size());
+    const QJsonArray content = nodeContentOf(blocks.at(0).toObject());
+    ASSERT_EQ(3, content.size());
+    EXPECT_EQ(QStringLiteral("Hello world"), textOf(content.at(0).toObject()));
+    EXPECT_EQ(QStringLiteral("hardBreak"), nodeTypeOf(content.at(1).toObject()));
+    EXPECT_EQ(QStringLiteral("next"), textOf(content.at(2).toObject()));
+}
+
+TEST(UT_MigrationHtmlConverter, NormalizesEmptyDocument)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(QString());
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(1, blocks.size());
+    EXPECT_EQ(QStringLiteral("paragraph"), nodeTypeOf(blocks.at(0).toObject()));
+    EXPECT_TRUE(nodeContentOf(blocks.at(0).toObject()).isEmpty());
+}
+
+TEST(UT_MigrationHtmlConverter, DowngradesUnknownBlockTagsToParagraph)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<section><custom>Visible</custom></section>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("downgraded-html-block")));
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(1, blocks.size());
+    EXPECT_EQ(QStringLiteral("paragraph"), nodeTypeOf(blocks.at(0).toObject()));
+    ASSERT_EQ(1, nodeContentOf(blocks.at(0).toObject()).size());
+    EXPECT_EQ(QStringLiteral("Visible"), textOf(nodeContentOf(blocks.at(0).toObject()).at(0).toObject()));
+}
+
+TEST(UT_MigrationHtmlConverter, SkipsDangerousNodesAndTheirContent)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p>safe<script>alert(1)</script><iframe>frame</iframe>tail</p><object>bad</object>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("dangerous-html-node")));
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(1, blocks.size());
+    const QJsonArray content = nodeContentOf(blocks.at(0).toObject());
+    ASSERT_EQ(1, content.size());
+    EXPECT_EQ(QStringLiteral("safetail"), textOf(content.at(0).toObject()));
+}

--- a/tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp
@@ -89,10 +89,15 @@ TEST(UT_MigrationJsonBuilder, CreatesHeadingAndHardBreak)
 {
     const QJsonObject heading = MigrationJsonBuilder::makeHeading(
         2, QJsonArray { MigrationJsonBuilder::makeText(QStringLiteral("标题")) });
+    const QJsonObject blockquote = MigrationJsonBuilder::makeBlockquote(
+        arrayOf(MigrationJsonBuilder::makeParagraph(arrayOf(MigrationJsonBuilder::makeText(QStringLiteral("引用"))))));
     const QJsonObject hardBreak = MigrationJsonBuilder::makeHardBreak();
 
     expectNodeType(heading, QStringLiteral("heading"));
     EXPECT_EQ(2, attrsOf(heading).value(QStringLiteral("level")).toInt());
+    expectNodeType(blockquote, QStringLiteral("blockquote"));
+    ASSERT_EQ(1, blockquote.value(QStringLiteral("content")).toArray().size());
+    expectNodeType(blockquote.value(QStringLiteral("content")).toArray().at(0).toObject(), QStringLiteral("paragraph"));
     expectNodeType(hardBreak, QStringLiteral("hardBreak"));
 }
 

--- a/tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp
@@ -10,7 +10,6 @@
 #include <QDir>
 #include <QFile>
 #include <QJsonArray>
-#include <QJsonDocument>
 #include <QJsonObject>
 #include <QProcess>
 #include <QTemporaryFile>
@@ -50,6 +49,11 @@ QJsonArray paragraphContent(const QJsonObject &paragraph)
     return paragraph.value(QStringLiteral("content")).toArray();
 }
 
+QJsonObject nodeAttrs(const QJsonObject &node)
+{
+    return node.value(QStringLiteral("attrs")).toObject();
+}
+
 void expectNodeType(const QJsonObject &node, const QString &type)
 {
     EXPECT_EQ(type, node.value(QStringLiteral("type")).toString());
@@ -68,6 +72,28 @@ QString findRepoRoot()
     }
 
     return QString();
+}
+
+void expectPassesValidators(const QJsonObject &envelope)
+{
+    const MigrationJsonValidationResult validation = MigrationJsonValidator::validateEnvelope(envelope);
+    EXPECT_TRUE(validation.ok()) << (validation.errors.isEmpty() ? std::string() : validation.errors.value(0).code.toStdString());
+
+    const QString repoRoot = findRepoRoot();
+    if (repoRoot.isEmpty()) {
+        GTEST_SKIP() << "web-editor/scripts/validate-envelope.mjs not found";
+    }
+
+    QTemporaryFile envelopeFile(QDir::tempPath() + QStringLiteral("/note-data-envelope-XXXXXX.json"));
+    ASSERT_TRUE(envelopeFile.open());
+    ASSERT_NE(-1, envelopeFile.write(MigrationJsonBuilder::toCompactJson(envelope).toUtf8()));
+    ASSERT_TRUE(envelopeFile.flush());
+
+    QProcess validator;
+    validator.setWorkingDirectory(repoRoot);
+    validator.start(QStringLiteral("node"), { QStringLiteral("web-editor/scripts/validate-envelope.mjs"), envelopeFile.fileName() });
+    ASSERT_TRUE(validator.waitForFinished(30000));
+    EXPECT_EQ(0, validator.exitCode()) << validator.readAllStandardError().toStdString();
 }
 
 } // namespace
@@ -196,22 +222,128 @@ TEST(UT_MigrationNoteDataConverter, ComparesGoldenJsonAndPassesValidators)
 
     EXPECT_TRUE(result.ok());
     EXPECT_EQ(golden, MigrationJsonBuilder::toCompactJson(result.envelope));
+    expectPassesValidators(result.envelope);
+}
+
+TEST(UT_MigrationNoteDataConverter, ConvertsVoiceBlockGoldenAndPassesValidators)
+{
+    const QString metadata = QStringLiteral(
+        R"({"noteDatas":[{"type":2,"voiceId":"voice-1","voicePath":"voicenote/a.mp3","voiceSize":60000,"createTime":"2026-07-17 10:00:00","title":"录音","text":"转写文本"}]})");
+    const QString golden = QStringLiteral(
+        R"({"content":{"content":[{"attrs":{"createTime":"2026-07-17 10:00:00","text":"转写文本","title":"录音","translateUnfold":true,"voiceId":"voice-1","voicePath":"voicenote/a.mp3","voiceSize":60000},"type":"voiceBlock"}],"type":"doc"},"format":"tiptap","schemaVersion":1})");
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(result.warnings.isEmpty());
+    EXPECT_EQ(golden, MigrationJsonBuilder::toCompactJson(result.envelope));
+    expectPassesValidators(result.envelope);
+}
+
+TEST(UT_MigrationNoteDataConverter, ConvertsMixedTextAndVoiceBlocksPreservingOrder)
+{
+    const QString metadata = QStringLiteral(
+        R"({"noteDatas":[{"type":1,"text":"before"},{"type":2,"voiceId":"voice-2","voicePath":"voicenote/b.mp3","voiceSize":12,"title":"voice"},{"type":1,"text":"after"}]})");
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    const QJsonArray content = docContent(result);
+    ASSERT_EQ(3, content.size());
+    expectNodeType(content.at(0).toObject(), QStringLiteral("paragraph"));
+    EXPECT_EQ(QStringLiteral("before"), paragraphContent(content.at(0).toObject()).at(0).toObject().value(QStringLiteral("text")).toString());
+    expectNodeType(content.at(1).toObject(), QStringLiteral("voiceBlock"));
+    EXPECT_EQ(QStringLiteral("voice-2"), nodeAttrs(content.at(1).toObject()).value(QStringLiteral("voiceId")).toString());
+    expectNodeType(content.at(2).toObject(), QStringLiteral("paragraph"));
+    EXPECT_EQ(QStringLiteral("after"), paragraphContent(content.at(2).toObject()).at(0).toObject().value(QStringLiteral("text")).toString());
+}
+
+TEST(UT_MigrationNoteDataConverter, GeneratesVoiceIdNormalizesPathAndParsesVoiceSize)
+{
+    QJsonObject voiceBlock;
+    voiceBlock.insert(QStringLiteral("type"), 2);
+    voiceBlock.insert(QStringLiteral("voicePath"), QStringLiteral("/tmp/recordings/a.mp3"));
+    voiceBlock.insert(QStringLiteral("voiceSize"), QStringLiteral("60000"));
+    voiceBlock.insert(QStringLiteral("createTime"), QStringLiteral("2026-07-17 10:00:00"));
+    voiceBlock.insert(QStringLiteral("title"), QStringLiteral("录音"));
+    const QJsonObject metadata { { QStringLiteral("noteDatas"), QJsonArray { voiceBlock } } };
+
+    const MigrationNoteDataConversionResult first = MigrationNoteDataConverter::convertBlocks(metadata);
+    const MigrationNoteDataConversionResult second = MigrationNoteDataConverter::convertBlocks(metadata);
+
+    EXPECT_TRUE(first.ok());
+    EXPECT_TRUE(hasWarningCode(first, QStringLiteral("generated-voice-id")));
+    EXPECT_TRUE(hasWarningCode(first, QStringLiteral("normalized-voice-path")));
+    const QJsonObject attrs = nodeAttrs(docContent(first).at(0).toObject());
+    EXPECT_TRUE(attrs.value(QStringLiteral("voiceId")).toString().startsWith(QStringLiteral("legacy-voice-")));
+    EXPECT_EQ(attrs.value(QStringLiteral("voiceId")).toString(), nodeAttrs(docContent(second).at(0).toObject()).value(QStringLiteral("voiceId")).toString());
+    EXPECT_EQ(QStringLiteral("voicenote/a.mp3"), attrs.value(QStringLiteral("voicePath")).toString());
+    EXPECT_EQ(60000, attrs.value(QStringLiteral("voiceSize")).toInt());
+}
+
+TEST(UT_MigrationNoteDataConverter, CoercesInvalidVoiceSizeAndStringFieldsWithWarnings)
+{
+    QJsonObject voiceBlock;
+    voiceBlock.insert(QStringLiteral("type"), 2);
+    voiceBlock.insert(QStringLiteral("voiceId"), QStringLiteral("voice-3"));
+    voiceBlock.insert(QStringLiteral("voicePath"), QStringLiteral("voicenote/c.mp3"));
+    voiceBlock.insert(QStringLiteral("voiceSize"), -10);
+    voiceBlock.insert(QStringLiteral("title"), 12);
+    voiceBlock.insert(QStringLiteral("text"), true);
+    const QJsonObject metadata { { QStringLiteral("noteDatas"), QJsonArray { voiceBlock } } };
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertBlocks(metadata);
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("negative-voice-size")));
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("invalid-voice-string-field")));
+    const QJsonObject attrs = nodeAttrs(docContent(result).at(0).toObject());
+    EXPECT_EQ(0, attrs.value(QStringLiteral("voiceSize")).toInt());
+    EXPECT_TRUE(attrs.value(QStringLiteral("title")).isNull());
+    EXPECT_TRUE(attrs.value(QStringLiteral("text")).isNull());
+}
+
+TEST(UT_MigrationNoteDataConverter, SkipsVoiceBlockWithoutPathAsError)
+{
+    const QString metadata = QStringLiteral(
+        R"({"noteDatas":[{"type":1,"text":"before"},{"type":2,"voiceId":"voice-missing-path","voiceSize":1},{"type":1,"text":"after"}]})");
+
+    const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertBlocks(metadata);
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(hasErrorCode(result, QStringLiteral("missing-voice-path")));
+    const QJsonArray content = docContent(result);
+    ASSERT_EQ(2, content.size());
+    EXPECT_EQ(QStringLiteral("before"), paragraphContent(content.at(0).toObject()).at(0).toObject().value(QStringLiteral("text")).toString());
+    EXPECT_EQ(QStringLiteral("after"), paragraphContent(content.at(1).toObject()).at(0).toObject().value(QStringLiteral("text")).toString());
     const MigrationJsonValidationResult validation = MigrationJsonValidator::validateEnvelope(result.envelope);
-    EXPECT_TRUE(validation.ok()) << validation.errors.value(0).code.toStdString();
+    EXPECT_TRUE(validation.ok()) << (validation.errors.isEmpty() ? std::string() : validation.errors.value(0).code.toStdString());
+}
 
-    const QString repoRoot = findRepoRoot();
-    if (repoRoot.isEmpty()) {
-        GTEST_SKIP() << "web-editor/scripts/validate-envelope.mjs not found";
+TEST(UT_MigrationNoteDataConverter, RejectsUnsafeVoicePaths)
+{
+    const QStringList unsafePaths {
+        QStringLiteral("voicenote/../escape.mp3"),
+        QStringLiteral("voicenote/./a.mp3"),
+        QStringLiteral("voicenote//a.mp3"),
+        QStringLiteral("/tmp/voicenote/../../etc/passwd"),
+        QStringLiteral("/tmp//recordings/a.mp3"),
+    };
+
+    for (const QString &voicePath : unsafePaths) {
+        QJsonObject voiceBlock;
+        voiceBlock.insert(QStringLiteral("type"), 2);
+        voiceBlock.insert(QStringLiteral("voiceId"), QStringLiteral("voice-unsafe"));
+        voiceBlock.insert(QStringLiteral("voicePath"), voicePath);
+        voiceBlock.insert(QStringLiteral("voiceSize"), 1);
+        const QJsonObject metadata { { QStringLiteral("noteDatas"), QJsonArray { voiceBlock } } };
+
+        const MigrationNoteDataConversionResult result = MigrationNoteDataConverter::convertBlocks(metadata);
+
+        EXPECT_FALSE(result.ok()) << voicePath.toStdString();
+        EXPECT_TRUE(hasErrorCode(result, QStringLiteral("invalid-voice-path"))) << voicePath.toStdString();
+        const QJsonArray content = docContent(result);
+        ASSERT_EQ(1, content.size()) << voicePath.toStdString();
+        expectNodeType(content.at(0).toObject(), QStringLiteral("paragraph"));
     }
-
-    QTemporaryFile envelopeFile(QDir::tempPath() + QStringLiteral("/note-data-text-envelope-XXXXXX.json"));
-    ASSERT_TRUE(envelopeFile.open());
-    ASSERT_NE(-1, envelopeFile.write(MigrationJsonBuilder::toCompactJson(result.envelope).toUtf8()));
-    ASSERT_TRUE(envelopeFile.flush());
-
-    QProcess validator;
-    validator.setWorkingDirectory(repoRoot);
-    validator.start(QStringLiteral("node"), { QStringLiteral("web-editor/scripts/validate-envelope.mjs"), envelopeFile.fileName() });
-    ASSERT_TRUE(validator.waitForFinished(30000));
-    EXPECT_EQ(0, validator.exitCode()) << validator.readAllStandardError().toStdString();
 }


### PR DESCRIPTION
## Summary
- Convert legacy `noteDatas` voice blocks into Tiptap `voiceBlock` nodes in `MigrationNoteDataConverter`.
- Preserve voice metadata/text needed for schema V1 persistence while keeping runtime state out of the document.
- Add `MigrationHtmlConverter` for legacy `htmlCode` basic block migration: plain text, `p`, `div`, `br`, `h1-h6`, `blockquote`, unknown block downgrade, and dangerous node filtering.
- Add/extend unit coverage for voice block conversion, basic HTML block conversion, and builder blockquote creation.

## Validation
- `git diff --check`
- Independent g++ build of `/tmp/ut_migrationnotedataconverter`
- `/tmp/ut_migrationnotedataconverter --gtest_filter='UT_MigrationNoteDataConverter.*'` (14/14 passed)
- Independent g++ build of `/tmp/ut_migrationhtmlconverter`
- `/tmp/ut_migrationhtmlconverter --gtest_filter='UT_MigrationHtmlConverter.*'` (6/6 passed)
- Independent g++ build of `/tmp/ut_migrationjsonbuilder`
- `/tmp/ut_migrationjsonbuilder --gtest_filter='UT_MigrationJsonBuilder.*'` (8/8 passed)
- `cmake -S . -B build`
- `cmake --build build --target deepin-voice-note -j2`
- `npm test --prefix web-editor` (18/18 passed)

Issue: V-240
