### PR TITLE
feat(migration): scanner fix, write-back, and writer refactor

### DIFF
--- a/src/importolddata/dbmigration/migrationscanner.cpp
+++ b/src/importolddata/dbmigration/migrationscanner.cpp
@@ -70,6 +70,13 @@ void MigrationScanner::onRowProcessed(int processedCount)
     Q_UNUSED(processedCount)
 }
 
+bool MigrationScanner::checkIterationFailure(const QSqlQuery &query) const
+{
+    // P3: query.next() 中途因读取错误返回 false 时，lastError() 有效且非 NoError。
+    return query.lastError().isValid()
+           && query.lastError().type() != QSqlError::NoError;
+}
+
 ScanResult MigrationScanner::scan()
 {
     ScanResult result;
@@ -160,16 +167,27 @@ ScanResult MigrationScanner::scan()
                 }
 
                 if (result.code != ScanErrorCode::Aborted) {
-                    result.success = true;
-                    result.code = ScanErrorCode::None;
-                    result.message = QStringLiteral(
-                                         "Scan completed: total=%1 needMigrate=%2 "
-                                         "alreadyTiptap=%3 abnormal=%4")
-                                         .arg(result.totalCount)
-                                         .arg(result.needMigrateCount)
-                                         .arg(result.alreadyTiptapCount)
-                                         .arg(result.abnormalCount);
-                    qInfo("MigrationScanner: %s", qPrintable(result.message));
+                    // P3: query.next() 中途因读取错误返回 false（非游标正常耗尽）时，
+                    // 经 checkIterationFailure() 判定，归为 QueryFailed 而非误报成功。
+                    if (checkIterationFailure(query)) {
+                        result.success = false;
+                        result.code = ScanErrorCode::QueryFailed;
+                        result.message = QStringLiteral(
+                                             "Scan query iteration failed: %1")
+                                             .arg(query.lastError().text());
+                        qWarning("MigrationScanner: %s", qPrintable(result.message));
+                    } else {
+                        result.success = true;
+                        result.code = ScanErrorCode::None;
+                        result.message = QStringLiteral(
+                                             "Scan completed: total=%1 needMigrate=%2 "
+                                             "alreadyTiptap=%3 abnormal=%4")
+                                             .arg(result.totalCount)
+                                             .arg(result.needMigrateCount)
+                                             .arg(result.alreadyTiptapCount)
+                                             .arg(result.abnormalCount);
+                        qInfo("MigrationScanner: %s", qPrintable(result.message));
+                    }
                 }
             }
         }

--- a/src/importolddata/dbmigration/migrationscanner.h
+++ b/src/importolddata/dbmigration/migrationscanner.h
@@ -9,6 +9,8 @@
 
 #include <atomic>
 
+class QSqlQuery;
+
 // TTP-017: 只读扫描错误码。
 // 对齐集成数据契约「扫描结果」：失败时给出可区分原因码 + 描述。
 enum class ScanErrorCode {
@@ -74,6 +76,10 @@ protected:
     // 每处理完一行后回调（默认空实现）。子类可重写以驱动协作取消或进度上报，
     // 扫描主循环在回调后的下一行检查取消标志位。
     virtual void onRowProcessed(int processedCount);
+
+    // P3: 判定 query.next() 循环退出后是否因读取错误（非游标正常耗尽）而失败。
+    // 默认实现检查 QSqlQuery::lastError()；测试子类可重写以注入中途失败。
+    virtual bool checkIterationFailure(const QSqlQuery &query) const;
 
 private:
     QString effectiveDbPath() const;

--- a/src/importolddata/dbmigration/migrationwriter.cpp
+++ b/src/importolddata/dbmigration/migrationwriter.cpp
@@ -16,6 +16,7 @@
 #include <QByteArray>
 #include <QDir>
 #include <QFileInfo>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
@@ -32,6 +33,18 @@ constexpr int kColEncrypt = 1;
 // SQLite busy 超时（毫秒），缓解与 VNoteDbManager 运行态连接的写锁竞争。
 constexpr int kBusyTimeoutMs = 5000;
 }  // namespace
+
+// 归一化 TTP-013 两类转换器 warnings（结构同构：path/code/message）为 MigrationWarning。
+template <typename Issue>
+QVector<MigrationWarning> collectWarnings(const QVector<Issue> &issues)
+{
+    QVector<MigrationWarning> warnings;
+    warnings.reserve(issues.size());
+    for (const Issue &issue : issues) {
+        warnings.append(MigrationWarning{issue.path, issue.code, issue.message});
+    }
+    return warnings;
+}
 
 MigrationWriter::MigrationWriter()
 {
@@ -67,16 +80,209 @@ QString MigrationWriter::makeConnectionName() const
         .arg(counter.fetchAndAddRelaxed(1));
 }
 
