### PR TITLE
V-240: convert HTML text marks

### DIFF
--- a/src/importolddata/tiptapmigration/migrationhtmlconverter.cpp
+++ b/src/importolddata/tiptapmigration/migrationhtmlconverter.cpp
@@ -7,8 +7,11 @@
 #include "migrationjsonbuilder.h"
 
 #include <QJsonArray>
+#include <QJsonObject>
 #include <QJsonValue>
+#include <QRegularExpression>
 #include <QSet>
+#include <QStringList>
 
 namespace {
 
@@ -60,6 +63,21 @@ const QSet<QString> &blockTags()
     return tags;
 }
 
+const QSet<QString> &supportedStyleProperties()
+{
+    static const QSet<QString> properties {
+        QStringLiteral("background-color"),
+        QStringLiteral("color"),
+        QStringLiteral("font-family"),
+        QStringLiteral("font-size"),
+        QStringLiteral("font-style"),
+        QStringLiteral("font-weight"),
+        QStringLiteral("text-decoration"),
+        QStringLiteral("text-decoration-line")
+    };
+    return properties;
+}
+
 void addIssue(QVector<MigrationHtmlConversionIssue> &issues,
               const QString &path,
               const QString &code,
@@ -74,6 +92,11 @@ void addWarning(MigrationHtmlConversionResult &result,
                 const QString &message)
 {
     addIssue(result.warnings, path, code, message);
+}
+
+QString elementPath(const MigrationHtmlNode &node)
+{
+    return QStringLiteral("/%1").arg(node.tagName.isEmpty() ? QStringLiteral("node") : node.tagName);
 }
 
 void copyParseIssues(const MigrationHtmlParseResult &parsed, MigrationHtmlConversionResult &result)
@@ -123,6 +146,11 @@ bool isHardBreakNode(const QJsonValue &value)
     return value.isObject() && value.toObject().value(QStringLiteral("type")).toString() == QStringLiteral("hardBreak");
 }
 
+QJsonArray marksOfTextNode(const QJsonObject &node)
+{
+    return node.value(QStringLiteral("marks")).toArray();
+}
+
 bool contentEndsWithSpace(const QJsonArray &content)
 {
     if (content.isEmpty() || !isTextNode(content.at(content.size() - 1))) {
@@ -132,7 +160,57 @@ bool contentEndsWithSpace(const QJsonArray &content)
     return content.at(content.size() - 1).toObject().value(QStringLiteral("text")).toString().endsWith(QLatin1Char(' '));
 }
 
-void appendTextNode(QJsonArray &content, const QString &text)
+QString markTypeOf(const QJsonValue &value)
+{
+    return value.isObject() ? value.toObject().value(QStringLiteral("type")).toString() : QString();
+}
+
+QJsonArray withoutMarkType(const QJsonArray &marks, const QString &type)
+{
+    QJsonArray filtered;
+    for (const QJsonValue &mark : marks) {
+        if (markTypeOf(mark) != type) {
+            filtered.append(mark);
+        }
+    }
+    return filtered;
+}
+
+QJsonArray withMark(QJsonArray marks, const QJsonObject &mark)
+{
+    const QString type = mark.value(QStringLiteral("type")).toString();
+    if (type.isEmpty()) {
+        return marks;
+    }
+
+    marks = withoutMarkType(marks, type);
+    marks.append(mark);
+    return marks;
+}
+
+QJsonArray withSimpleMark(const QJsonArray &marks, const QString &type)
+{
+    return withMark(marks, MigrationJsonBuilder::makeMark(type));
+}
+
+QJsonArray withoutSimpleMark(const QJsonArray &marks, const QString &type)
+{
+    return withoutMarkType(marks, type);
+}
+
+QJsonArray withAttrMark(const QJsonArray &marks,
+                        const QString &type,
+                        const QString &attrName,
+                        const QString &attrValue)
+{
+    if (attrValue.isEmpty()) {
+        return marks;
+    }
+
+    return withMark(marks, MigrationJsonBuilder::makeMark(type, QJsonObject { { attrName, attrValue } }));
+}
+
+void appendTextNode(QJsonArray &content, const QString &text, const QJsonArray &marks)
 {
     if (text.isEmpty()) {
         return;
@@ -140,15 +218,17 @@ void appendTextNode(QJsonArray &content, const QString &text)
 
     if (!content.isEmpty() && isTextNode(content.at(content.size() - 1))) {
         QJsonObject last = content.at(content.size() - 1).toObject();
-        last.insert(QStringLiteral("text"), last.value(QStringLiteral("text")).toString() + text);
-        content.replace(content.size() - 1, last);
-        return;
+        if (marksOfTextNode(last) == marks) {
+            last.insert(QStringLiteral("text"), last.value(QStringLiteral("text")).toString() + text);
+            content.replace(content.size() - 1, last);
+            return;
+        }
     }
 
-    content.append(MigrationJsonBuilder::makeText(text));
+    content.append(MigrationJsonBuilder::makeText(text, marks));
 }
 
-void appendVisibleText(QJsonArray &content, const QString &text)
+void appendVisibleText(QJsonArray &content, const QString &text, const QJsonArray &marks)
 {
     QString normalized;
     bool pendingSpace = false;
@@ -173,7 +253,7 @@ void appendVisibleText(QJsonArray &content, const QString &text)
         normalized.append(QLatin1Char(' '));
     }
 
-    appendTextNode(content, normalized);
+    appendTextNode(content, normalized, marks);
 }
 
 void trimTrailingTextSpace(QJsonArray &content)
@@ -202,24 +282,348 @@ void appendHardBreak(QJsonArray &content)
     content.append(MigrationJsonBuilder::makeHardBreak());
 }
 