-// 归一化 TTP-013 两类转换器 warnings（结构同构：path/code/message）为 MigrationWarning。
-template <typename Issue>
-QVector<MigrationWarning> collectWarnings(const QVector<Issue> &issues)
+MigrationWriter::NoteRow MigrationWriter::readNoteRow(QSqlDatabase &db, qint32 noteId,
+                                                      qint32 folderId,
+                                                      WriteResult *result) const
 {
-    QVector<MigrationWarning> warnings;
-    warnings.reserve(issues.size());
-    for (const Issue &issue : issues) {
-        warnings.append(MigrationWarning{issue.path, issue.code, issue.message});
+    NoteRow row;
+    // 列名取自 DbVisitor::DBNote::noteColumnsName，与运行态查询同源
+    // （encrypt 实际落在 expand_filed2 列）。
+    const QStringList &cols = DbVisitor::DBNote::noteColumnsName;
+    const QString selectSql = QStringLiteral("SELECT %1, %2 FROM %3 WHERE %4=?")
+                                  .arg(cols.value(DbVisitor::DBNote::meta_data),
+                                       cols.value(DbVisitor::DBNote::encrypt),
+                                       VNoteDbManager::NOTES_TABLE_NAME,
+                                       cols.value(DbVisitor::DBNote::note_id));
+
+    QSqlQuery readQuery(db);
+    readQuery.prepare(selectSql);
+    readQuery.addBindValue(noteId);
+    if (!readQuery.exec()) {
+        result->code = WriteErrorCode::ReadFailed;
+        result->message = QStringLiteral("Failed to read note: %1")
+                              .arg(readQuery.lastError().text());
+        qWarning("MigrationWriter: note_id=%lld folder_id=%lld %s",
+                 static_cast<long long>(noteId),
+                 static_cast<long long>(folderId),
+                 qPrintable(result->message));
+        return row;
     }
-    return warnings;
+
+    if (!readQuery.next()) {
+        // 查无此行：原数据（无）保留，按 NoteNotFound 上报。
+        result->code = WriteErrorCode::NoteNotFound;
+        result->message = QStringLiteral("note_id not found");
+        qInfo("MigrationWriter: note_id=%lld folder_id=%lld not found",
+              static_cast<long long>(noteId),
+              static_cast<long long>(folderId));
+        return row;
+    }
+
+    row.found = true;
+    row.encryption = readQuery.value(kColEncrypt).toInt();
+    const QVariant metaDataVar = readQuery.value(kColMetaData);
+    // 加密还原：对齐 dbvisitor.cpp 读取语义，base64 还原后再探测/转换。
+    row.metaData = (row.encryption != 0)
+        ? QString::fromUtf8(QByteArray::fromBase64(metaDataVar.toByteArray()))
+        : metaDataVar.toString();
+    return row;
+}
+
+QJsonObject MigrationWriter::convertByFormat(LegacyFormat format,
+                                             const QString &metaDataStr,
+                                             qint32 folderId, qint32 noteId,
+                                             QVector<MigrationWarning> *warnings,
+                                             WriteResult *result) const
+{
+    QJsonObject envelope;
+    switch (format) {
+    case LegacyFormat::LegacyHtmlCode: {
+        // htmlCode 可能是 JSON {"htmlCode":...} 包封，也可能是裸 HTML。
+        QString htmlCode = metaDataStr;
+        const QJsonDocument doc = QJsonDocument::fromJson(metaDataStr.toUtf8());
+        if (doc.isObject()) {
+            const QJsonObject root = doc.object();
+            const QJsonValue code = root.value(QStringLiteral("htmlCode"));
+            if (code.isString()) {
+                htmlCode = code.toString();
+            }
+        }
+        const MigrationHtmlConversionResult converted =
+            MigrationHtmlConverter::convert(htmlCode);
+        *warnings = collectWarnings(converted.warnings);
+        if (!converted.ok()) {
+            result->warnings = *warnings;
+            result->code = WriteErrorCode::ConvertFailed;
+            result->message = QStringLiteral("html convert failed");
+            qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                     "format=%s convert failed",
+                     static_cast<long long>(noteId),
+                     static_cast<long long>(folderId),
+                     qPrintable(LegacyFormatDetector::formatName(format)));
+            break;
+        }
+        envelope = converted.envelope;
+        break;
+    }
+    case LegacyFormat::LegacyNoteDatas: {
+        const MigrationNoteDataConversionResult converted =
+            MigrationNoteDataConverter::convertBlocks(metaDataStr);
+        *warnings = collectWarnings(converted.warnings);
+        if (!converted.ok()) {
+            result->warnings = *warnings;
+            result->code = WriteErrorCode::ConvertFailed;
+            result->message = QStringLiteral("noteDatas convert failed");
+            qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                     "format=%s convert failed",
+                     static_cast<long long>(noteId),
+                     static_cast<long long>(folderId),
+                     qPrintable(LegacyFormatDetector::formatName(format)));
+            break;
+        }
+        envelope = converted.envelope;
+        break;
+    }
+    case LegacyFormat::ProseMirrorDoc: {
+        // R-PM1：无专用转换器，直接用 TTP-013 builder 包封已有 doc 对象。
+        const QJsonDocument doc = QJsonDocument::fromJson(metaDataStr.toUtf8());
+        envelope = MigrationJsonBuilder::makeEnvelope(doc.object());
+        break;
+    }
+    case LegacyFormat::PlainText: {
+        // R-PM1：无专用转换器，包成单段落 doc（空串→空段落）。
+        QJsonArray paragraphContent;
+        if (!metaDataStr.isEmpty()) {
+            paragraphContent.append(MigrationJsonBuilder::makeText(metaDataStr));
+        }
+        envelope = MigrationJsonBuilder::makeEnvelope(
+            MigrationJsonBuilder::makeDoc(
+                QJsonArray{MigrationJsonBuilder::makeParagraph(paragraphContent)}));
+        break;
+    }
+    default:
+        break;
+    }
+    return envelope;
+}
+
+void MigrationWriter::validateAndPersist(QSqlDatabase &db, const QJsonObject &envelope,
+                                         int encryption, qint32 noteId, qint32 folderId,
+                                         LegacyFormat format,
+                                         const QVector<MigrationWarning> &warnings,
+                                         WriteResult *result) const
+{
+    // 强制校验：写回前必须通过 C++ validator。
+    const MigrationJsonValidationResult validated =
+        MigrationJsonValidator::validateEnvelope(envelope);
+    if (!validated.ok()) {
+        result->warnings = warnings;
+        result->code = WriteErrorCode::ValidationFailed;
+        result->message =
+            QStringLiteral("envelope validation failed: %1 error(s)")
+                .arg(validated.errors.size());
+        qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                 "format=%s validation failed",
+                 static_cast<long long>(noteId),
+                 static_cast<long long>(folderId),
+                 qPrintable(LegacyFormatDetector::formatName(format)));
+        return;
+    }
+
+    // 紧凑化（QJsonDocument::Compact）。
+    const QString compact = MigrationJsonBuilder::toCompactJson(envelope);
+    // 加密再入库：对齐 dbvisitor.cpp 写入语义，不改 expand_filed2。
+    // 绑定 QString 走 TEXT 通道（与 UpdateNoteDbVisitor 一致），
+    // 避免 QByteArray 绑定落入 BLOB 导致 detect() 读回异常。
+    const QString stored = (encryption != 0)
+        ? QString::fromUtf8(compact.toLocal8Bit().toBase64())
+        : compact;
+
+    // 单条参数化 UPDATE（单语句原子），仅 SET meta_data，
+    // 不触 modify_time 列、不触 folder 表。
+    const QStringList &cols = DbVisitor::DBNote::noteColumnsName;
+    const QString updateSql = QStringLiteral("UPDATE %1 SET %2=? WHERE %3=?")
+                                  .arg(VNoteDbManager::NOTES_TABLE_NAME,
+                                       cols.value(DbVisitor::DBNote::meta_data),
+                                       cols.value(DbVisitor::DBNote::note_id));
+    QSqlQuery writeQuery(db);
+    writeQuery.prepare(updateSql);
+    writeQuery.addBindValue(stored);
+    writeQuery.addBindValue(noteId);
+    if (!writeQuery.exec()) {
+        result->warnings = warnings;
+        result->code = WriteErrorCode::WriteFailed;
+        result->message =
+            QStringLiteral("update failed: %1").arg(writeQuery.lastError().text());
+        qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                 "format=%s write failed",
+                 static_cast<long long>(noteId),
+                 static_cast<long long>(folderId),
+                 qPrintable(LegacyFormatDetector::formatName(format)));
+        return;
+    }
+
+    if (writeQuery.numRowsAffected() != 1) {
+        result->warnings = warnings;
+        result->code = WriteErrorCode::WriteFailed;
+        result->message =
+            QStringLiteral("update affected %1 row(s)").arg(writeQuery.numRowsAffected());
+        qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                 "format=%s unexpected rows affected",
+                 static_cast<long long>(noteId),
+                 static_cast<long long>(folderId),
+                 qPrintable(LegacyFormatDetector::formatName(format)));
+        return;
+    }
+
+    result->warnings = warnings;
+    result->success = true;
+    result->code = WriteErrorCode::None;
+    result->originalDataPreserved = false;
+    result->message = QStringLiteral("migrated");
+    qInfo("MigrationWriter: note_id=%lld folder_id=%lld format=%s migrated",
+          static_cast<long long>(noteId),
+          static_cast<long long>(folderId),
+          qPrintable(LegacyFormatDetector::formatName(format)));
 }
 
 WriteResult MigrationWriter::writeOne(qint32 folderId, qint32 noteId)
@@ -113,43 +319,10 @@ WriteResult MigrationWriter::writeOne(qint32 folderId, qint32 noteId)
                      static_cast<long long>(folderId),
                      qPrintable(result.message));
         } else {
-            // 列名取自 DbVisitor::DBNote::noteColumnsName，与运行态查询同源
-            // （encrypt 实际落在 expand_filed2 列）。
-            const QStringList &cols = DbVisitor::DBNote::noteColumnsName;
-            const QString selectSql = QStringLiteral("SELECT %1, %2 FROM %3 WHERE %4=?")
-                                          .arg(cols.value(DbVisitor::DBNote::meta_data),
-                                               cols.value(DbVisitor::DBNote::encrypt),
-                                               VNoteDbManager::NOTES_TABLE_NAME,
-                                               cols.value(DbVisitor::DBNote::note_id));
-
-            QSqlQuery readQuery(db);
-            readQuery.prepare(selectSql);
-            readQuery.addBindValue(noteId);
-            if (!readQuery.exec()) {
-                result.code = WriteErrorCode::ReadFailed;
-                result.message = QStringLiteral("Failed to read note: %1")
-                                     .arg(readQuery.lastError().text());
-                qWarning("MigrationWriter: note_id=%lld folder_id=%lld %s",
-                         static_cast<long long>(noteId),
-                         static_cast<long long>(folderId),
-                         qPrintable(result.message));
-            } else if (!readQuery.next()) {
-                // 查无此行：原数据（无）保留，按 NoteNotFound 上报。
-                result.code = WriteErrorCode::NoteNotFound;
-                result.message = QStringLiteral("note_id not found");
-                qInfo("MigrationWriter: note_id=%lld folder_id=%lld not found",
-                      static_cast<long long>(noteId),
-                      static_cast<long long>(folderId));
-            } else {
-                const int encryption = readQuery.value(kColEncrypt).toInt();
-                const QVariant metaDataVar = readQuery.value(kColMetaData);
-                // 加密还原：对齐 dbvisitor.cpp 读取语义，base64 还原后再探测/转换。
-                const QString metaDataStr = (encryption != 0)
-                    ? QString::fromUtf8(QByteArray::fromBase64(metaDataVar.toByteArray()))
-                    : metaDataVar.toString();
-
+            const NoteRow row = readNoteRow(db, noteId, folderId, &result);
+            if (row.found) {
                 // 探测分派。
-                const LegacyFormat format = LegacyFormatDetector::detect(metaDataStr);
+                const LegacyFormat format = LegacyFormatDetector::detect(row.metaData);
 
                 if (format == LegacyFormat::TiptapEnvelope) {
                     // 已是信封（用户已编辑或前次部分迁移已写），跳过写回，避免覆盖最新内容。
@@ -171,80 +344,10 @@ WriteResult MigrationWriter::writeOne(qint32 folderId, qint32 noteId)
                              qPrintable(result.message));
                 } else {
                     // 转换分派：LegacyHtmlCode / LegacyNoteDatas / ProseMirrorDoc / PlainText。
-                    QJsonObject envelope;
                     QVector<MigrationWarning> warnings;
-
-                    switch (format) {
-                    case LegacyFormat::LegacyHtmlCode: {
-                        // htmlCode 可能是 JSON {"htmlCode":...} 包封，也可能是裸 HTML。
-                        QString htmlCode = metaDataStr;
-                        const QJsonDocument doc =
-                            QJsonDocument::fromJson(metaDataStr.toUtf8());
-                        if (doc.isObject()) {
-                            const QJsonObject root = doc.object();
-                            const QJsonValue code = root.value(QStringLiteral("htmlCode"));
-                            if (code.isString()) {
-                                htmlCode = code.toString();
-                            }
-                        }
-                        const MigrationHtmlConversionResult converted =
-                            MigrationHtmlConverter::convert(htmlCode);
-                        warnings = collectWarnings(converted.warnings);
-                        if (!converted.ok()) {
-                            result.warnings = warnings;
-                            result.code = WriteErrorCode::ConvertFailed;
-                            result.message = QStringLiteral("html convert failed");
-                            qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
-                                     "format=%s convert failed",
-                                     static_cast<long long>(noteId),
-                                     static_cast<long long>(folderId),
-                                     qPrintable(LegacyFormatDetector::formatName(format)));
-                            break;
-                        }
-                        envelope = converted.envelope;
-                        break;
-                    }
-                    case LegacyFormat::LegacyNoteDatas: {
-                        const MigrationNoteDataConversionResult converted =
-                            MigrationNoteDataConverter::convertBlocks(metaDataStr);
-                        warnings = collectWarnings(converted.warnings);
-                        if (!converted.ok()) {
-                            result.warnings = warnings;
-                            result.code = WriteErrorCode::ConvertFailed;
-                            result.message = QStringLiteral("noteDatas convert failed");
-                            qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
-                                     "format=%s convert failed",
-                                     static_cast<long long>(noteId),
-                                     static_cast<long long>(folderId),
-                                     qPrintable(LegacyFormatDetector::formatName(format)));
-                            break;
-                        }
-                        envelope = converted.envelope;
-                        break;
-                    }
-                    case LegacyFormat::ProseMirrorDoc: {
-                        // R-PM1：无专用转换器，直接用 TTP-013 builder 包封已有 doc 对象。
-                        const QJsonDocument doc =
-                            QJsonDocument::fromJson(metaDataStr.toUtf8());
-                        envelope = MigrationJsonBuilder::makeEnvelope(doc.object());
-                        break;
-                    }
-                    case LegacyFormat::PlainText: {
-                        // R-PM1：无专用转换器，包成单段落 doc（空串→空段落）。
-                        QJsonArray paragraphContent;
-                        if (!metaDataStr.isEmpty()) {
-                            paragraphContent.append(
-                                MigrationJsonBuilder::makeText(metaDataStr));
-                        }
-                        envelope = MigrationJsonBuilder::makeEnvelope(
-                            MigrationJsonBuilder::makeDoc(
-                                QJsonArray{MigrationJsonBuilder::makeParagraph(
-                                    paragraphContent)}));
-                        break;
-                    }
-                    default:
-                        break;
-                    }
+                    const QJsonObject envelope =
+                        convertByFormat(format, row.metaData, folderId, noteId,
+                                        &warnings, &result);
 
                     // 转换失败已组装结果，直接跳过写回。
                     if (result.code == WriteErrorCode::ConvertFailed) {
@@ -257,77 +360,8 @@ WriteResult MigrationWriter::writeOne(qint32 folderId, qint32 noteId)
                                  static_cast<long long>(noteId),
                                  static_cast<long long>(folderId));
                     } else {
-                        // 强制校验：写回前必须通过 C++ validator。
-                        const MigrationJsonValidationResult validated =
-                            MigrationJsonValidator::validateEnvelope(envelope);
-                        if (!validated.ok()) {
-                            result.warnings = warnings;
-                            result.code = WriteErrorCode::ValidationFailed;
-                            result.message = QStringLiteral(
-                                "envelope validation failed: %1 error(s)")
-                                                 .arg(validated.errors.size());
-                            qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
-                                     "format=%s validation failed",
-                                     static_cast<long long>(noteId),
-                                     static_cast<long long>(folderId),
-                                     qPrintable(LegacyFormatDetector::formatName(format)));
-                        } else {
-                            // 紧凑化（QJsonDocument::Compact）。
-                            const QString compact =
-                                MigrationJsonBuilder::toCompactJson(envelope);
-                            // 加密再入库：对齐 dbvisitor.cpp 写入语义，不改 expand_filed2。
-                            // 绑定 QString 走 TEXT 通道（与 UpdateNoteDbVisitor 一致），
-                            // 避免 QByteArray 绑定落入 BLOB 导致 detect() 读回异常。
-                            const QString stored = (encryption != 0)
-                                ? QString::fromUtf8(compact.toLocal8Bit().toBase64())
-                                : compact;
-
-                            // 单条参数化 UPDATE（单语句原子），仅 SET meta_data，
-                            // 不触 modify_time 列、不触 folder 表。
-                            const QString updateSql =
-                                QStringLiteral("UPDATE %1 SET %2=? WHERE %3=?")
-                                    .arg(VNoteDbManager::NOTES_TABLE_NAME,
-                                         cols.value(DbVisitor::DBNote::meta_data),
-                                         cols.value(DbVisitor::DBNote::note_id));
-                            QSqlQuery writeQuery(db);
-                            writeQuery.prepare(updateSql);
-                            writeQuery.addBindValue(stored);
-                            writeQuery.addBindValue(noteId);
-                            if (!writeQuery.exec()) {
-                                result.warnings = warnings;
-                                result.code = WriteErrorCode::WriteFailed;
-                                result.message = QStringLiteral(
-                                    "update failed: %1")
-                                                     .arg(writeQuery.lastError().text());
-                                qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
-                                         "format=%s write failed",
-                                         static_cast<long long>(noteId),
-                                         static_cast<long long>(folderId),
-                                         qPrintable(LegacyFormatDetector::formatName(format)));
-                            } else if (writeQuery.numRowsAffected() != 1) {
-                                result.warnings = warnings;
-                                result.code = WriteErrorCode::WriteFailed;
-                                result.message = QStringLiteral(
-                                    "update affected %1 row(s)")
-                                                     .arg(writeQuery.numRowsAffected());
-                                qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
-                                         "format=%s unexpected rows affected",
-                                         static_cast<long long>(noteId),
-                                         static_cast<long long>(folderId),
-                                         qPrintable(LegacyFormatDetector::formatName(format)));
-                            } else {
-                                result.warnings = warnings;
-                                result.success = true;
-                                result.code = WriteErrorCode::None;
-                                result.originalDataPreserved = false;
-                                result.message = QStringLiteral("migrated");
-                                qInfo("MigrationWriter: note_id=%lld folder_id=%lld "
-                                      "format=%s migrated",
-                                      static_cast<long long>(noteId),
-                                      static_cast<long long>(folderId),
-                                      qPrintable(LegacyFormatDetector::formatName(format)));
-                            }
-                        }
+                        validateAndPersist(db, envelope, row.encryption, noteId, folderId,
+                                           format, warnings, &result);
                     }
                 }
             }