-void appendInlineNode(const MigrationHtmlNode &node, QJsonArray &content, MigrationHtmlConversionResult &result);
-
-void appendInlineChildren(const MigrationHtmlNode &node, QJsonArray &content, MigrationHtmlConversionResult &result)
+QString stripImportant(QString value)
 {
-    for (const MigrationHtmlNode &child : node.children) {
-        appendInlineNode(child, content, result);
+    value = value.trimmed();
+    if (value.endsWith(QStringLiteral("!important"), Qt::CaseInsensitive)) {
+        value.chop(QStringLiteral("!important").size());
+        value = value.trimmed();
+    }
+    return value;
+}
+
+QStringList styleDeclarations(const MigrationHtmlNode &node)
+{
+    return MigrationHtmlParser::attribute(node, QStringLiteral("style")).split(QLatin1Char(';'), Qt::SkipEmptyParts);
+}
+
+void warnUnsupportedStyle(const MigrationHtmlNode &node,
+                          const QString &property,
+                          MigrationHtmlConversionResult &result)
+{
+    addWarning(result,
+               elementPath(node) + QStringLiteral(".style.%1").arg(property),
+               QStringLiteral("unsupported-html-style"),
+               QStringLiteral("HTML style '%1' is not supported by this migration step and was ignored").arg(property));
+}
+
+void warnInvalidStyleValue(const MigrationHtmlNode &node,
+                           const QString &property,
+                           MigrationHtmlConversionResult &result)
+{
+    addWarning(result,
+               elementPath(node) + QStringLiteral(".style.%1").arg(property),
+               QStringLiteral("invalid-html-style-value"),
+               QStringLiteral("HTML style '%1' has an unsupported value and was ignored").arg(property));
+}
+
+QString normalizedHexByte(int value)
+{
+    return QStringLiteral("%1").arg(value, 2, 16, QLatin1Char('0'));
+}
+
+QString normalizedColorValue(QString value)
+{
+    value = stripImportant(value).toLower();
+    value.remove(QLatin1Char(' '));
+    if (value.isEmpty()) {
+        return QString();
+    }
+
+    static const QRegularExpression shortHex(QStringLiteral("^#([0-9a-f]{3})$"));
+    const QRegularExpressionMatch shortHexMatch = shortHex.match(value);
+    if (shortHexMatch.hasMatch()) {
+        const QString digits = shortHexMatch.captured(1);
+        return QStringLiteral("#%1%1%2%2%3%3")
+            .arg(digits.at(0))
+            .arg(digits.at(1))
+            .arg(digits.at(2));
+    }
+
+    static const QRegularExpression longHex(QStringLiteral("^#[0-9a-f]{6}$"));
+    if (longHex.match(value).hasMatch()) {
+        return value;
+    }
+
+    static const QRegularExpression rgbColor(
+        QStringLiteral("^rgba?\\((\\d{1,3}),(\\d{1,3}),(\\d{1,3})(?:,(?:0|1|0?\\.\\d+))?\\)$"));
+    const QRegularExpressionMatch rgbMatch = rgbColor.match(value);
+    if (rgbMatch.hasMatch()) {
+        bool redOk = false;
+        bool greenOk = false;
+        bool blueOk = false;
+        const int red = rgbMatch.captured(1).toInt(&redOk);
+        const int green = rgbMatch.captured(2).toInt(&greenOk);
+        const int blue = rgbMatch.captured(3).toInt(&blueOk);
+        if (redOk && greenOk && blueOk && red >= 0 && red <= 255 && green >= 0 && green <= 255 && blue >= 0 && blue <= 255) {
+            return QStringLiteral("#%1%2%3")
+                .arg(normalizedHexByte(red), normalizedHexByte(green), normalizedHexByte(blue));
+        }
+    }
+
+    static const QSet<QString> namedColors {
+        QStringLiteral("black"),
+        QStringLiteral("blue"),
+        QStringLiteral("cyan"),
+        QStringLiteral("gray"),
+        QStringLiteral("green"),
+        QStringLiteral("grey"),
+        QStringLiteral("magenta"),
+        QStringLiteral("orange"),
+        QStringLiteral("purple"),
+        QStringLiteral("red"),
+        QStringLiteral("transparent"),
+        QStringLiteral("white"),
+        QStringLiteral("yellow")
+    };
+    if (namedColors.contains(value)) {
+        return value;
+    }
+
+    return QString();
+}
+
+QString normalizedFontFamily(QString value)
+{
+    value = stripImportant(value).trimmed();
+    return value.contains(QLatin1Char(';')) ? QString() : value;
+}
+
+QString normalizedFontSize(QString value)
+{
+    value = stripImportant(value).trimmed().toLower();
+    static const QRegularExpression cssSize(QStringLiteral("^\\d+(?:\\.\\d+)?(?:px|pt|em|rem|%)$"));
+    return cssSize.match(value).hasMatch() ? value : QString();
+}
+
+bool isBoldFontWeight(QString value, bool *known)
+{
+    value = stripImportant(value).trimmed().toLower();
+    *known = true;
+    if (value == QStringLiteral("bold") || value == QStringLiteral("bolder")) {
+        return true;
+    }
+    if (value == QStringLiteral("normal") || value == QStringLiteral("lighter")) {
+        return false;
+    }
+
+    bool ok = false;
+    const int numericWeight = value.toInt(&ok);
+    if (ok) {
+        return numericWeight >= 600;
+    }
+
+    *known = false;
+    return false;
+}
+
+bool isItalicFontStyle(QString value, bool *known)
+{
+    value = stripImportant(value).trimmed().toLower();
+    *known = true;
+    if (value == QStringLiteral("italic") || value == QStringLiteral("oblique")) {
+        return true;
+    }
+    if (value == QStringLiteral("normal")) {
+        return false;
+    }
+
+    *known = false;
+    return false;
+}
+
+void applyTextDecorationMarks(const MigrationHtmlNode &node,
+                              const QString &property,
+                              QString value,
+                              QJsonArray *marks,
+                              MigrationHtmlConversionResult &result)
+{
+    value = stripImportant(value).toLower();
+    const QStringList tokens = value.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+    if (tokens.isEmpty()) {
+        warnInvalidStyleValue(node, property, result);
+        return;
+    }
+
+    bool hasUnsupportedToken = false;
+    bool hasDecorationToken = false;
+    bool hasNoneToken = false;
+    for (const QString &token : tokens) {
+        if (token == QStringLiteral("underline")) {
+            *marks = withSimpleMark(*marks, QStringLiteral("underline"));
+            hasDecorationToken = true;
+        } else if (token == QStringLiteral("line-through")) {
+            *marks = withSimpleMark(*marks, QStringLiteral("strike"));
+            hasDecorationToken = true;
+        } else if (token == QStringLiteral("none")) {
+            hasNoneToken = true;
+        } else {
+            hasUnsupportedToken = true;
+        }
+    }
+
+    // Treat a standalone 'none' as an explicit close for inherited decoration marks.
+    if (hasNoneToken && !hasDecorationToken) {
+        *marks = withoutSimpleMark(*marks, QStringLiteral("underline"));
+        *marks = withoutSimpleMark(*marks, QStringLiteral("strike"));
+    }
+
+    if (hasUnsupportedToken) {
+        warnInvalidStyleValue(node, property, result);
     }
 }
 
-void appendInlineNode(const MigrationHtmlNode &node, QJsonArray &content, MigrationHtmlConversionResult &result)
+void warnUnsupportedStyleDeclarations(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+{
+    for (const QString &declaration : styleDeclarations(node)) {
+        const int colonIndex = declaration.indexOf(QLatin1Char(':'));
+        if (colonIndex <= 0) {
+            continue;
+        }
+
+        const QString property = declaration.left(colonIndex).trimmed().toLower();
+        if (!property.isEmpty() && !supportedStyleProperties().contains(property)) {
+            warnUnsupportedStyle(node, property, result);
+        }
+    }
+}
+
+void applyStyleMarks(const MigrationHtmlNode &node, QJsonArray *marks, MigrationHtmlConversionResult &result)
+{
+    for (const QString &declaration : styleDeclarations(node)) {
+        const int colonIndex = declaration.indexOf(QLatin1Char(':'));
+        if (colonIndex <= 0) {
+            continue;
+        }
+
+        const QString property = declaration.left(colonIndex).trimmed().toLower();
+        const QString value = declaration.mid(colonIndex + 1).trimmed();
+        if (property == QStringLiteral("color")) {
+            const QString color = normalizedColorValue(value);
+            if (color.isEmpty()) {
+                warnInvalidStyleValue(node, property, result);
+            } else {
+                *marks = withAttrMark(*marks, QStringLiteral("color"), QStringLiteral("color"), color);
+            }
+            continue;
+        }
+
+        if (property == QStringLiteral("background-color")) {
+            const QString color = normalizedColorValue(value);
+            if (color.isEmpty()) {
+                warnInvalidStyleValue(node, property, result);
+            } else {
+                *marks = withAttrMark(*marks, QStringLiteral("highlight"), QStringLiteral("color"), color);
+            }
+            continue;
+        }
+
+        if (property == QStringLiteral("font-family")) {
+            const QString fontFamily = normalizedFontFamily(value);
+            if (fontFamily.isEmpty()) {
+                warnInvalidStyleValue(node, property, result);
+            } else {
+                *marks = withAttrMark(*marks, QStringLiteral("fontFamily"), QStringLiteral("fontFamily"), fontFamily);
+            }
+            continue;
+        }
+
+        if (property == QStringLiteral("font-size")) {
+            const QString fontSize = normalizedFontSize(value);
+            if (fontSize.isEmpty()) {
+                warnInvalidStyleValue(node, property, result);
+            } else {
+                *marks = withAttrMark(*marks, QStringLiteral("fontSize"), QStringLiteral("fontSize"), fontSize);
+            }
+            continue;
+        }
+
+        if (property == QStringLiteral("font-weight")) {
+            bool known = false;
+            if (isBoldFontWeight(value, &known)) {
+                *marks = withSimpleMark(*marks, QStringLiteral("bold"));
+            } else if (known) {
+                *marks = withoutSimpleMark(*marks, QStringLiteral("bold"));
+            } else if (!known) {
+                warnInvalidStyleValue(node, property, result);
+            }
+            continue;
+        }
+
+        if (property == QStringLiteral("font-style")) {
+            bool known = false;
+            if (isItalicFontStyle(value, &known)) {
+                *marks = withSimpleMark(*marks, QStringLiteral("italic"));
+            } else if (known) {
+                *marks = withoutSimpleMark(*marks, QStringLiteral("italic"));
+            } else if (!known) {
+                warnInvalidStyleValue(node, property, result);
+            }
+            continue;
+        }
+
+        if (property == QStringLiteral("text-decoration") || property == QStringLiteral("text-decoration-line")) {
+            applyTextDecorationMarks(node, property, value, marks, result);
+        }
+    }
+}
+
+QJsonArray marksForElement(const MigrationHtmlNode &node,
+                           const QJsonArray &inheritedMarks,
+                           MigrationHtmlConversionResult &result)
+{
+    QJsonArray marks = inheritedMarks;
+    if (node.tagName == QStringLiteral("b") || node.tagName == QStringLiteral("strong")) {
+        marks = withSimpleMark(marks, QStringLiteral("bold"));
+    } else if (node.tagName == QStringLiteral("i") || node.tagName == QStringLiteral("em")) {
+        marks = withSimpleMark(marks, QStringLiteral("italic"));
+    } else if (node.tagName == QStringLiteral("u")) {
+        marks = withSimpleMark(marks, QStringLiteral("underline"));
+    } else if (node.tagName == QStringLiteral("s") || node.tagName == QStringLiteral("strike") || node.tagName == QStringLiteral("del")) {
+        marks = withSimpleMark(marks, QStringLiteral("strike"));
+    } else if (node.tagName == QStringLiteral("font")) {
+        const QString color = normalizedColorValue(MigrationHtmlParser::attribute(node, QStringLiteral("color")));
+        const QString face = normalizedFontFamily(MigrationHtmlParser::attribute(node, QStringLiteral("face")));
+        if (!color.isEmpty()) {
+            marks = withAttrMark(marks, QStringLiteral("color"), QStringLiteral("color"), color);
+        }
+        if (!face.isEmpty()) {
+            marks = withAttrMark(marks, QStringLiteral("fontFamily"), QStringLiteral("fontFamily"), face);
+        }
+    }
+
+    warnUnsupportedStyleDeclarations(node, result);
+    applyStyleMarks(node, &marks, result);
+    return marks;
+}
+
+void appendInlineNode(const MigrationHtmlNode &node,
+                      QJsonArray &content,
+                      const QJsonArray &marks,
+                      MigrationHtmlConversionResult &result);
+
+void appendInlineChildren(const MigrationHtmlNode &node,
+                          QJsonArray &content,
+                          const QJsonArray &marks,
+                          MigrationHtmlConversionResult &result)
+{
+    for (const MigrationHtmlNode &child : node.children) {
+        appendInlineNode(child, content, marks, result);
+    }
+}
+
+void appendInlineNode(const MigrationHtmlNode &node,
+                      QJsonArray &content,
+                      const QJsonArray &marks,
+                      MigrationHtmlConversionResult &result)
 {
     if (node.type == MigrationHtmlNodeType::Text) {
-        appendVisibleText(content, node.text);
+        appendVisibleText(content, node.text, marks);
         return;
     }
 
     if (node.type != MigrationHtmlNodeType::Element) {
-        appendInlineChildren(node, content, result);
+        appendInlineChildren(node, content, marks, result);
         return;
     }
 
@@ -236,7 +640,7 @@ void appendInlineNode(const MigrationHtmlNode &node, QJsonArray &content, Migrat
         appendHardBreak(content);
     }
 
-    appendInlineChildren(node, content, result);
+    appendInlineChildren(node, content, marksForElement(node, marks, result), result);
 }
 
 void appendParagraphIfContent(QJsonArray &inlineContent, QJsonArray &blocks)
@@ -251,7 +655,7 @@ void appendParagraphIfContent(QJsonArray &inlineContent, QJsonArray &blocks)
 QJsonArray inlineContentFrom(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
 {
     QJsonArray content;
-    appendInlineChildren(node, content, result);
+    appendInlineChildren(node, content, marksForElement(node, QJsonArray(), result), result);
     trimTrailingTextSpace(content);
     return content;
 }
@@ -274,7 +678,7 @@ void appendBlocksFromChildren(const MigrationHtmlNode &node, QJsonArray &blocks,
             continue;
         }
 
-        appendInlineNode(child, inlineContent, result);
+        appendInlineNode(child, inlineContent, QJsonArray(), result);
     }
 
     if (!inlineContent.isEmpty()) {

--- a/src/importolddata/tiptapmigration/migrationhtmlconverter.cpp
+++ b/src/importolddata/tiptapmigration/migrationhtmlconverter.cpp
@@ -72,6 +72,7 @@ const QSet<QString> &supportedStyleProperties()
         QStringLiteral("font-size"),
         QStringLiteral("font-style"),
         QStringLiteral("font-weight"),
+        QStringLiteral("text-align"),
         QStringLiteral("text-decoration"),
         QStringLiteral("text-decoration-line")
     };
@@ -129,6 +130,17 @@ bool isHeadingElement(const MigrationHtmlNode &node)
 
     const QChar level = node.tagName.at(1);
     return level >= QLatin1Char('1') && level <= QLatin1Char('6');
+}
+
+bool isListElement(const MigrationHtmlNode &node)
+{
+    return node.type == MigrationHtmlNodeType::Element
+        && (node.tagName == QStringLiteral("ul") || node.tagName == QStringLiteral("ol"));
+}
+
+bool isListItemElement(const MigrationHtmlNode &node)
+{
+    return node.type == MigrationHtmlNodeType::Element && node.tagName == QStringLiteral("li");
 }
 
 int headingLevel(const MigrationHtmlNode &node)
@@ -317,6 +329,24 @@ void warnInvalidStyleValue(const MigrationHtmlNode &node,
                QStringLiteral("HTML style '%1' has an unsupported value and was ignored").arg(property));
 }
 