--- a/src/importolddata/dbmigration/migrationwriter.cpp
+++ b/src/importolddata/dbmigration/migrationwriter.cpp
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationwriter.h"
+
+#include "legacyformatdetector.h"       // LegacyFormatDetector::detect()/formatName()
+#include "migrationhtmlconverter.h"     // MigrationHtmlConverter::convert()
+#include "migrationjsonbuilder.h"       // MigrationJsonBuilder::toCompactJson()/makeEnvelope()/...
+#include "migrationjsonvalidator.h"     // MigrationJsonValidator::validateEnvelope()
+#include "migrationnotedataconverter.h" // MigrationNoteDataConverter::convertBlocks()
+#include "db/dbvisitor.h"               // DbVisitor::DBNote 列枚举/列名
+#include "db/vnotedbmanager.h"          // VNoteDbManager::NOTES_TABLE_NAME/DBVERSION
+#include "globaldef.h"                  // DEEPIN_VOICE_NOTE
+
+#include <QAtomicInt>
+#include <QByteArray>
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QStandardPaths>
+#include <QVariant>
+
+namespace {
+// 读取 SELECT 取列顺序（按 SELECT 列表的位置索引读取，避免依赖表全列序）。
+constexpr int kColMetaData = 0;
+constexpr int kColEncrypt = 1;
+// SQLite busy 超时（毫秒），缓解与 VNoteDbManager 运行态连接的写锁竞争。
+constexpr int kBusyTimeoutMs = 5000;
+}  // namespace
+
+MigrationWriter::MigrationWriter()
+{
+}
+
+MigrationWriter::MigrationWriter(const QString &dbPath)
+    : m_dbPath(dbPath)
+{
+}
+
+QString MigrationWriter::dbPath() const
+{
+    return m_dbPath;
+}
+
+QString MigrationWriter::defaultDbPath()
+{
+    const QString appData = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    return appData + QDir::separator() + DEEPIN_VOICE_NOTE
+           + QString(VNoteDbManager::DBVERSION) + QStringLiteral(".db");
+}
+
+QString MigrationWriter::effectiveDbPath() const
+{
+    return m_dbPath.isEmpty() ? defaultDbPath() : m_dbPath;
+}
+
+QString MigrationWriter::makeConnectionName() const
+{
+    // 进程级递增计数，保证多次写回/测试场景连接名唯一，用后 removeDatabase 释放。
+    static QAtomicInt counter(0);
+    return QStringLiteral("voice_note_migration_write_%1")
+        .arg(counter.fetchAndAddRelaxed(1));
+}
+
+// 归一化 TTP-013 两类转换器 warnings（结构同构：path/code/message）为 MigrationWarning。
+template <typename Issue>
+QVector<MigrationWarning> collectWarnings(const QVector<Issue> &issues)
+{
+    QVector<MigrationWarning> warnings;
+    warnings.reserve(issues.size());
+    for (const Issue &issue : issues) {
+        warnings.append(MigrationWarning{issue.path, issue.code, issue.message});
+    }
+    return warnings;
+}
+
+WriteResult MigrationWriter::writeOne(qint32 folderId, qint32 noteId)
+{
+    WriteResult result;
+    result.noteId = noteId;
+
+    const QString dbPath = effectiveDbPath();
+
+    // 源库文件不存在直接失败，避免 SQLite 打开静默创建空库（写副作用防御）。
+    if (!QFileInfo(dbPath).isFile()) {
+        result.code = WriteErrorCode::ReadFailed;
+        result.message = QStringLiteral("Database file not found: %1").arg(dbPath);
+        qWarning("MigrationWriter: note_id=%lld folder_id=%lld %s",
+                 static_cast<long long>(noteId),
+                 static_cast<long long>(folderId),
+                 qPrintable(result.message));
+        return result;
+    }
+
+    const QString connName = makeConnectionName();
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), connName);
+        db.setDatabaseName(dbPath);
+        // 非只读连接，设 busy 超时缓解与运行态连接的写锁竞争。
+        db.setConnectOptions(
+            QStringLiteral("QSQLITE_BUSY_TIMEOUT=%1").arg(kBusyTimeoutMs));
+        if (!db.open()) {
+            result.code = WriteErrorCode::ReadFailed;
+            result.message = QStringLiteral("Failed to open database: %1")
+                                 .arg(db.lastError().text());
+            qWarning("MigrationWriter: note_id=%lld folder_id=%lld %s",
+                     static_cast<long long>(noteId),
+                     static_cast<long long>(folderId),
+                     qPrintable(result.message));
+        } else {
+            // 列名取自 DbVisitor::DBNote::noteColumnsName，与运行态查询同源
+            // （encrypt 实际落在 expand_filed2 列）。
+            const QStringList &cols = DbVisitor::DBNote::noteColumnsName;
+            const QString selectSql = QStringLiteral("SELECT %1, %2 FROM %3 WHERE %4=?")
+                                          .arg(cols.value(DbVisitor::DBNote::meta_data),
+                                               cols.value(DbVisitor::DBNote::encrypt),
+                                               VNoteDbManager::NOTES_TABLE_NAME,
+                                               cols.value(DbVisitor::DBNote::note_id));
+
+            QSqlQuery readQuery(db);
+            readQuery.prepare(selectSql);
+            readQuery.addBindValue(noteId);
+            if (!readQuery.exec()) {
+                result.code = WriteErrorCode::ReadFailed;
+                result.message = QStringLiteral("Failed to read note: %1")
+                                     .arg(readQuery.lastError().text());
+                qWarning("MigrationWriter: note_id=%lld folder_id=%lld %s",
+                         static_cast<long long>(noteId),
+                         static_cast<long long>(folderId),
+                         qPrintable(result.message));
+            } else if (!readQuery.next()) {
+                // 查无此行：原数据（无）保留，按 NoteNotFound 上报。
+                result.code = WriteErrorCode::NoteNotFound;
+                result.message = QStringLiteral("note_id not found");
+                qInfo("MigrationWriter: note_id=%lld folder_id=%lld not found",
+                      static_cast<long long>(noteId),
+                      static_cast<long long>(folderId));
+            } else {
+                const int encryption = readQuery.value(kColEncrypt).toInt();
+                const QVariant metaDataVar = readQuery.value(kColMetaData);
+                // 加密还原：对齐 dbvisitor.cpp 读取语义，base64 还原后再探测/转换。
+                const QString metaDataStr = (encryption != 0)
+                    ? QString::fromUtf8(QByteArray::fromBase64(metaDataVar.toByteArray()))
+                    : metaDataVar.toString();
+
+                // 探测分派。
+                const LegacyFormat format = LegacyFormatDetector::detect(metaDataStr);
+
+                if (format == LegacyFormat::TiptapEnvelope) {
+                    // 已是信封（用户已编辑或前次部分迁移已写），跳过写回，避免覆盖最新内容。
+                    result.success = true;
+                    result.code = WriteErrorCode::None;
+                    result.originalDataPreserved = true;
+                    result.message = QStringLiteral("already tiptap, skipped");
+                    qInfo("MigrationWriter: note_id=%lld folder_id=%lld format=%s skipped",
+                          static_cast<long long>(noteId),
+                          static_cast<long long>(folderId),
+                          qPrintable(LegacyFormatDetector::formatName(format)));
+                } else if (format == LegacyFormat::Invalid) {
+                    result.code = WriteErrorCode::UnsupportedFormat;
+                    result.message = QStringLiteral("unrecognized meta_data format");
+                    qWarning("MigrationWriter: note_id=%lld folder_id=%lld format=%s %s",
+                             static_cast<long long>(noteId),
+                             static_cast<long long>(folderId),
+                             qPrintable(LegacyFormatDetector::formatName(format)),
+                             qPrintable(result.message));
+                } else {
+                    // 转换分派：LegacyHtmlCode / LegacyNoteDatas / ProseMirrorDoc / PlainText。
+                    QJsonObject envelope;
+                    QVector<MigrationWarning> warnings;
+
+                    switch (format) {
+                    case LegacyFormat::LegacyHtmlCode: {
+                        // htmlCode 可能是 JSON {"htmlCode":...} 包封，也可能是裸 HTML。
+                        QString htmlCode = metaDataStr;
+                        const QJsonDocument doc =
+                            QJsonDocument::fromJson(metaDataStr.toUtf8());
+                        if (doc.isObject()) {
+                            const QJsonObject root = doc.object();
+                            const QJsonValue code = root.value(QStringLiteral("htmlCode"));
+                            if (code.isString()) {
+                                htmlCode = code.toString();
+                            }
+                        }
+                        const MigrationHtmlConversionResult converted =
+                            MigrationHtmlConverter::convert(htmlCode);
+                        warnings = collectWarnings(converted.warnings);
+                        if (!converted.ok()) {
+                            result.warnings = warnings;
+                            result.code = WriteErrorCode::ConvertFailed;
+                            result.message = QStringLiteral("html convert failed");
+                            qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                                     "format=%s convert failed",
+                                     static_cast<long long>(noteId),
+                                     static_cast<long long>(folderId),
+                                     qPrintable(LegacyFormatDetector::formatName(format)));
+                            break;
+                        }
+                        envelope = converted.envelope;
+                        break;
+                    }
+                    case LegacyFormat::LegacyNoteDatas: {
+                        const MigrationNoteDataConversionResult converted =
+                            MigrationNoteDataConverter::convertBlocks(metaDataStr);
+                        warnings = collectWarnings(converted.warnings);
+                        if (!converted.ok()) {
+                            result.warnings = warnings;
+                            result.code = WriteErrorCode::ConvertFailed;
+                            result.message = QStringLiteral("noteDatas convert failed");
+                            qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                                     "format=%s convert failed",
+                                     static_cast<long long>(noteId),
+                                     static_cast<long long>(folderId),
+                                     qPrintable(LegacyFormatDetector::formatName(format)));
+                            break;
+                        }
+                        envelope = converted.envelope;
+                        break;
+                    }
+                    case LegacyFormat::ProseMirrorDoc: {
+                        // R-PM1：无专用转换器，直接用 TTP-013 builder 包封已有 doc 对象。
+                        const QJsonDocument doc =
+                            QJsonDocument::fromJson(metaDataStr.toUtf8());
+                        envelope = MigrationJsonBuilder::makeEnvelope(doc.object());
+                        break;
+                    }
+                    case LegacyFormat::PlainText: {
+                        // R-PM1：无专用转换器，包成单段落 doc（空串→空段落）。
+                        QJsonArray paragraphContent;
+                        if (!metaDataStr.isEmpty()) {
+                            paragraphContent.append(
+                                MigrationJsonBuilder::makeText(metaDataStr));
+                        }
+                        envelope = MigrationJsonBuilder::makeEnvelope(
+                            MigrationJsonBuilder::makeDoc(
+                                QJsonArray{MigrationJsonBuilder::makeParagraph(
+                                    paragraphContent)}));
+                        break;
+                    }
+                    default:
+                        break;
+                    }
+
+                    // 转换失败已组装结果，直接跳过写回。
+                    if (result.code == WriteErrorCode::ConvertFailed) {
+                        // warnings 已填，originalDataPreserved 默认 true。
+                    } else if (envelope.isEmpty()) {
+                        result.warnings = warnings;
+                        result.code = WriteErrorCode::ConvertFailed;
+                        result.message = QStringLiteral("convert produced empty envelope");
+                        qWarning("MigrationWriter: note_id=%lld folder_id=%lld empty envelope",
+                                 static_cast<long long>(noteId),
+                                 static_cast<long long>(folderId));
+                    } else {
+                        // 强制校验：写回前必须通过 C++ validator。
+                        const MigrationJsonValidationResult validated =
+                            MigrationJsonValidator::validateEnvelope(envelope);
+                        if (!validated.ok()) {
+                            result.warnings = warnings;
+                            result.code = WriteErrorCode::ValidationFailed;
+                            result.message = QStringLiteral(
+                                "envelope validation failed: %1 error(s)")
+                                                 .arg(validated.errors.size());
+                            qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                                     "format=%s validation failed",
+                                     static_cast<long long>(noteId),
+                                     static_cast<long long>(folderId),
+                                     qPrintable(LegacyFormatDetector::formatName(format)));
+                        } else {
+                            // 紧凑化（QJsonDocument::Compact）。
+                            const QString compact =
+                                MigrationJsonBuilder::toCompactJson(envelope);
+                            // 加密再入库：对齐 dbvisitor.cpp 写入语义，不改 expand_filed2。
+                            // 绑定 QString 走 TEXT 通道（与 UpdateNoteDbVisitor 一致），
+                            // 避免 QByteArray 绑定落入 BLOB 导致 detect() 读回异常。
+                            const QString stored = (encryption != 0)
+                                ? QString::fromUtf8(compact.toLocal8Bit().toBase64())
+                                : compact;
+
+                            // 单条参数化 UPDATE（单语句原子），仅 SET meta_data，
+                            // 不触 modify_time 列、不触 folder 表。
+                            const QString updateSql =
+                                QStringLiteral("UPDATE %1 SET %2=? WHERE %3=?")
+                                    .arg(VNoteDbManager::NOTES_TABLE_NAME,
+                                         cols.value(DbVisitor::DBNote::meta_data),
+                                         cols.value(DbVisitor::DBNote::note_id));
+                            QSqlQuery writeQuery(db);
+                            writeQuery.prepare(updateSql);
+                            writeQuery.addBindValue(stored);
+                            writeQuery.addBindValue(noteId);
+                            if (!writeQuery.exec()) {
+                                result.warnings = warnings;
+                                result.code = WriteErrorCode::WriteFailed;
+                                result.message = QStringLiteral(
+                                    "update failed: %1")
+                                                     .arg(writeQuery.lastError().text());
+                                qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                                         "format=%s write failed",
+                                         static_cast<long long>(noteId),
+                                         static_cast<long long>(folderId),
+                                         qPrintable(LegacyFormatDetector::formatName(format)));
+                            } else if (writeQuery.numRowsAffected() != 1) {
+                                result.warnings = warnings;
+                                result.code = WriteErrorCode::WriteFailed;
+                                result.message = QStringLiteral(
+                                    "update affected %1 row(s)")
+                                                     .arg(writeQuery.numRowsAffected());
+                                qWarning("MigrationWriter: note_id=%lld folder_id=%lld "
+                                         "format=%s unexpected rows affected",
+                                         static_cast<long long>(noteId),
+                                         static_cast<long long>(folderId),
+                                         qPrintable(LegacyFormatDetector::formatName(format)));
+                            } else {
+                                result.warnings = warnings;
+                                result.success = true;
+                                result.code = WriteErrorCode::None;
+                                result.originalDataPreserved = false;
+                                result.message = QStringLiteral("migrated");
+                                qInfo("MigrationWriter: note_id=%lld folder_id=%lld "
+                                      "format=%s migrated",
+                                      static_cast<long long>(noteId),
+                                      static_cast<long long>(folderId),
+                                      qPrintable(LegacyFormatDetector::formatName(format)));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        db.close();
+    }
+    // 连接已离开作用域，安全移除（避免 "connection still in use" 警告）。
+    QSqlDatabase::removeDatabase(connName);
+    return result;
+}

--- a/src/importolddata/dbmigration/migrationwriter.h
+++ b/src/importolddata/dbmigration/migrationwriter.h
@@ -7,6 +7,12 @@
 #include <QString>
 #include <QVector>
 
+// Forward declarations — 仅头文件需要的类型，实现见 .cpp。
+class QSqlDatabase;
+class QJsonObject;
+
+enum class LegacyFormat;
+
 // TTP-018: 单条事务写回错误码。
 // 对齐集成数据契约「单条写回回报」+ GAP-2：失败时给出可区分原因码 + 描述。
 enum class WriteErrorCode {
@@ -65,9 +71,37 @@ public:
     QString dbPath() const;
 
 private:
+    // 读取单行 meta_data + encrypt 的中间结果。
+    // found=false 表示查无此行（NoteNotFound）或读取失败（ReadFailed），
+    // 此时 result->code/message 已由本方法填入。
+    struct NoteRow {
+        bool found = false;
+        int encryption = 0;     // expand_filed2 原值（用于读解密与写再加密）
+        QString metaData;       // 已按 encryption 解密还原后的 meta_data 字符串
+    };
+
     QString effectiveDbPath() const;
     // 进程级唯一 RW 连接名，避免与 VNoteDbManager 运行态连接争用。
     QString makeConnectionName() const;
+
+    // 读取单行笔记。失败时设置 result 的 ReadFailed/NoteNotFound 并日志，found=false。
+    NoteRow readNoteRow(QSqlDatabase &db, qint32 noteId, qint32 folderId,
+                        WriteResult *result) const;
+
+    // 按探测格式分派转换，产出信封并归一化 warnings。
+    // 转换失败时设置 result 的 ConvertFailed 并日志，返回空 envelope。
+    QJsonObject convertByFormat(LegacyFormat format, const QString &metaDataStr,
+                                qint32 folderId, qint32 noteId,
+                                QVector<MigrationWarning> *warnings,
+                                WriteResult *result) const;
+
+    // 信封校验 → 紧凑化 → 加密再入库 → 单条参数化 UPDATE。
+    // 成功设置 result.success；失败设置 ValidationFailed/WriteFailed 并日志。
+    void validateAndPersist(QSqlDatabase &db, const QJsonObject &envelope,
+                            int encryption, qint32 noteId, qint32 folderId,
+                            LegacyFormat format,
+                            const QVector<MigrationWarning> &warnings,
+                            WriteResult *result) const;
 
     QString m_dbPath;
 };