+void warnDowngradedTextAlign(const MigrationHtmlNode &node,
+                             const QString &value,
+                             MigrationHtmlConversionResult &result)
+{
+    addWarning(result,
+               elementPath(node) + QStringLiteral(".style.text-align"),
+               QStringLiteral("downgraded-text-align"),
+               QStringLiteral("HTML text-align '%1' is not supported by Schema V1 and was ignored").arg(value));
+}
+
+void warnInvalidListChild(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+{
+    addWarning(result,
+               elementPath(node),
+               QStringLiteral("downgraded-html-list-child"),
+               QStringLiteral("HTML node <%1> inside a list was wrapped into a list item").arg(node.tagName));
+}
+
 QString normalizedHexByte(int value)
 {
     return QStringLiteral("%1").arg(value, 2, 16, QLatin1Char('0'));
@@ -394,6 +424,33 @@ QString normalizedFontSize(QString value)
     value = stripImportant(value).trimmed().toLower();
     static const QRegularExpression cssSize(QStringLiteral("^\\d+(?:\\.\\d+)?(?:px|pt|em|rem|%)$"));
     return cssSize.match(value).hasMatch() ? value : QString();
+}
+
+void warnTextAlignDeclarations(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+{
+    for (const QString &declaration : styleDeclarations(node)) {
+        const int colonIndex = declaration.indexOf(QLatin1Char(':'));
+        if (colonIndex <= 0) {
+            continue;
+        }
+
+        const QString property = declaration.left(colonIndex).trimmed().toLower();
+        if (property != QStringLiteral("text-align")) {
+            continue;
+        }
+
+        const QString value = stripImportant(declaration.mid(colonIndex + 1)).trimmed().toLower();
+        if (value == QStringLiteral("left") || value == QStringLiteral("start") || value == QStringLiteral("initial")) {
+            continue;
+        }
+
+        if (value == QStringLiteral("center") || value == QStringLiteral("right")
+            || value == QStringLiteral("end") || value == QStringLiteral("justify")) {
+            warnDowngradedTextAlign(node, value, result);
+        } else {
+            warnInvalidStyleValue(node, property, result);
+        }
+    }
 }
 
 bool isBoldFontWeight(QString value, bool *known)
@@ -652,17 +709,28 @@ void appendParagraphIfContent(QJsonArray &inlineContent, QJsonArray &blocks)
     inlineContent = QJsonArray();
 }
 
-QJsonArray inlineContentFrom(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+QJsonArray inlineContentFrom(const MigrationHtmlNode &node,
+                             MigrationHtmlConversionResult &result,
+                             const QJsonArray &inheritedMarks = QJsonArray())
 {
     QJsonArray content;
-    appendInlineChildren(node, content, marksForElement(node, QJsonArray(), result), result);
+    appendInlineChildren(node, content, marksForElement(node, inheritedMarks, result), result);
     trimTrailingTextSpace(content);
     return content;
 }
 
-QJsonObject blockFromElement(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result);
+QJsonObject blockFromElement(const MigrationHtmlNode &node,
+                             MigrationHtmlConversionResult &result,
+                             const QJsonArray &inheritedMarks = QJsonArray());
 
-void appendBlocksFromChildren(const MigrationHtmlNode &node, QJsonArray &blocks, MigrationHtmlConversionResult &result)
+QJsonObject listFromElement(const MigrationHtmlNode &node,
+                            MigrationHtmlConversionResult &result,
+                            const QJsonArray &inheritedMarks = QJsonArray());
+
+void appendBlocksFromChildren(const MigrationHtmlNode &node,
+                              QJsonArray &blocks,
+                              MigrationHtmlConversionResult &result,
+                              const QJsonArray &inheritedMarks = QJsonArray())
 {
     QJsonArray inlineContent;
     for (const MigrationHtmlNode &child : node.children) {
@@ -674,11 +742,11 @@ void appendBlocksFromChildren(const MigrationHtmlNode &node, QJsonArray &blocks,
             if (!inlineContent.isEmpty()) {
                 appendParagraphIfContent(inlineContent, blocks);
             }
-            blocks.append(blockFromElement(child, result));
+            blocks.append(blockFromElement(child, result, inheritedMarks));
             continue;
         }
 
-        appendInlineNode(child, inlineContent, QJsonArray(), result);
+        appendInlineNode(child, inlineContent, inheritedMarks, result);
     }
 
     if (!inlineContent.isEmpty()) {
@@ -686,7 +754,9 @@ void appendBlocksFromChildren(const MigrationHtmlNode &node, QJsonArray &blocks,
     }
 }
 
-QJsonObject downgradedParagraphFromBlock(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+QJsonObject downgradedParagraphFromBlock(const MigrationHtmlNode &node,
+                                         MigrationHtmlConversionResult &result,
+                                         const QJsonArray &inheritedMarks = QJsonArray())
 {
     if (node.tagName != QStringLiteral("p") && node.tagName != QStringLiteral("div")) {
         addWarning(result,
@@ -695,27 +765,145 @@ QJsonObject downgradedParagraphFromBlock(const MigrationHtmlNode &node, Migratio
                    QStringLiteral("HTML block <%1> was downgraded to paragraph").arg(node.tagName));
     }
 
-    return MigrationJsonBuilder::makeParagraph(inlineContentFrom(node, result));
+    return MigrationJsonBuilder::makeParagraph(inlineContentFrom(node, result, inheritedMarks));
 }
 
-QJsonObject blockquoteFromElement(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+void appendInlineContentAsParagraph(QJsonArray &inlineContent, QJsonArray &blocks)
+{
+    trimTrailingTextSpace(inlineContent);
+    if (!inlineContent.isEmpty()) {
+        blocks.append(MigrationJsonBuilder::makeParagraph(inlineContent));
+    }
+    inlineContent = QJsonArray();
+}
+
+QJsonArray listItemContentFromElement(const MigrationHtmlNode &node,
+                                      MigrationHtmlConversionResult &result,
+                                      const QJsonArray &parentMarks = QJsonArray())
 {
     QJsonArray content;
-    appendBlocksFromChildren(node, content, result);
+    QJsonArray inlineContent;
+    warnTextAlignDeclarations(node, result);
+    const QJsonArray inheritedMarks = marksForElement(node, parentMarks, result);
+
+    for (const MigrationHtmlNode &child : node.children) {
+        if (isDangerousElement(child)) {
+            continue;
+        }
+
+        if (isListElement(child)) {
+            appendInlineContentAsParagraph(inlineContent, content);
+            if (content.isEmpty()) {
+                content.append(MigrationJsonBuilder::makeParagraph());
+            }
+            content.append(listFromElement(child, result, inheritedMarks));
+            continue;
+        }
+
+        if (isBlockElement(child)) {
+            appendInlineContentAsParagraph(inlineContent, content);
+            content.append(blockFromElement(child, result, inheritedMarks));
+            continue;
+        }
+
+        appendInlineNode(child, inlineContent, inheritedMarks, result);
+    }
+
+    appendInlineContentAsParagraph(inlineContent, content);
+    return content;
+}
+
+QJsonObject listItemFromInvalidListChild(const MigrationHtmlNode &node,
+                                         MigrationHtmlConversionResult &result,
+                                         const QJsonArray &parentMarks = QJsonArray())
+{
+    warnInvalidListChild(node, result);
+
+    if (isListElement(node)) {
+        return MigrationJsonBuilder::makeListItem(QJsonArray {
+            MigrationJsonBuilder::makeParagraph(),
+            listFromElement(node, result, parentMarks)
+        });
+    }
+
+    if (isBlockElement(node)) {
+        return MigrationJsonBuilder::makeListItem(QJsonArray { blockFromElement(node, result, parentMarks) });
+    }
+
+    QJsonArray inlineContent;
+    appendInlineNode(node, inlineContent, parentMarks, result);
+    trimTrailingTextSpace(inlineContent);
+    return MigrationJsonBuilder::makeListItem(QJsonArray { MigrationJsonBuilder::makeParagraph(inlineContent) });
+}
+
+QJsonObject listFromElement(const MigrationHtmlNode &node,
+                            MigrationHtmlConversionResult &result,
+                            const QJsonArray &inheritedMarks)
+{
+    warnTextAlignDeclarations(node, result);
+    const QJsonArray listMarks = marksForElement(node, inheritedMarks, result);
+
+    QJsonArray items;
+    for (const MigrationHtmlNode &child : node.children) {
+        if (isDangerousElement(child)) {
+            continue;
+        }
+
+        if (child.type == MigrationHtmlNodeType::Text && child.text.trimmed().isEmpty()) {
+            continue;
+        }
+
+        if (isListItemElement(child)) {
+            items.append(MigrationJsonBuilder::makeListItem(
+                listItemContentFromElement(child, result, listMarks)));
+        } else {
+            items.append(listItemFromInvalidListChild(child, result, listMarks));
+        }
+    }
+
+    return node.tagName == QStringLiteral("ol")
+        ? MigrationJsonBuilder::makeOrderedList(items)
+        : MigrationJsonBuilder::makeBulletList(items);
+}
+
+QJsonObject blockquoteFromElement(const MigrationHtmlNode &node,
+                                  MigrationHtmlConversionResult &result,
+                                  const QJsonArray &inheritedMarks = QJsonArray())
+{
+    QJsonArray content;
+    appendBlocksFromChildren(node, content, result, inheritedMarks);
     return MigrationJsonBuilder::makeBlockquote(content);
 }
 
-QJsonObject blockFromElement(const MigrationHtmlNode &node, MigrationHtmlConversionResult &result)
+QJsonObject blockFromElement(const MigrationHtmlNode &node,
+                             MigrationHtmlConversionResult &result,
+                             const QJsonArray &inheritedMarks)
 {
     if (isHeadingElement(node)) {
-        return MigrationJsonBuilder::makeHeading(headingLevel(node), inlineContentFrom(node, result));
+        warnTextAlignDeclarations(node, result);
+        return MigrationJsonBuilder::makeHeading(headingLevel(node), inlineContentFrom(node, result, inheritedMarks));
+    }
+
+    if (isListElement(node)) {
+        return listFromElement(node, result, inheritedMarks);
+    }
+
+    if (isListItemElement(node)) {
+        warnTextAlignDeclarations(node, result);
+        addWarning(result,
+                   elementPath(node),
+                   QStringLiteral("downgraded-orphan-list-item"),
+                   QStringLiteral("HTML list item outside a list was downgraded to paragraph"));
+        return downgradedParagraphFromBlock(node, result, inheritedMarks);
     }
 
     if (node.tagName == QStringLiteral("blockquote")) {
-        return blockquoteFromElement(node, result);
+        warnTextAlignDeclarations(node, result);
+        return blockquoteFromElement(node, result, inheritedMarks);
     }
 
-    return downgradedParagraphFromBlock(node, result);
+    warnTextAlignDeclarations(node, result);
+    return downgradedParagraphFromBlock(node, result, inheritedMarks);
 }
 
 QJsonObject envelopeFromParsed(const MigrationHtmlParseResult &parsed, MigrationHtmlConversionResult &result)

--- a/tests/src/importolddata/tiptapmigration/ut_migrationhtmlconverter.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationhtmlconverter.cpp
@@ -36,6 +36,33 @@ QString textOf(const QJsonObject &node)
     return node.value(QStringLiteral("text")).toString();
 }
 
+QJsonArray marksOf(const QJsonObject &node)
+{
+    return node.value(QStringLiteral("marks")).toArray();
+}
+
+QJsonObject markOfType(const QJsonObject &node, const QString &type)
+{
+    for (const QJsonValue &markValue : marksOf(node)) {
+        const QJsonObject mark = markValue.toObject();
+        if (mark.value(QStringLiteral("type")).toString() == type) {
+            return mark;
+        }
+    }
+
+    return QJsonObject();
+}
+
+bool hasMark(const QJsonObject &node, const QString &type)
+{
+    return !markOfType(node, type).isEmpty();
+}
+
+QJsonObject markAttrsOf(const QJsonObject &node, const QString &type)
+{
+    return markOfType(node, type).value(QStringLiteral("attrs")).toObject();
+}
+
 bool hasWarningCode(const MigrationHtmlConversionResult &result, const QString &code)
 {
     for (const MigrationHtmlConversionIssue &warning : result.warnings) {
@@ -169,4 +196,200 @@ TEST(UT_MigrationHtmlConverter, SkipsDangerousNodesAndTheirContent)
     const QJsonArray content = nodeContentOf(blocks.at(0).toObject());
     ASSERT_EQ(1, content.size());
     EXPECT_EQ(QStringLiteral("safetail"), textOf(content.at(0).toObject()));
+}
+
+TEST(UT_MigrationHtmlConverter, ConvertsNestedTagMarksAndDeduplicates)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><strong>A <em>B</em></strong><b><strong>C</strong></b></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(1, blocks.size());
+    const QJsonArray content = nodeContentOf(blocks.at(0).toObject());
+    ASSERT_EQ(3, content.size());
+
+    const QJsonObject boldText = content.at(0).toObject();
+    EXPECT_EQ(QStringLiteral("A"), textOf(boldText).trimmed());
+    EXPECT_TRUE(hasMark(boldText, QStringLiteral("bold")));
+    EXPECT_EQ(1, marksOf(boldText).size());
+
+    const QJsonObject nestedText = content.at(1).toObject();
+    EXPECT_EQ(QStringLiteral("B"), textOf(nestedText));
+    EXPECT_TRUE(hasMark(nestedText, QStringLiteral("bold")));
+    EXPECT_TRUE(hasMark(nestedText, QStringLiteral("italic")));
+    EXPECT_EQ(2, marksOf(nestedText).size());
+
+    const QJsonObject dedupedText = content.at(2).toObject();
+    EXPECT_EQ(QStringLiteral("C"), textOf(dedupedText));
+    EXPECT_TRUE(hasMark(dedupedText, QStringLiteral("bold")));
+    EXPECT_EQ(1, marksOf(dedupedText).size());
+}
+
+TEST(UT_MigrationHtmlConverter, ConvertsInlineStyleMarksAndNormalizesColors)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><span style=\"color: rgb(10, 20, 30); background-color: #abc; "
+                       "font-family: Noto Sans; font-size: 14PX\">Styled</span></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    EXPECT_TRUE(result.warnings.isEmpty());
+
+    const QJsonArray content = nodeContentOf(docContentOf(result).at(0).toObject());
+    ASSERT_EQ(1, content.size());
+    const QJsonObject text = content.at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Styled"), textOf(text));
+    EXPECT_EQ(QStringLiteral("#0a141e"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
+    EXPECT_EQ(QStringLiteral("#aabbcc"), markAttrsOf(text, QStringLiteral("highlight")).value(QStringLiteral("color")).toString());
+    EXPECT_EQ(QStringLiteral("Noto Sans"), markAttrsOf(text, QStringLiteral("fontFamily")).value(QStringLiteral("fontFamily")).toString());
+    EXPECT_EQ(QStringLiteral("14px"), markAttrsOf(text, QStringLiteral("fontSize")).value(QStringLiteral("fontSize")).toString());
+}
+
+TEST(UT_MigrationHtmlConverter, ConvertsStyleEquivalentTextMarks)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><span style=\"font-weight: 700; font-style: italic; "
+                       "text-decoration: underline line-through\">Decorated</span></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonObject text = nodeContentOf(docContentOf(result).at(0).toObject()).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Decorated"), textOf(text));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("bold")));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("italic")));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("underline")));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("strike")));
+}
+
+TEST(UT_MigrationHtmlConverter, NormalFontWeightClearsInheritedBoldMark)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><strong>Bold <span style=\"font-weight: normal\">Plain</span></strong></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray content = nodeContentOf(docContentOf(result).at(0).toObject());
+    ASSERT_EQ(2, content.size());
+    const QJsonObject boldText = content.at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Bold"), textOf(boldText).trimmed());
+    EXPECT_TRUE(hasMark(boldText, QStringLiteral("bold")));
+
+    const QJsonObject plainText = content.at(1).toObject();
+    EXPECT_EQ(QStringLiteral("Plain"), textOf(plainText));
+    EXPECT_FALSE(hasMark(plainText, QStringLiteral("bold")));
+}
+
+TEST(UT_MigrationHtmlConverter, NonBoldFontWeightClearsInheritedStyleBoldMark)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><span style=\"font-weight: bold\">Bold "
+                       "<span style=\"font-weight: 500\">Plain</span></span></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray content = nodeContentOf(docContentOf(result).at(0).toObject());
+    ASSERT_EQ(2, content.size());
+    EXPECT_TRUE(hasMark(content.at(0).toObject(), QStringLiteral("bold")));
+    EXPECT_EQ(QStringLiteral("Plain"), textOf(content.at(1).toObject()));
+    EXPECT_FALSE(hasMark(content.at(1).toObject(), QStringLiteral("bold")));
+}
+
+TEST(UT_MigrationHtmlConverter, NormalFontStyleClearsInheritedItalicMark)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><em>Italic <span style=\"font-style: normal\">Plain</span></em></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray content = nodeContentOf(docContentOf(result).at(0).toObject());
+    ASSERT_EQ(2, content.size());
+    const QJsonObject italicText = content.at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Italic"), textOf(italicText).trimmed());
+    EXPECT_TRUE(hasMark(italicText, QStringLiteral("italic")));
+
+    const QJsonObject plainText = content.at(1).toObject();
+    EXPECT_EQ(QStringLiteral("Plain"), textOf(plainText));
+    EXPECT_FALSE(hasMark(plainText, QStringLiteral("italic")));
+}
+
+TEST(UT_MigrationHtmlConverter, TextDecorationNoneClearsInheritedDecorationMarks)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><u>Under <span style=\"text-decoration: none\">Plain</span></u></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray content = nodeContentOf(docContentOf(result).at(0).toObject());
+    ASSERT_EQ(2, content.size());
+    EXPECT_TRUE(hasMark(content.at(0).toObject(), QStringLiteral("underline")));
+    EXPECT_EQ(QStringLiteral("Plain"), textOf(content.at(1).toObject()));
+    EXPECT_FALSE(hasMark(content.at(1).toObject(), QStringLiteral("underline")));
+    EXPECT_FALSE(hasMark(content.at(1).toObject(), QStringLiteral("strike")));
+}
+
+TEST(UT_MigrationHtmlConverter, WarnsUnsupportedTextDecorationValues)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><span style=\"text-decoration: overline\">Text</span></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("invalid-html-style-value")));
+
+    const QJsonObject text = nodeContentOf(docContentOf(result).at(0).toObject()).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Text"), textOf(text));
+    EXPECT_TRUE(marksOf(text).isEmpty());
+}
+
+TEST(UT_MigrationHtmlConverter, AppliesSupportedTextDecorationAndWarnsUnsupportedTokens)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><span style=\"text-decoration-line: underline overline\">Text</span></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("invalid-html-style-value")));
+
+    const QJsonObject text = nodeContentOf(docContentOf(result).at(0).toObject()).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Text"), textOf(text));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("underline")));
+    EXPECT_FALSE(hasMark(text, QStringLiteral("strike")));
+}
+
+TEST(UT_MigrationHtmlConverter, WarnsUnsupportedAndInvalidStylesButKeepsText)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><span style=\"line-height: 2; color: not a color; "
+                       "font-size: huge\">Text</span></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("unsupported-html-style")));
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("invalid-html-style-value")));
+
+    const QJsonObject text = nodeContentOf(docContentOf(result).at(0).toObject()).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Text"), textOf(text));
+    EXPECT_TRUE(marksOf(text).isEmpty());
+}
+
+TEST(UT_MigrationHtmlConverter, ConvertsFontTagColorAndFace)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p><font color=\"#ABCDEF\" face=\"Noto Serif\">Font</font></p>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonObject text = nodeContentOf(docContentOf(result).at(0).toObject()).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Font"), textOf(text));
+    EXPECT_EQ(QStringLiteral("#abcdef"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
+    EXPECT_EQ(QStringLiteral("Noto Serif"), markAttrsOf(text, QStringLiteral("fontFamily")).value(QStringLiteral("fontFamily")).toString());
 }

--- a/tests/src/importolddata/tiptapmigration/ut_migrationhtmlconverter.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationhtmlconverter.cpp
@@ -393,3 +393,199 @@ TEST(UT_MigrationHtmlConverter, ConvertsFontTagColorAndFace)
     EXPECT_EQ(QStringLiteral("#abcdef"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
     EXPECT_EQ(QStringLiteral("Noto Serif"), markAttrsOf(text, QStringLiteral("fontFamily")).value(QStringLiteral("fontFamily")).toString());
 }
+
+TEST(UT_MigrationHtmlConverter, ConvertsNestedBulletAndOrderedLists)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ul><li>One<ol><li>Two</li></ol></li>"
+                       "<li><p><strong>Three</strong></p></li></ul>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(1, blocks.size());
+    const QJsonObject bulletList = blocks.at(0).toObject();
+    EXPECT_EQ(QStringLiteral("bulletList"), nodeTypeOf(bulletList));
+
+    const QJsonArray bulletItems = nodeContentOf(bulletList);
+    ASSERT_EQ(2, bulletItems.size());
+
+    const QJsonArray firstItemContent = nodeContentOf(bulletItems.at(0).toObject());
+    ASSERT_EQ(2, firstItemContent.size());
+    EXPECT_EQ(QStringLiteral("paragraph"), nodeTypeOf(firstItemContent.at(0).toObject()));
+    EXPECT_EQ(QStringLiteral("One"), textOf(nodeContentOf(firstItemContent.at(0).toObject()).at(0).toObject()));
+    EXPECT_EQ(QStringLiteral("orderedList"), nodeTypeOf(firstItemContent.at(1).toObject()));
+
+    const QJsonArray orderedItems = nodeContentOf(firstItemContent.at(1).toObject());
+    ASSERT_EQ(1, orderedItems.size());
+    const QJsonArray nestedItemContent = nodeContentOf(orderedItems.at(0).toObject());
+    ASSERT_EQ(1, nestedItemContent.size());
+    EXPECT_EQ(QStringLiteral("Two"), textOf(nodeContentOf(nestedItemContent.at(0).toObject()).at(0).toObject()));
+
+    const QJsonArray secondItemContent = nodeContentOf(bulletItems.at(1).toObject());
+    ASSERT_EQ(1, secondItemContent.size());
+    const QJsonObject strongText = nodeContentOf(secondItemContent.at(0).toObject()).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Three"), textOf(strongText));
+    EXPECT_TRUE(hasMark(strongText, QStringLiteral("bold")));
+}
+
+TEST(UT_MigrationHtmlConverter, WrapsInvalidListChildrenIntoListItems)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ul style=\"font-weight: bold\"><span>Loose</span><li>Item</li></ul>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("downgraded-html-list-child")));
+
+    const QJsonArray items = nodeContentOf(docContentOf(result).at(0).toObject());
+    ASSERT_EQ(2, items.size());
+    const QJsonArray looseItemContent = nodeContentOf(items.at(0).toObject());
+    ASSERT_EQ(1, looseItemContent.size());
+    EXPECT_EQ(QStringLiteral("paragraph"), nodeTypeOf(looseItemContent.at(0).toObject()));
+    const QJsonObject looseText = nodeContentOf(looseItemContent.at(0).toObject()).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Loose"), textOf(looseText));
+    EXPECT_TRUE(hasMark(looseText, QStringLiteral("bold")));
+}
+
+TEST(UT_MigrationHtmlConverter, AppliesListItemInlineStyleMarksToDirectText)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ul><li style=\"font-weight: bold; color: red\">Item</li></ul>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonObject list = docContentOf(result).at(0).toObject();
+    const QJsonObject item = nodeContentOf(list).at(0).toObject();
+    const QJsonObject paragraph = nodeContentOf(item).at(0).toObject();
+    const QJsonObject text = nodeContentOf(paragraph).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Item"), textOf(text));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("bold")));
+    EXPECT_EQ(QStringLiteral("red"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
+}
+
+TEST(UT_MigrationHtmlConverter, AppliesListItemInlineStyleMarksToBlockChildText)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ul><li style=\"font-weight: bold; color: red\"><p>Item</p></li></ul>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonObject list = docContentOf(result).at(0).toObject();
+    const QJsonObject item = nodeContentOf(list).at(0).toObject();
+    const QJsonObject paragraph = nodeContentOf(item).at(0).toObject();
+    const QJsonObject text = nodeContentOf(paragraph).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Item"), textOf(text));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("bold")));
+    EXPECT_EQ(QStringLiteral("red"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
+}
+
+TEST(UT_MigrationHtmlConverter, BlockChildStyleOverridesListItemInheritedMarks)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ul><li style=\"font-weight: bold; color: red\">"
+                       "<p style=\"font-weight: normal; color: blue\">Plain</p></li></ul>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonObject list = docContentOf(result).at(0).toObject();
+    const QJsonObject item = nodeContentOf(list).at(0).toObject();
+    const QJsonObject paragraph = nodeContentOf(item).at(0).toObject();
+    const QJsonObject text = nodeContentOf(paragraph).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Plain"), textOf(text));
+    EXPECT_FALSE(hasMark(text, QStringLiteral("bold")));
+    EXPECT_EQ(QStringLiteral("blue"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
+}
+
+TEST(UT_MigrationHtmlConverter, AppliesListInlineStyleMarksToDirectListItemText)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ul style=\"font-weight: bold; color: red\"><li>Item</li></ul>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonObject list = docContentOf(result).at(0).toObject();
+    const QJsonObject item = nodeContentOf(list).at(0).toObject();
+    const QJsonObject paragraph = nodeContentOf(item).at(0).toObject();
+    const QJsonObject text = nodeContentOf(paragraph).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Item"), textOf(text));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("bold")));
+    EXPECT_EQ(QStringLiteral("red"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
+}
+
+TEST(UT_MigrationHtmlConverter, AppliesListInlineStyleMarksToBlockChildText)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ol style=\"font-weight: bold; color: red\"><li><p>Item</p></li></ol>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonObject list = docContentOf(result).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("orderedList"), nodeTypeOf(list));
+    const QJsonObject item = nodeContentOf(list).at(0).toObject();
+    const QJsonObject paragraph = nodeContentOf(item).at(0).toObject();
+    const QJsonObject text = nodeContentOf(paragraph).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Item"), textOf(text));
+    EXPECT_TRUE(hasMark(text, QStringLiteral("bold")));
+    EXPECT_EQ(QStringLiteral("red"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
+}
+
+TEST(UT_MigrationHtmlConverter, BlockChildStyleOverridesListInheritedMarks)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ul style=\"font-weight: bold; color: red\"><li>"
+                       "<p style=\"font-weight: normal; color: blue\">Plain</p></li></ul>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+
+    const QJsonObject list = docContentOf(result).at(0).toObject();
+    const QJsonObject item = nodeContentOf(list).at(0).toObject();
+    const QJsonObject paragraph = nodeContentOf(item).at(0).toObject();
+    const QJsonObject text = nodeContentOf(paragraph).at(0).toObject();
+    EXPECT_EQ(QStringLiteral("Plain"), textOf(text));
+    EXPECT_FALSE(hasMark(text, QStringLiteral("bold")));
+    EXPECT_EQ(QStringLiteral("blue"), markAttrsOf(text, QStringLiteral("color")).value(QStringLiteral("color")).toString());
+}
+
+TEST(UT_MigrationHtmlConverter, WarnsTextAlignOnListItem)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<ul><li style=\"text-align: center\">Item</li></ul>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    ASSERT_EQ(1, result.warnings.size());
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("downgraded-text-align")));
+
+    const QJsonObject list = docContentOf(result).at(0).toObject();
+    const QJsonObject item = nodeContentOf(list).at(0).toObject();
+    const QJsonObject paragraph = nodeContentOf(item).at(0).toObject();
+    EXPECT_FALSE(attrsOf(paragraph).contains(QStringLiteral("textAlign")));
+    EXPECT_EQ(QStringLiteral("Item"), textOf(nodeContentOf(paragraph).at(0).toObject()));
+}
+
+TEST(UT_MigrationHtmlConverter, DowngradesTextAlignBecauseSchemaV1HasNoAlignmentAttrs)
+{
+    const MigrationHtmlConversionResult result = MigrationHtmlConverter::convert(
+        QStringLiteral("<p style=\"text-align: center\">Centered</p>"
+                       "<h2 style=\"text-align: left\">Title</h2>"));
+
+    EXPECT_TRUE(result.ok());
+    expectEnvelopeValid(result);
+    ASSERT_EQ(1, result.warnings.size());
+    EXPECT_TRUE(hasWarningCode(result, QStringLiteral("downgraded-text-align")));
+
+    const QJsonArray blocks = docContentOf(result);
+    ASSERT_EQ(2, blocks.size());
+    EXPECT_FALSE(attrsOf(blocks.at(0).toObject()).contains(QStringLiteral("textAlign")));
+    EXPECT_EQ(QStringLiteral("Centered"), textOf(nodeContentOf(blocks.at(0).toObject()).at(0).toObject()));
+    EXPECT_FALSE(attrsOf(blocks.at(1).toObject()).contains(QStringLiteral("textAlign")));
+    EXPECT_EQ(QStringLiteral("Title"), textOf(nodeContentOf(blocks.at(1).toObject()).at(0).toObject()));
+}


### PR DESCRIPTION
## Summary
- Convert legacy HTML text tags into Tiptap marks: `b/strong`, `i/em`, `u`, `s/strike/del`, and `font` attributes.
- Convert supported inline CSS styles into marks: `color`, `background-color`, `font-family`, `font-size`, `font-weight`, `font-style`, and `text-decoration`.
- Handle mark deduplication and inherited mark overrides, including normal/non-bold/non-italic and `text-decoration: none` clearing inherited marks.
- Preserve visible text while warning on unsupported or invalid style values.

## Validation
- `git diff --name-only upstream/develop/snipe...HEAD` (only 2 TTP-009 files)
- `git diff --check upstream/develop/snipe..HEAD`
- `/tmp/ut_migrationhtmlconverter --gtest_filter='UT_MigrationHtmlConverter.*'` (17/17 passed)
- `cmake --build build --target deepin-voice-note -j2`
- `npm test --prefix web-editor` (18/18 passed)

Issue: V-240
Sub-issue: V-250 / TTP-009