--- a/src/importolddata/dbmigration/migrationwriter.h
+++ b/src/importolddata/dbmigration/migrationwriter.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONWRITER_H
+#define MIGRATIONWRITER_H
+
+#include <QString>
+#include <QVector>
+
+// TTP-018: 单条事务写回错误码。
+// 对齐集成数据契约「单条写回回报」+ GAP-2：失败时给出可区分原因码 + 描述。
+enum class WriteErrorCode {
+    None,               // 成功
+    NoteNotFound,       // note_id 查无此行
+    ReadFailed,         // 读取 meta_data/encrypt 的 DB 错误或库文件不可用
+    UnsupportedFormat,  // detect() 返回 Invalid（不可识别，无法转换）
+    ConvertFailed,      // 转换器返回 errors（result.ok()==false）
+    ValidationFailed,   // MigrationJsonValidator::validateEnvelope() 不通过
+    WriteFailed,        // UPDATE 执行失败或未按预期影响行
+    Other
+};
+
+// 统一告警条目（归一化 TTP-013 两类转换器 warnings，GAP-2：path/code/message）。
+struct MigrationWarning {
+    QString path;
+    QString code;
+    QString message;
+};
+
+// 单条写回回报（GAP-2：成功与失败均附带 warnings[]）。
+struct WriteResult {
+    qint32 noteId = 0;
+    bool success = false;
+    WriteErrorCode code = WriteErrorCode::None;
+    QString message;                   // 可区分原因的简述（不含正文/信封）
+    bool originalDataPreserved = true; // 失败时是否原数据原样保留
+    QVector<MigrationWarning> warnings;
+};
+
+// TTP-018: 单条事务写回模块。
+// 在迁移链路 Migrating 态下，对单条笔记执行「读 meta_data → 探测分派 → 转换 →
+// 信封校验 → 紧凑化 → 加密再入库 → 单条参数化 UPDATE → 结构化回报」闭环。
+//
+// 写回仅替换 vnote_items_tbl.meta_data 为 Tiptap 紧凑信封，写回前必须经
+// MigrationJsonValidator::validateEnvelope() 通过；失败保留原数据、单条失败不连累
+// 其他条；加密笔记照旧 base64 编码入库且不改加密标志（expand_filed2）。
+//
+// 边界：不扫描、不调度、不管状态、不生成报告、不复用 UpdateNoteDbVisitor、
+// 不改 src/db/ 与 tiptapmigration/（只读复用 TTP-013 零件）。自带 RW QSqlDatabase
+// 连接（仿 MigrationScanner），单条参数化 UPDATE（单语句原子），不启用事务开关。
+class MigrationWriter
+{
+public:
+    // 默认构造：使用 defaultDbPath() 定位业务库（与 scanner/backup 同源）。
+    MigrationWriter();
+    // 注入 db 路径（测试用，便于指向临时 SQLite 库）。
+    explicit MigrationWriter(const QString &dbPath);
+
+    // 对单条笔记执行完整闭环，返回结构化回报。同步、不抛异常。
+    WriteResult writeOne(qint32 folderId, qint32 noteId);
+
+    // 默认业务库路径定位（只读复用 VNoteDbManager::DBVERSION / DEEPIN_VOICE_NOTE 逻辑）。
+    static QString defaultDbPath();
+
+    QString dbPath() const;
+
+private:
+    QString effectiveDbPath() const;
+    // 进程级唯一 RW 连接名，避免与 VNoteDbManager 运行态连接争用。
+    QString makeConnectionName() const;
+
+    QString m_dbPath;
+};
+
+#endif  // MIGRATIONWRITER_H

--- a/tests/src/importolddata/dbmigration/ut_migrationscanner.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationscanner.cpp
@@ -331,3 +331,67 @@ TEST(UT_MigrationScanner, NeedMigrateListContainsOnlyNoteIds)
     EXPECT_EQ(r.needMigrateNoteIds.size(), r.needMigrateCount);
     EXPECT_EQ(r.abnormals.size(), r.abnormalCount);
 }
+
+// --- P3: query.next() 中途失败归为 QueryFailed，不误报成功 ---
+// 真实 SQLite 难以稳定构造 next() 中途读取失败，故用子类注入 checkIterationFailure
+// 模拟 lastError 置位的中途出错场景，断言 P3 分支返回 QueryFailed + success=false。
+
+namespace {
+class IterationFailScanner : public MigrationScanner
+{
+public:
+    using MigrationScanner::MigrationScanner;
+    int failAfter = 2;
+
+protected:
+    void onRowProcessed(int processedCount) override
+    {
+        m_processed = processedCount;
+    }
+    bool checkIterationFailure(const QSqlQuery &query) const override
+    {
+        Q_UNUSED(query)
+        // 处理满 failAfter 行后模拟 next() 中途出错（lastError 无效但强制失败）。
+        return m_processed >= failAfter;
+    }
+
+private:
+    mutable int m_processed = 0;
+};
+}  // namespace
+
+TEST(UT_MigrationScanner, MidIterationFailureReportedAsQueryFailed)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/iterfail.db");
+    ASSERT_TRUE(createBulkDb(dbPath, 10));
+
+    IterationFailScanner scanner(dbPath);
+    scanner.failAfter = 2;
+    const ScanResult r = scanner.scan();
+
+    // 中途失败不得误报成功
+    EXPECT_FALSE(r.success);
+    EXPECT_EQ(r.code, ScanErrorCode::QueryFailed);
+    EXPECT_FALSE(r.message.isEmpty());
+    // P3 判定点在循环退出后；覆盖该分支返回 QueryFailed 即验证修复目标。
+    EXPECT_GT(r.totalCount, 0);
+}
+
+// --- 正常完成：checkIterationFailure 默认实现不误报失败（回归保护）---
+
+TEST(UT_MigrationScanner, NormalCompletionNotMistakenForFailure)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/ok.db");
+    ASSERT_TRUE(createFixtureDb(dbPath));
+
+    MigrationScanner scanner(dbPath);
+    const ScanResult r = scanner.scan();
+
+    EXPECT_TRUE(r.success);
+    EXPECT_EQ(r.code, ScanErrorCode::None);
+    EXPECT_EQ(r.totalCount, 7);
+}

--- a/tests/src/importolddata/dbmigration/ut_migrationwriter.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationwriter.cpp
@@ -10,6 +10,7 @@
 #include <QByteArray>
 #include <QDateTime>
 #include <QFileInfo>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QSqlDatabase>
@@ -413,4 +414,65 @@ TEST(UT_MigrationWriter, ReadFailedWhenMissing)
     EXPECT_FALSE(r.success);
     EXPECT_EQ(r.code, WriteErrorCode::ReadFailed);
     EXPECT_FALSE(QFileInfo::exists(dbPath));
+}
+
+// --- PlainText 转换分支（非 JSON/非 HTML 纯文本 → 单段落 doc）---
+
+TEST(UT_MigrationWriter, PlainTextConvertedToEnvelope)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/plain.db");
+    ASSERT_TRUE(createDb(dbPath));
+    // 非 JSON、非 HTML 的纯文本串，detect() 归类为 PlainText。
+    const QString metaData = QStringLiteral("hello plain text note");
+    ASSERT_TRUE(insertNoteInto(dbPath, 30, metaData));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 30);
+    EXPECT_TRUE(r.success);
+    EXPECT_EQ(r.code, WriteErrorCode::None);
+
+    const NoteRow row = readNote(dbPath, 30);
+    ASSERT_TRUE(row.found);
+    EXPECT_EQ(LegacyFormatDetector::detect(row.metaData), LegacyFormat::TiptapEnvelope);
+    // 解析信封，断言 content.doc 含一个段落，段落内文本为原文。
+    const QJsonObject envelope = QJsonDocument::fromJson(row.metaData.toUtf8()).object();
+    const QJsonObject content = envelope.value(QStringLiteral("content")).toObject();
+    ASSERT_EQ(content.value(QStringLiteral("type")).toString(), QStringLiteral("doc"));
+    const QJsonArray docContent = content.value(QStringLiteral("content")).toArray();
+    ASSERT_EQ(docContent.size(), 1);
+    const QJsonObject paragraph = docContent.at(0).toObject();
+    EXPECT_EQ(paragraph.value(QStringLiteral("type")).toString(), QStringLiteral("paragraph"));
+    const QJsonArray paragraphContent = paragraph.value(QStringLiteral("content")).toArray();
+    ASSERT_EQ(paragraphContent.size(), 1);
+    const QJsonObject textNode = paragraphContent.at(0).toObject();
+    EXPECT_EQ(textNode.value(QStringLiteral("type")).toString(), QStringLiteral("text"));
+    EXPECT_EQ(textNode.value(QStringLiteral("text")).toString(), metaData);
+}
+
+// --- LegacyHtmlCode 裸 HTML 子分支（doc.isObject()==false）---
+
+TEST(UT_MigrationWriter, BareHtmlConvertedToEnvelope)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/barehtml.db");
+    ASSERT_TRUE(createDb(dbPath));
+    // 裸 HTML 串（非 JSON 包封），detect() 经 looksLikeHtml 归类为 LegacyHtmlCode，
+    // 转换分支中 QJsonDocument::fromJson 解析失败、doc.isObject()==false，htmlCode 取原串。
+    const QString metaData = QStringLiteral("<p>bare html content</p>");
+    ASSERT_TRUE(insertNoteInto(dbPath, 31, metaData));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 31);
+    EXPECT_TRUE(r.success);
+    EXPECT_EQ(r.code, WriteErrorCode::None);
+
+    const NoteRow row = readNote(dbPath, 31);
+    ASSERT_TRUE(row.found);
+    EXPECT_EQ(LegacyFormatDetector::detect(row.metaData), LegacyFormat::TiptapEnvelope);
+    const QJsonObject obj = QJsonDocument::fromJson(row.metaData.toUtf8()).object();
+    EXPECT_EQ(obj.value(QStringLiteral("format")).toString(), QStringLiteral("tiptap"));
+    EXPECT_FALSE(obj.contains(QStringLiteral("htmlCode")));
 }

--- a/tests/src/importolddata/dbmigration/ut_migrationwriter.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationwriter.cpp
@@ -1,0 +1,416 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "importolddata/dbmigration/migrationwriter.h"
+
+#include "importolddata/tiptapmigration/legacyformatdetector.h"
+
+#include "gtest/gtest.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QTemporaryDir>
+
+namespace {
+
+// 唯一连接名后缀，避免多用例连接名冲突。
+QString uniqueConn(const char *prefix)
+{
+    return QStringLiteral("%1_%2").arg(QLatin1String(prefix),
+                                       QDateTime::currentDateTime().toMSecsSinceEpoch());
+}
+
+// 建一张与运行态同名列的 vnote_items_tbl（含 expand_filed2 = encrypt 列）。
+bool createTable(QSqlQuery &q)
+{
+    return q.exec(QStringLiteral(
+        "CREATE TABLE vnote_items_tbl ("
+        "note_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "folder_id INTEGER, "
+        "note_type INTEGER, "
+        "note_title TEXT, "
+        "meta_data TEXT, "
+        "note_state INTEGER, "
+        "create_time TEXT, "
+        "modify_time TEXT, "
+        "delete_time TEXT, "
+        "expand_filed1 INTEGER, "
+        "expand_filed2 INTEGER)"));
+}
+
+// 插入一行笔记（encrypt 落在 expand_filed2 列，modify_time 固定便于断言未变）。
+bool insertNote(QSqlQuery &q, qint32 noteId, const QString &metaData,
+                int encrypt = 0, const QString &modifyTime = QStringLiteral("2026-01-01 00:00:00"))
+{
+    q.prepare(QStringLiteral("INSERT INTO vnote_items_tbl "
+                              "(note_id, folder_id, note_type, note_title, meta_data, "
+                              "note_state, create_time, modify_time, delete_time, "
+                              "expand_filed1, expand_filed2) "
+                              "VALUES (?, 0, 0, 't', ?, 0, '', ?, '', 0, ?)"));
+    q.addBindValue(noteId);
+    q.addBindValue(metaData);
+    q.addBindValue(modifyTime);
+    q.addBindValue(encrypt);
+    return q.exec();
+}
+
+// 建库并插入若干行（按需由用例填充），返回库可读写连接。
+bool createDb(const QString &path)
+{
+    const QString conn = uniqueConn("ut_writer_mk");
+    bool ok = false;
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return false;
+        }
+        QSqlQuery q(db);
+        ok = createTable(q);
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return ok;
+}
+
+// 在已存在的库上插入一行（独立连接）。
+bool insertNoteInto(const QString &path, qint32 noteId, const QString &metaData,
+                    int encrypt = 0,
+                    const QString &modifyTime = QStringLiteral("2026-01-01 00:00:00"))
+{
+    const QString conn = uniqueConn("ut_writer_ins");
+    bool ok = false;
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return false;
+        }
+        QSqlQuery q(db);
+        ok = insertNote(q, noteId, metaData, encrypt, modifyTime);
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return ok;
+}
+
+// 读回单行 meta_data / expand_filed2 / modify_time。
+struct NoteRow {
+    bool found = false;
+    QString metaData;
+    int encrypt = 0;
+    QString modifyTime;
+};
+
+NoteRow readNote(const QString &path, qint32 noteId)
+{
+    NoteRow row;
+    const QString conn = uniqueConn("ut_writer_rd");
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return row;
+        }
+        QSqlQuery q(db);
+        q.prepare(QStringLiteral("SELECT meta_data, expand_filed2, modify_time "
+                                  "FROM vnote_items_tbl WHERE note_id=?"));
+        q.addBindValue(noteId);
+        if (q.exec() && q.next()) {
+            row.found = true;
+            row.metaData = q.value(0).toString();
+            row.encrypt = q.value(1).toInt();
+            row.modifyTime = q.value(2).toString();
+        }
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return row;
+}
+
+// 在库上执行任意 DDL（如建触发器），独立连接。
+bool execDdl(const QString &path, const QString &ddl)
+{
+    const QString conn = uniqueConn("ut_writer_ddl");
+    bool ok = false;
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return false;
+        }
+        QSqlQuery q(db);
+        ok = q.exec(ddl);
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return ok;
+}
+
+}  // namespace
+
+// --- 默认路径定位 ---
+
+TEST(UT_MigrationWriter, DefaultDbPathIsAbsolute)
+{
+    const QString dbPath = MigrationWriter::defaultDbPath();
+    ASSERT_FALSE(dbPath.isEmpty());
+    EXPECT_TRUE(QFileInfo(dbPath).isAbsolute());
+}
+
+// --- #1 noteDatas → 信封 ---
+
+TEST(UT_MigrationWriter, NoteDatasConvertedToEnvelope)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    ASSERT_TRUE(createDb(dbPath));
+    const QString metaData = QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"hello\"}]}");
+    ASSERT_TRUE(insertNoteInto(dbPath, 10, metaData));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 10);
+    EXPECT_TRUE(r.success);
+    EXPECT_EQ(r.code, WriteErrorCode::None);
+
+    const NoteRow row = readNote(dbPath, 10);
+    ASSERT_TRUE(row.found);
+    // 写回后为 Tiptap 信封。
+    EXPECT_EQ(LegacyFormatDetector::detect(row.metaData), LegacyFormat::TiptapEnvelope);
+    // modify_time 未被触碰。
+    EXPECT_EQ(row.modifyTime, QStringLiteral("2026-01-01 00:00:00"));
+}
+
+// --- #2 htmlCode → 信封（清空）---
+
+TEST(UT_MigrationWriter, HtmlCodeReplacedByEnvelopeWithoutHtmlCodeKey)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/html.db");
+    ASSERT_TRUE(createDb(dbPath));
+    const QString metaData = QStringLiteral("{\"htmlCode\":\"<p>hi</p>\"}");
+    ASSERT_TRUE(insertNoteInto(dbPath, 11, metaData));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 11);
+    EXPECT_TRUE(r.success);
+
+    const NoteRow row = readNote(dbPath, 11);
+    ASSERT_TRUE(row.found);
+    EXPECT_EQ(LegacyFormatDetector::detect(row.metaData), LegacyFormat::TiptapEnvelope);
+    const QJsonObject obj = QJsonDocument::fromJson(row.metaData.toUtf8()).object();
+    // 信封内不含旧 htmlCode 键。
+    EXPECT_FALSE(obj.contains(QStringLiteral("htmlCode")));
+    EXPECT_EQ(obj.value(QStringLiteral("format")).toString(), QStringLiteral("tiptap"));
+}
+
+// --- #3 加密 round-trip ---
+
+TEST(UT_MigrationWriter, EncryptedNoteRoundTrip)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/enc.db");
+    ASSERT_TRUE(createDb(dbPath));
+    const QString plain = QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"secret\"}]}");
+    const QString encoded = QString::fromLatin1(plain.toUtf8().toBase64());
+    ASSERT_TRUE(insertNoteInto(dbPath, 12, encoded, 1));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 12);
+    EXPECT_TRUE(r.success);
+
+    const NoteRow row = readNote(dbPath, 12);
+    ASSERT_TRUE(row.found);
+    // 加密标志不变。
+    EXPECT_EQ(row.encrypt, 1);
+    // meta_data 仍为 base64，解码后为紧凑信封。
+    const QString decoded = QString::fromUtf8(QByteArray::fromBase64(row.metaData.toUtf8()));
+    EXPECT_EQ(LegacyFormatDetector::detect(decoded), LegacyFormat::TiptapEnvelope);
+    EXPECT_FALSE(decoded.contains(QLatin1String("\n")));
+}
+
+// --- #4 校验不通过 → 不写回（ValidationFailed）---
+
+TEST(UT_MigrationWriter, ValidationFailedPreservesOriginal)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/vfail.db");
+    ASSERT_TRUE(createDb(dbPath));
+    // ProseMirrorDoc 含不支持的节点：包封后 validator 拒绝。
+    const QString metaData =
+        QStringLiteral("{\"type\":\"doc\",\"content\":[{\"type\":\"unknownNode\"}]}");
+    ASSERT_TRUE(insertNoteInto(dbPath, 13, metaData));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 13);
+    EXPECT_FALSE(r.success);
+    EXPECT_EQ(r.code, WriteErrorCode::ValidationFailed);
+    EXPECT_TRUE(r.originalDataPreserved);
+
+    const NoteRow row = readNote(dbPath, 13);
+    ASSERT_TRUE(row.found);
+    // 原数据原样保留。
+    EXPECT_EQ(row.metaData, metaData);
+}
+
+// --- #4' 转换失败 → 不写回（ConvertFailed）---
+
+TEST(UT_MigrationWriter, ConvertFailedPreservesOriginal)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/cfail.db");
+    ASSERT_TRUE(createDb(dbPath));
+    // noteDatas 语音块缺 voicePath → 转换器报错。
+    const QString metaData = QStringLiteral("{\"noteDatas\":[{\"type\":2,\"voicePath\":\"\"}]}");
+    ASSERT_TRUE(insertNoteInto(dbPath, 14, metaData));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 14);
+    EXPECT_FALSE(r.success);
+    EXPECT_EQ(r.code, WriteErrorCode::ConvertFailed);
+    EXPECT_TRUE(r.originalDataPreserved);
+
+    const NoteRow row = readNote(dbPath, 14);
+    ASSERT_TRUE(row.found);
+    EXPECT_EQ(row.metaData, metaData);
+}
+
+// --- #5 写回失败 → 原数据保留 ---
+
+TEST(UT_MigrationWriter, WriteFailedPreservesOriginal)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/wfail.db");
+    ASSERT_TRUE(createDb(dbPath));
+    const QString metaData = QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"x\"}]}");
+    ASSERT_TRUE(insertNoteInto(dbPath, 15, metaData));
+    // 建一个 BEFORE UPDATE 触发器强制 UPDATE 失败（RAISE ABORT 回滚单语句）。
+    ASSERT_TRUE(execDdl(dbPath, QStringLiteral(
+        "CREATE TRIGGER block_update BEFORE UPDATE ON vnote_items_tbl "
+        "BEGIN SELECT RAISE(ABORT, 'update blocked'); END;")));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 15);
+    EXPECT_FALSE(r.success);
+    EXPECT_EQ(r.code, WriteErrorCode::WriteFailed);
+    EXPECT_TRUE(r.originalDataPreserved);
+
+    const NoteRow row = readNote(dbPath, 15);
+    ASSERT_TRUE(row.found);
+    EXPECT_EQ(row.metaData, metaData);
+}
+
+// --- #6 已是 Tiptap → 跳过 ---
+
+TEST(UT_MigrationWriter, AlreadyTiptapSkipped)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/tip.db");
+    ASSERT_TRUE(createDb(dbPath));
+    const QString metaData = QStringLiteral("{\"format\":\"tiptap\",\"content\":{}}");
+    ASSERT_TRUE(insertNoteInto(dbPath, 16, metaData));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 16);
+    EXPECT_TRUE(r.success);
+    EXPECT_TRUE(r.originalDataPreserved);
+
+    const NoteRow row = readNote(dbPath, 16);
+    ASSERT_TRUE(row.found);
+    // 未写回，原样保留。
+    EXPECT_EQ(row.metaData, metaData);
+}
+
+// --- #7 单条失败隔离 ---
+
+TEST(UT_MigrationWriter, SingleFailureIsolation)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/iso.db");
+    ASSERT_TRUE(createDb(dbPath));
+    // 坏：不可识别格式（Invalid）。
+    ASSERT_TRUE(insertNoteInto(dbPath, 20, QStringLiteral("{\"unknown\":\"obj\"}")));
+    // 好：旧 noteDatas。
+    ASSERT_TRUE(insertNoteInto(dbPath, 21, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"ok\"}]}")));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult bad = writer.writeOne(0, 20);
+    EXPECT_FALSE(bad.success);
+    EXPECT_EQ(bad.code, WriteErrorCode::UnsupportedFormat);
+
+    // 坏的不影响好的成功写回。
+    const WriteResult good = writer.writeOne(0, 21);
+    EXPECT_TRUE(good.success);
+    const NoteRow row = readNote(dbPath, 21);
+    ASSERT_TRUE(row.found);
+    EXPECT_EQ(LegacyFormatDetector::detect(row.metaData), LegacyFormat::TiptapEnvelope);
+}
+
+// --- #8 warnings 透传 ---
+
+TEST(UT_MigrationWriter, WarningsPassedThrough)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/warn.db");
+    ASSERT_TRUE(createDb(dbPath));
+    // 非文本/非语音块 → 转换器产出 warning（skipped-non-text-block），ok()==true。
+    const QString metaData = QStringLiteral("{\"noteDatas\":[{\"type\":3}]}");
+    ASSERT_TRUE(insertNoteInto(dbPath, 22, metaData));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 22);
+    EXPECT_TRUE(r.success);
+    ASSERT_FALSE(r.warnings.isEmpty());
+    const MigrationWarning w = r.warnings.first();
+    EXPECT_FALSE(w.code.isEmpty());
+    EXPECT_FALSE(w.message.isEmpty());
+}
+
+// --- #9 NoteNotFound ---
+
+TEST(UT_MigrationWriter, NoteNotFoundPreservesOriginal)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/nf.db");
+    ASSERT_TRUE(createDb(dbPath));
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 9999);
+    EXPECT_FALSE(r.success);
+    EXPECT_EQ(r.code, WriteErrorCode::NoteNotFound);
+    EXPECT_TRUE(r.originalDataPreserved);
+}
+
+// --- 源库文件不存在 → ReadFailed ---
+
+TEST(UT_MigrationWriter, ReadFailedWhenMissing)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/nonexistent.db");
+
+    MigrationWriter writer(dbPath);
+    const WriteResult r = writer.writeOne(0, 1);
+    EXPECT_FALSE(r.success);
+    EXPECT_EQ(r.code, WriteErrorCode::ReadFailed);
+    EXPECT_FALSE(QFileInfo::exists(dbPath));
+}


### PR DESCRIPTION
## Migration infrastructure: scanner fix, write-back, and writer refactor

This PR adds the single-note transactional write-back stage of the Tiptap content migration, plus a scanner robustness fix and a structural refactor of the writer.

### Commits

1. **fix(migration): detect query iteration failure in scanner** — adds a virtual `checkIterationFailure()` hook so the scan loop can distinguish a genuine end-of-cursor from a stuck/failed iteration; truncated scans now surface as `QueryFailed` instead of silent partial results.
2. **feat(migration): implement single-note transactional write-back** — `MigrationWriter` module providing the full closed loop for a single note: read `meta_data`, dispatch by detected legacy format, convert to Tiptap envelope, validate, compact, and write back via a single parameterized `UPDATE`. Failure isolation preserves original data on any error.
3. **refactor(migration): split MigrationWriter::writeOne and cover remaining branches** — extracts `readNoteRow()`, `convertByFormat()`, and `validateAndPersist()` as private helpers; adds tests for PlainText and bare HTML conversion branches. Pure structural refactor, behavior preserved bit-for-bit.

### New modules

- `migrationwriter.{h,cpp}` — single-note transactional write-back

### Modified modules

- `migrationscanner.{h,cpp}` — iteration failure detection

### Tests

- `ut_migrationscanner.cpp` — 2 new cases (mid-iteration failure, normal completion regression)
- `ut_migrationwriter.cpp` — 14 cases (write-back scenarios, failure isolation, converter branches)
