### PR TITLE
feat(migration): report, orchestrator, and progress view

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -7,6 +7,7 @@
 #include "vnoteitemoper.h"
 #include "vnotefolderoper.h"
 #include "VNoteMainManager.h"
+#include "migrationviewcontroller.h"  // TTP-021 升级进度界面控制器
 #include "jscontent.h"
 #include "webrichetextmanager.h"
 #include "setting.h"
@@ -166,10 +167,21 @@ QObject *voiceRecoder_provider(QQmlEngine *engine, QJSEngine *scriptEngine)
     return VoiceRecoderHandler::instance();
 }
 
+QObject *migrationViewController_provider(QQmlEngine *engine, QJSEngine *scriptEngine)
+{
+    qInfo() << "migrationViewController_provider called";
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+
+    return MigrationViewController::instance();
+}
+
 void VNoteMainManager::initQMLRegister()
 {
     qInfo() << "Initializing QML registration";
     qmlRegisterSingletonType<VNoteMainManager>("VNote", 1, 0, "VNoteMainManager", mainManager_provider);
+    // TTP-021: 升级进度界面控制器单例
+    qmlRegisterSingletonType<MigrationViewController>("VNote", 1, 0, "MigrationViewController", migrationViewController_provider);
     qmlRegisterSingletonType<JsContent>("VNote", 1, 0, "Webobj", jsContent_provider);
     // 菜单项管理
     qmlRegisterSingletonType<ActionManager>("VNote", 1, 0, "ActionManager", actionManager_provider);

--- a/src/common/migrationviewcontroller.cpp
+++ b/src/common/migrationviewcontroller.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationviewcontroller.h"
+
+#include <QLoggingCategory>
+
+namespace {
+Q_LOGGING_CATEGORY(lcMigrationView, "voice_note_migration_view")
+}
+
+MigrationViewController *MigrationViewController::instance()
+{
+    static MigrationViewController instance;
+    return &instance;
+}
+
+MigrationViewController::MigrationViewController(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void MigrationViewController::start()
+{
+    // M2：跨线程 QueuedConnection 投递 ProgressSnapshot/MigrationState 前必须注册 metatype，
+    // 否则后台线程 emit 的进度/阶段/终态信号无法跨线程队列投递。
+    qRegisterMetaType<MigrationOrchestrator::ProgressSnapshot>();
+    qRegisterMetaType<MigrationState>();
+
+    if (m_orchestrator || m_migrationActive) {
+        qCInfo(lcMigrationView) << "start: migration already in progress, ignore";
+        return;
+    }
+
+    // 据状态机判定是否需迁移：Pending 或可续传（BackingUp/Scanning/Migrating/PartialCompleted）
+    // 需展示进度界面；NotNeeded/Completed/Failed（已完成）直接放行不展示。
+    MigrationStateMachine state(MigrationStateMachine::defaultFilePath());
+    state.load();
+    const MigrationState current = state.currentState();
+    const bool needRun = (current == MigrationState::Pending) || state.isResumable();
+    qCInfo(lcMigrationView) << "start: currentState=" << migrationStateToString(current)
+                            << "needRun=" << needRun;
+    if (!needRun) {
+        setMigrationActive(false);
+        return;
+    }
+
+    // 展示进度界面并拉起后台编排器；startIfNeeded 内部在后台线程启动前以
+    // Qt::QueuedConnection 把进度/阶段/终态/中断信号连接到本控制器。
+    setMigrationActive(true);
+    MigrationOrchestrator *orchestrator = MigrationOrchestrator::startIfNeeded(this);
+    if (!orchestrator) {
+        // 状态在判定与启动之间变化（磁盘异常边界）：回退为不放行展示。
+        qCWarning(lcMigrationView) << "start: startIfNeeded returned null, hide overlay";
+        setMigrationActive(false);
+        return;
+    }
+    m_orchestrator = orchestrator;
+}
+
+void MigrationViewController::requestCancel()
+{
+    if (m_cancelling) {
+        return;
+    }
+    setCancelling(true);
+    if (m_orchestrator) {
+        // requestCancel 仅置原子标志，线程安全，可直接跨线程调用（不经过事件队列）。
+        m_orchestrator->requestCancel();
+        qCInfo(lcMigrationView) << "requestCancel: forwarded to orchestrator";
+    } else {
+        qCWarning(lcMigrationView) << "requestCancel: no active orchestrator";
+    }
+}
+
+void MigrationViewController::enterApp()
+{
+    qCInfo(lcMigrationView) << "enterApp: dismiss terminal view";
+    setTerminalState(QString());
+    setBackupPath(QString());
+    setReportPath(QString());
+    setMigrationActive(false);
+    releaseOrchestrator();
+}
+
+void MigrationViewController::onProgressChanged(const MigrationOrchestrator::ProgressSnapshot &snapshot)
+{
+    // M1：仅消费 progressChanged 信号，不跨线程调 progressSnapshot()。
+    setProcessed(snapshot.processed);
+    setTotal(snapshot.total);
+    setSuccess(snapshot.success);
+    setFail(snapshot.fail);
+}
+
+void MigrationViewController::onStageChanged(MigrationState stage)
+{
+    setStage(migrationStateToString(stage));
+}
+
+void MigrationViewController::onTerminalInfo(MigrationState finalState, const QString &backupPath, const QString &reportPath)
+{
+    qCInfo(lcMigrationView) << "onTerminalInfo: finalState=" << migrationStateToString(finalState)
+                            << "backupPath=" << backupPath << "reportPath=" << reportPath;
+    setBackupPath(backupPath);
+    setReportPath(reportPath);
+    setCancelling(false);
+    setMigrationActive(false);
+    if (finalState == MigrationState::NotNeeded) {
+        // NotNeeded 不展示终态视图，直接放行。
+        setTerminalState(QString());
+    } else {
+        // Completed/PartialCompleted/Failed：终态视图由 terminalState 非空驱动展示，
+        // 供用户查看备份/报告路径并通过"进入应用"放行。
+        setTerminalState(migrationStateToString(finalState));
+    }
+    releaseOrchestrator();
+}
+
+void MigrationViewController::onAborted()
+{
+    qCInfo(lcMigrationView) << "onAborted: non-terminal exit, release overlay";
+    setCancelling(false);
+    setMigrationActive(false);
+    releaseOrchestrator();
+}
+
+// --- 私有 ---
+
+void MigrationViewController::releaseOrchestrator()
+{
+    if (m_orchestrator) {
+        // 断开编排器到本控制器的所有信号连接；编排器由 deleteLater 回收，不在此 delete。
+        m_orchestrator->disconnect(this);
+        m_orchestrator = nullptr;
+    }
+}
+
+void MigrationViewController::setMigrationActive(bool active)
+{
+    if (m_migrationActive == active) {
+        return;
+    }
+    m_migrationActive = active;
+    emit migrationActiveChanged();
+}
+
+void MigrationViewController::setStage(const QString &stage)
+{
+    if (m_stage == stage) {
+        return;
+    }
+    m_stage = stage;
+    emit stageChanged();
+}
+
+void MigrationViewController::setProcessed(int value)
+{
+    if (m_processed == value) {
+        return;
+    }
+    m_processed = value;
+    emit processedChanged();
+}
+
+void MigrationViewController::setTotal(int value)
+{
+    if (m_total == value) {
+        return;
+    }
+    m_total = value;
+    emit totalChanged();
+}
+
+void MigrationViewController::setSuccess(int value)
+{
+    if (m_success == value) {
+        return;
+    }
+    m_success = value;
+    emit successChanged();
+}
+
+void MigrationViewController::setFail(int value)
+{
+    if (m_fail == value) {
+        return;
+    }
+    m_fail = value;
+    emit failChanged();
+}
+
+void MigrationViewController::setTerminalState(const QString &state)
+{
+    if (m_terminalState == state) {
+        return;
+    }
+    m_terminalState = state;
+    emit terminalStateChanged();
+}
+
+void MigrationViewController::setBackupPath(const QString &path)
+{
+    if (m_backupPath == path) {
+        return;
+    }
+    m_backupPath = path;
+    emit backupPathChanged();
+}
+
+void MigrationViewController::setReportPath(const QString &path)
+{
+    if (m_reportPath == path) {
+        return;
+    }
+    m_reportPath = path;
+    emit reportPathChanged();
+}
+
+void MigrationViewController::setCancelling(bool value)
+{
+    if (m_cancelling == value) {
+        return;
+    }
+    m_cancelling = value;
+    emit cancellingChanged();
+}

--- a/src/common/migrationviewcontroller.h
+++ b/src/common/migrationviewcontroller.h
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONVIEWCONTROLLER_H
+#define MIGRATIONVIEWCONTROLLER_H
+
+#include "importolddata/dbmigration/migrationorchestrator.h"  // ProgressSnapshot / MigrationState
+#include "importolddata/dbmigration/migrationstate.h"
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+// TTP-021: 升级进度界面控制器（QML 单例）。
+//
+// 消费 TTP-020 编排层信号（progressChanged/stageChanged/terminalInfo/aborted），
+// 映射为 QML 只读属性供 MigrationProgressView 绑定；提供取消入口与终态放行入口。
+// 仅消费信号，不跨线程调 progressSnapshot()（M1），不反向控制迁移内部逻辑。
+//
+// 生命周期：start() 由 main.cpp 在 DB 就绪后单行调用；编排器由 startIfNeeded() 返回，
+// 控制器以 QPointer 持有，终态/aborted 后 disconnect + 清空（编排器由 deleteLater 回收）。
+class MigrationViewController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool migrationActive READ migrationActive NOTIFY migrationActiveChanged)
+    Q_PROPERTY(QString stage READ stage NOTIFY stageChanged)
+    Q_PROPERTY(int processed READ processed NOTIFY processedChanged)
+    Q_PROPERTY(int total READ total NOTIFY totalChanged)
+    Q_PROPERTY(int success READ success NOTIFY successChanged)
+    Q_PROPERTY(int fail READ fail NOTIFY failChanged)
+    Q_PROPERTY(QString terminalState READ terminalState NOTIFY terminalStateChanged)
+    Q_PROPERTY(QString backupPath READ backupPath NOTIFY backupPathChanged)
+    Q_PROPERTY(QString reportPath READ reportPath NOTIFY reportPathChanged)
+    Q_PROPERTY(bool cancelling READ cancelling NOTIFY cancellingChanged)
+
+public:
+    static MigrationViewController *instance();
+
+    bool migrationActive() const { return m_migrationActive; }
+    QString stage() const { return m_stage; }
+    int processed() const { return m_processed; }
+    int total() const { return m_total; }
+    int success() const { return m_success; }
+    int fail() const { return m_fail; }
+    QString terminalState() const { return m_terminalState; }
+    QString backupPath() const { return m_backupPath; }
+    QString reportPath() const { return m_reportPath; }
+    bool cancelling() const { return m_cancelling; }
+
+    // 启动入口：注册跨线程 metatype（M2）、据状态机判定是否需迁移、拉起后台编排器。
+    void start();
+
+public slots:
+    // 取消入口（QML 调用）：转发到编排器（原子置位，线程安全）并置 cancelling。
+    Q_INVOKABLE void requestCancel();
+    // 终态放行入口（QML "进入应用" 按钮）：收起终态视图。
+    Q_INVOKABLE void enterApp();
+
+    // 编排器信号→属性映射槽（由 startIfNeeded 以 Qt::QueuedConnection 连接）。
+    void onProgressChanged(const MigrationOrchestrator::ProgressSnapshot &snapshot);
+    void onStageChanged(MigrationState stage);
+    void onTerminalInfo(MigrationState finalState, const QString &backupPath, const QString &reportPath);
+    void onAborted();
+
+signals:
+    void migrationActiveChanged();
+    void stageChanged();
+    void processedChanged();
+    void totalChanged();
+    void successChanged();
+    void failChanged();
+    void terminalStateChanged();
+    void backupPathChanged();
+    void reportPathChanged();
+    void cancellingChanged();
+
+private:
+    explicit MigrationViewController(QObject *parent = nullptr);
+
+    void setMigrationActive(bool active);
+    void setStage(const QString &stage);
+    void setProcessed(int value);
+    void setTotal(int value);
+    void setSuccess(int value);
+    void setFail(int value);
+    void setTerminalState(const QString &state);
+    void setBackupPath(const QString &path);
+    void setReportPath(const QString &path);
+    void setCancelling(bool value);
+
+    // 终态/aborted 后断开编排器信号并清空 QPointer（编排器由 deleteLater 回收）。
+    void releaseOrchestrator();
+
+    bool m_migrationActive = false;
+    QString m_stage;
+    int m_processed = 0;
+    int m_total = 0;
+    int m_success = 0;
+    int m_fail = 0;
+    QString m_terminalState;
+    QString m_backupPath;
+    QString m_reportPath;
+    bool m_cancelling = false;
+
+    QPointer<MigrationOrchestrator> m_orchestrator;
+};
+
+#endif // MIGRATIONVIEWCONTROLLER_H

--- a/src/deepin-voice-note.qrc
+++ b/src/deepin-voice-note.qrc
@@ -22,6 +22,7 @@
         <file>gui/mainwindow/FolderListView.qml</file>
         <file>gui/mainwindow/InitialInterface.qml</file>
         <file>gui/mainwindow/ItemListView.qml</file>
+        <file>gui/mainwindow/MigrationProgressView.qml</file>
         <file>gui/mainwindow/MainWindow.qml</file>
         <file>gui/mainwindow/SelectView.qml</file>
         <file>gui/mainwindow/VNoteRightMenu.qml</file>

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -268,6 +268,11 @@ ApplicationWindow {
 
     }
 
+    // TTP-021: 升级进度界面全屏覆盖层（迁移期间遮蔽主编辑界面，终态展示备份/报告路径）。
+    MigrationProgressView {
+        anchors.fill: parent
+    }
+
     Connections {
         function handleFinishedFolderLoad(foldersData) {
             for (var i = 0; i < foldersData.length; i++) {

--- a/src/gui/mainwindow/MigrationProgressView.qml
+++ b/src/gui/mainwindow/MigrationProgressView.qml
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import VNote 1.0
+
+// TTP-021: 升级进度界面全屏覆盖层。
+// 迁移期间（migrationActive）遮蔽主编辑界面；终态（terminalState 非空）展示
+// 备份/报告路径与"进入应用"放行入口；NotNeeded 不展示直接放行。
+// 仅绑定计数/阶段/路径属性，不展示笔记正文/信封/meta_data/失败 note id 清单。
+Item {
+    id: root
+
+    // 覆盖层可见：迁移进行中 或 终态结果待用户放行。
+    visible: MigrationViewController.migrationActive || MigrationViewController.terminalState !== ""
+    z: 9999
+
+    // 终态结果待放行（Completed/PartialCompleted/Failed）。
+    readonly property bool terminalVisible: MigrationViewController.terminalState !== ""
+    // 迁移进行中（含等待态/Migrating），非终态。
+    readonly property bool runningActive: MigrationViewController.migrationActive && !terminalVisible
+
+    Rectangle {
+        id: background
+        anchors.fill: parent
+        color: "#FFFFFF"
+        opacity: 0.97
+    }
+
+    // 吸收鼠标事件，迁移期间/终态放行前阻止与下层主编辑界面交互。
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        propagateComposedEvents: false
+        // 不消费滚轮事件以外的内容；仅拦截点击，避免穿透到编辑器。
+        onClicked: function(mouse) { mouse.accepted = true }
+        onPressed: function(mouse) { mouse.accepted = true }
+        onPositionChanged: function(mouse) { mouse.accepted = true }
+    }
+
+    ColumnLayout {
+        anchors.centerIn: parent
+        spacing: 20
+        width: Math.min(420, parent.width - 80)
+
+        // 标题（占位文案，视觉由 designer 定稿）。
+        Text {
+            Layout.alignment: Qt.AlignHCenter
+            text: terminalVisible ? terminalTitle() : runningTitle()
+            font.pixelSize: 18
+            font.bold: true
+            color: "#303030"
+        }
+
+        // 阶段文案（运行态展示当前阶段）。
+        Text {
+            Layout.alignment: Qt.AlignHCenter
+            visible: runningActive
+            text: stageText(MigrationViewController.stage)
+            font.pixelSize: 14
+            color: "#666666"
+        }
+
+        // 进度条（运行态）。
+        ProgressBar {
+            Layout.fillWidth: true
+            visible: runningActive
+            // Migrating 阶段按已处理/总数推进；其余阶段不确定进度。
+            indeterminate: MigrationViewController.total === 0
+            from: 0
+            to: Math.max(1, MigrationViewController.total)
+            value: MigrationViewController.processed
+        }
+
+        // Migrating 计数（已处理/总数/成功/失败）。
+        Text {
+            Layout.alignment: Qt.AlignHCenter
+            visible: runningActive && MigrationViewController.stage === "Migrating"
+            text: qsTr("已处理 %1 / %2　成功 %3　失败 %4")
+                  .arg(MigrationViewController.processed)
+                  .arg(MigrationViewController.total)
+                  .arg(MigrationViewController.success)
+                  .arg(MigrationViewController.fail)
+            font.pixelSize: 13
+            color: "#888888"
+        }
+
+        // 终态信息：备份与报告路径（不渲染报告正文，仅展示路径供用户查阅）。
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: terminalVisible
+            spacing: 8
+
+            Text {
+                Layout.fillWidth: true
+                visible: MigrationViewController.backupPath !== ""
+                text: qsTr("备份位置：%1").arg(MigrationViewController.backupPath)
+                font.pixelSize: 13
+                color: "#555555"
+                wrapMode: Text.WrapAnywhere
+            }
+            Text {
+                Layout.fillWidth: true
+                visible: MigrationViewController.reportPath !== ""
+                text: qsTr("迁移报告：%1").arg(MigrationViewController.reportPath)
+                font.pixelSize: 13
+                color: "#555555"
+                wrapMode: Text.WrapAnywhere
+            }
+            // 部分完成/失败的计数摘要（仅计数，不展示失败 note id 清单）。
+            Text {
+                Layout.fillWidth: true
+                visible: terminalVisible && MigrationViewController.terminalState !== "Completed"
+                text: qsTr("成功 %1　失败 %2").arg(MigrationViewController.success).arg(MigrationViewController.fail)
+                font.pixelSize: 13
+                color: "#888888"
+            }
+        }
+
+        // 取消按钮（运行态可见；cancelling 时置灰）。
+        Button {
+            Layout.alignment: Qt.AlignHCenter
+            visible: runningActive
+            enabled: !MigrationViewController.cancelling
+            text: MigrationViewController.cancelling ? qsTr("正在取消…") : qsTr("取消迁移")
+            onClicked: MigrationViewController.requestCancel()
+        }
+
+        // "进入应用"放行入口（终态）。
+        Button {
+            Layout.alignment: Qt.AlignHCenter
+            visible: terminalVisible
+            text: qsTr("进入应用")
+            onClicked: MigrationViewController.enterApp()
+        }
+    }
+
+    function runningTitle() {
+        return qsTr("正在升级笔记数据，请勿关闭应用");
+    }
+
+    function terminalTitle() {
+        var s = MigrationViewController.terminalState;
+        if (s === "Completed") return qsTr("升级完成");
+        if (s === "PartialCompleted") return qsTr("升级部分完成");
+        if (s === "Failed") return qsTr("升级失败");
+        return qsTr("升级完成");
+    }
+
+    function stageText(stage) {
+        switch (stage) {
+            case "BackingUp": return qsTr("正在备份数据…");
+            case "Scanning": return qsTr("正在扫描笔记…");
+            case "Migrating": return qsTr("正在迁移笔记…");
+            default: return qsTr("正在准备…");
+        }
+    }
+}

--- a/src/importolddata/dbmigration/migrationorchestrator.cpp
+++ b/src/importolddata/dbmigration/migrationorchestrator.cpp
@@ -42,18 +42,34 @@ MigrationOrchestrator::MigrationOrchestrator(const QString &dbPath, const QStrin
 
 // --- 静态启动入口 ---
 
-void MigrationOrchestrator::startIfNeeded()
+MigrationOrchestrator *MigrationOrchestrator::startIfNeeded(QObject *signalConsumer)
 {
     MigrationOrchestrator *orchestrator = new MigrationOrchestrator();
     if (!orchestrator->shouldRun()) {
         qCInfo(lcMigrationOrchestrator) << "startIfNeeded: no migration to run, state="
                                         << migrationStateToString(orchestrator->m_state.currentState());
         delete orchestrator;
-        return;
+        return nullptr;
     }
 
     QThread *thread = new QThread();
     orchestrator->moveToThread(thread);
+    // 在后台线程启动前，把进度/阶段/终态/中断信号以 Qt::QueuedConnection 连接到 consumer
+    // （TTP-021 控制器）。QueuedConnection 保证跨线程安全投递，consumer 在其所在线程处理。
+    if (signalConsumer) {
+        connect(orchestrator, SIGNAL(progressChanged(MigrationOrchestrator::ProgressSnapshot)),
+                signalConsumer, SLOT(onProgressChanged(MigrationOrchestrator::ProgressSnapshot)),
+                Qt::QueuedConnection);
+        connect(orchestrator, SIGNAL(stageChanged(MigrationState)),
+                signalConsumer, SLOT(onStageChanged(MigrationState)),
+                Qt::QueuedConnection);
+        connect(orchestrator, SIGNAL(terminalInfo(MigrationState,QString,QString)),
+                signalConsumer, SLOT(onTerminalInfo(MigrationState,QString,QString)),
+                Qt::QueuedConnection);
+        connect(orchestrator, SIGNAL(aborted()),
+                signalConsumer, SLOT(onAborted()),
+                Qt::QueuedConnection);
+    }
     connect(thread, &QThread::started, orchestrator, &MigrationOrchestrator::run);
     // 终态与非终态退出都退出线程并回收 orchestrator（P2：覆盖不发 finished 的提前返回路径）。
     connect(orchestrator, &MigrationOrchestrator::finished, thread, &QThread::quit);
@@ -64,6 +80,7 @@ void MigrationOrchestrator::startIfNeeded()
     qCInfo(lcMigrationOrchestrator) << "startIfNeeded: launching migration in background thread, state="
                                     << migrationStateToString(orchestrator->m_state.currentState());
     thread->start();
+    return orchestrator;
 }
 
 bool MigrationOrchestrator::shouldRun() const
@@ -393,6 +410,9 @@ void MigrationOrchestrator::finalize(MigrationState finalState)
     }
 
     m_finishedEmitted.store(true);
+    // TTP-021：紧邻 finished 发出终态伴生信号，额外携带 backupPath。
+    // NotNeeded 终态无备份产出，backupPath 传空以满足 TTP-021 契约（与 reportPath 一致）。
+    emit terminalInfo(finalState, finalState == MigrationState::NotNeeded ? QString() : m_backupPath, reportPath);
     emit finished(finalState, reportPath);
 }
 

--- a/src/importolddata/dbmigration/migrationorchestrator.cpp
+++ b/src/importolddata/dbmigration/migrationorchestrator.cpp
@@ -1,0 +1,493 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationorchestrator.h"
+
+#include "migrationbackup.h"
+#include "migrationreport.h"
+#include "migrationscanner.h"
+#include "migrationwriter.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QLoggingCategory>
+#include <QThread>
+
+namespace {
+Q_LOGGING_CATEGORY(lcMigrationOrchestrator, "voice_note_migration_orchestrator")
+}
+
+MigrationOrchestrator::MigrationOrchestrator(QObject *parent)
+    : MigrationOrchestrator(MigrationBackup::defaultDbPath(),
+                            MigrationStateMachine::defaultFilePath(),
+                            MigrationBackup::defaultBackupDir(),
+                            MigrationReport::defaultReportDir(),
+                            parent)
+{
+}
+
+MigrationOrchestrator::MigrationOrchestrator(const QString &dbPath, const QString &stateFilePath,
+                                             const QString &backupDir, const QString &reportDir,
+                                             QObject *parent)
+    : QObject(parent)
+    , m_state(stateFilePath)
+    , m_dbPath(dbPath)
+    , m_backupDir(backupDir)
+    , m_reportDir(reportDir)
+{
+    m_state.load();
+}
+
+// --- 静态启动入口 ---
+
+void MigrationOrchestrator::startIfNeeded()
+{
+    MigrationOrchestrator *orchestrator = new MigrationOrchestrator();
+    if (!orchestrator->shouldRun()) {
+        qCInfo(lcMigrationOrchestrator) << "startIfNeeded: no migration to run, state="
+                                        << migrationStateToString(orchestrator->m_state.currentState());
+        delete orchestrator;
+        return;
+    }
+
+    QThread *thread = new QThread();
+    orchestrator->moveToThread(thread);
+    connect(thread, &QThread::started, orchestrator, &MigrationOrchestrator::run);
+    // 终态与非终态退出都退出线程并回收 orchestrator（P2：覆盖不发 finished 的提前返回路径）。
+    connect(orchestrator, &MigrationOrchestrator::finished, thread, &QThread::quit);
+    connect(orchestrator, &MigrationOrchestrator::aborted, thread, &QThread::quit);
+    connect(orchestrator, &MigrationOrchestrator::finished, orchestrator, &MigrationOrchestrator::deleteLater);
+    connect(orchestrator, &MigrationOrchestrator::aborted, orchestrator, &MigrationOrchestrator::deleteLater);
+    connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+    qCInfo(lcMigrationOrchestrator) << "startIfNeeded: launching migration in background thread, state="
+                                    << migrationStateToString(orchestrator->m_state.currentState());
+    thread->start();
+}
+
+bool MigrationOrchestrator::shouldRun() const
+{
+    const MigrationState state = m_state.currentState();
+    return state == MigrationState::Pending || m_state.isResumable();
+}
+
+// --- 主循环 ---
+
+void MigrationOrchestrator::run()
+{
+    // 包装 runInternal()：若内部未发 finished（非终态退出），补发 aborted() 以保证
+    // 后台 QThread 总是退出回收（P2）。测试直调 run() 时 aborted 无监听者，无副作用。
+    m_finishedEmitted.store(false);
+    runInternal();
+    if (!m_finishedEmitted.load()) {
+        qCInfo(lcMigrationOrchestrator) << "run: non-terminal exit, emit aborted";
+        emit aborted();
+    }
+}
+
+void MigrationOrchestrator::runInternal()
+{
+    m_timer.start();
+    m_state.load();
+
+    MigrationState state = m_state.currentState();
+    qCInfo(lcMigrationOrchestrator) << "run: enter, state=" << migrationStateToString(state);
+
+    // 已处成功终态：无需动作。
+    if (state == MigrationState::Completed || state == MigrationState::NotNeeded) {
+        return;
+    }
+
+    // 续传/重试入口：PartialCompleted 可合法回到 Pending 重做（重扫自动排除已迁移笔记）。
+    // 注意：BackingUp/Scanning/Migrating 不能直接转 Pending（TTP-015 合法转换边），
+    // 故这些中间态就地续传，不回 Pending；仅 PartialCompleted 回 Pending。
+    if (state == MigrationState::PartialCompleted) {
+        if (!m_state.requestTransition(MigrationState::Pending, MigrationSubstage::None,
+                                       QStringLiteral("resume from partial"))) {
+            return;
+        }
+    }
+
+    // 恢复游标数据：仅中间态续传时从游标恢复 backupPath/noteIds/计数。
+    // fresh Pending（含 PartialCompleted 回到 Pending 的重试）不恢复，重新备份/扫描，
+    // 避免沿用已过期的清单（重扫会自动排除已迁移笔记）。
+    if (state == MigrationState::BackingUp
+        || state == MigrationState::Scanning
+        || state == MigrationState::Migrating) {
+        restoreCursorFromState();
+    }
+
+    // 阶段 1：BackingUp
+    if (!doBackingUp()) {
+        return;
+    }
+
+    // 阶段 2：Scanning
+    if (m_state.currentState() == MigrationState::Scanning) {
+        if (!doScanning()) {
+            return;
+        }
+    }
+
+    // 阶段 3：Migrating
+    if (m_state.currentState() == MigrationState::Migrating) {
+        if (!doMigrating()) {
+            return;
+        }
+    }
+}
+
+// --- 阶段：BackingUp ---
+
+bool MigrationOrchestrator::doBackingUp()
+{
+    MigrationState state = m_state.currentState();
+
+    if (state == MigrationState::Pending) {
+        if (m_cancelRequested.load()) {
+            qCInfo(lcMigrationOrchestrator) << "doBackingUp: cancelled before start, leave Pending";
+            return false;
+        }
+        if (!m_state.requestTransition(MigrationState::BackingUp, MigrationSubstage::None,
+                                       QStringLiteral("backup start"))) {
+            finalize(MigrationState::Failed);
+            return false;
+        }
+        emitStage(MigrationState::BackingUp);
+    } else if (state == MigrationState::BackingUp) {
+        emitStage(MigrationState::BackingUp);
+    } else {
+        // 已过备份阶段（Scanning/Migrating）：backupPath 已从游标恢复。
+        return true;
+    }
+
+    if (m_cancelRequested.load()) {
+        qCInfo(lcMigrationOrchestrator) << "doBackingUp: cancelled at entry, leave mid-state for resume";
+        return false;
+    }
+
+    // 续传跳过备份（GAP-4）：BackupDone 已置 或 游标已含 backupPath。
+    const bool backupDone = (m_state.substage() == MigrationSubstage::BackupDone)
+                            || !m_backupPath.isEmpty();
+    if (backupDone) {
+        if (!m_state.requestTransition(MigrationState::Scanning, MigrationSubstage::BackupDone,
+                                       QStringLiteral("backup resume skip"))) {
+            finalize(MigrationState::Failed);
+            return false;
+        }
+        return true;
+    }
+
+    MigrationBackup backup(m_dbPath, m_backupDir);
+    const BackupResult result = backup.backup();
+    if (!result.success) {
+        qCWarning(lcMigrationOrchestrator) << "doBackingUp: backup failed:" << result.message;
+        finalize(MigrationState::Failed);
+        return false;
+    }
+
+    m_backupPath = result.backupPath;
+    persistCursor();
+    if (!m_state.requestTransition(MigrationState::Scanning, MigrationSubstage::BackupDone,
+                                   QStringLiteral("backup done"))) {
+        finalize(MigrationState::Failed);
+        return false;
+    }
+    return true;
+}
+
+// --- 阶段：Scanning ---
+
+bool MigrationOrchestrator::doScanning()
+{
+    emitStage(MigrationState::Scanning);
+
+    if (m_cancelRequested.load()) {
+        qCInfo(lcMigrationOrchestrator) << "doScanning: cancelled at entry, leave mid-state for resume";
+        return false;
+    }
+
+    // 续传跳过扫描（D2）：ScanDone 已置 或 游标已含清单。
+    const bool scanDone = (m_state.substage() == MigrationSubstage::ScanDone)
+                          || !m_noteIds.isEmpty();
+    if (scanDone) {
+        if (!m_state.requestTransition(MigrationState::Migrating, MigrationSubstage::MigratingCursor,
+                                       QStringLiteral("migrate start (scan resume)"))) {
+            finalize(MigrationState::Failed);
+            return false;
+        }
+        return true;
+    }
+
+    MigrationScanner scanner(m_dbPath);
+    const ScanResult result = scanner.scan();
+    if (!result.success) {
+        qCWarning(lcMigrationOrchestrator) << "doScanning: scan failed/aborted:" << result.message;
+        finalize(MigrationState::Failed);
+        return false;
+    }
+
+    m_scanTotalCount = result.totalCount;
+    m_scanNeedMigrateCount = result.needMigrateCount;
+    m_scanAlreadyTiptapCount = result.alreadyTiptapCount;
+    m_scanAbnormalCount = result.abnormalCount;
+    m_scanAbnormalNoteIds.clear();
+    for (const ScanAbnormal &ab : result.abnormals) {
+        m_scanAbnormalNoteIds.append(ab.noteId);
+    }
+    m_noteIds = result.needMigrateNoteIds;
+    m_total = m_noteIds.size();
+    m_nextIndex = 0;
+    m_processed = 0;
+    m_success = 0;
+    m_fail = 0;
+
+    if (result.needMigrateCount == 0) {
+        if (result.abnormalCount > 0) {
+            // D7：有异常但无需迁移 → Failed。
+            persistCursor();
+            finalize(MigrationState::Failed);
+            return false;
+        }
+        // 无需迁移 → NotNeeded（不出报告、不写回）。
+        m_state.requestTransition(MigrationState::NotNeeded, MigrationSubstage::None,
+                                  QStringLiteral("not needed"));
+        finalize(MigrationState::NotNeeded);
+        return false;
+    }
+
+    persistCursor();
+    if (!m_state.requestTransition(MigrationState::Migrating, MigrationSubstage::MigratingCursor,
+                                   QStringLiteral("migrate start"))) {
+        finalize(MigrationState::Failed);
+        return false;
+    }
+    return true;
+}
+
+// --- 阶段：Migrating ---
+
+bool MigrationOrchestrator::doMigrating()
+{
+    emitStage(MigrationState::Migrating);
+
+    m_snapshot.stage = MigrationState::Migrating;
+    m_snapshot.total = m_total;
+    m_snapshot.processed = m_processed;
+    m_snapshot.success = m_success;
+    m_snapshot.fail = m_fail;
+    emitProgress();
+
+    MigrationWriter writer(m_dbPath);
+    for (int i = m_nextIndex; i < m_noteIds.size(); ++i) {
+        // 条目边界检查取消（D3）：不中断进行中的 writeOne（同步无取消钩子）。
+        if (m_cancelRequested.load()) {
+            qCInfo(lcMigrationOrchestrator) << "doMigrating: cancelled at item boundary" << i;
+            m_state.markCancelled();  // Migrating → PartialCompleted，置 cancelled=true
+            finalize(MigrationState::PartialCompleted);
+            return false;
+        }
+
+        const qint32 noteId = m_noteIds[i];
+        const WriteResult wr = writer.writeOne(0, noteId);  // folderId=0（IF-1）
+        if (wr.success) {
+            ++m_success;
+        } else {
+            ++m_fail;
+            qCWarning(lcMigrationOrchestrator) << "doMigrating: writeOne failed for note" << noteId
+                                               << ":" << wr.message;
+        }
+        m_writeResults.append(wr);
+
+        m_nextIndex = i + 1;
+        m_processed = m_nextIndex;
+        persistCursor();  // 原子落盘，支撑进程异常退出后续传
+
+        m_snapshot.processed = m_processed;
+        m_snapshot.success = m_success;
+        m_snapshot.fail = m_fail;
+        emitProgress();  // D19 事件推送
+
+        // 测试钩子：模拟进程中断（停止且不终态处理，状态留 Migrating、游标保留 nextIndex）。
+        if (simulateInterrupt(m_processed)) {
+            qCInfo(lcMigrationOrchestrator) << "doMigrating: simulated interrupt at" << m_processed;
+            return false;
+        }
+    }
+
+    // 全部条目处理完：依据计数定终态。
+    MigrationState finalState;
+    if (m_fail == 0) {
+        finalState = MigrationState::Completed;
+    } else if (m_success > 0) {
+        finalState = MigrationState::PartialCompleted;
+    } else {
+        finalState = MigrationState::Failed;
+    }
+
+    if (!m_state.requestTransition(finalState, MigrationSubstage::MigratingCursor,
+                                   QStringLiteral("migrate done"))) {
+        finalize(finalState);
+        return false;
+    }
+    finalize(finalState);
+    return true;
+}
+
+// --- 终态 + 报告触发（D15）---
+
+void MigrationOrchestrator::finalize(MigrationState finalState)
+{
+    qCInfo(lcMigrationOrchestrator) << "finalize: finalState=" << migrationStateToString(finalState)
+                                    << "currentState=" << migrationStateToString(m_state.currentState())
+                                    << "cancelled=" << m_state.isCancelled()
+                                    << "success=" << m_success << "fail=" << m_fail;
+
+    // 确保状态机进入终态：失败/中间态路径可能尚未转换（取消/自然完成路径已转换）。
+    // 子阶段沿用当前态（按来源，如 BackupDone/ScanDone/MigratingCursor），比统一 MigratingCursor 更可读。
+    if (m_state.currentState() != finalState) {
+        if (!m_state.requestTransition(finalState, m_state.substage(),
+                                       QStringLiteral("finalize"))) {
+            // P3：受 TTP-015 合法转换边约束，某些 finalState 从当前态不可达
+            // （如 Pending→Failed：Pending 仅允许 →BackingUp）。此时状态机停留原态，
+            // 但 finished(finalState, reportPath) 与报告仍照常发出——持久状态与
+            // 报告/信号不一致，属磁盘异常边界（save 失败导致）。此处显式记录，不静默。
+            qCWarning(lcMigrationOrchestrator) << "finalize: cannot legally transition"
+                                               << migrationStateToString(m_state.currentState())
+                                               << "->" << migrationStateToString(finalState)
+                                               << "; state left as-is, report/signal still emitted";
+        }
+    }
+
+    // 仅 Failed 态回滚到备份基线（D1）；取消/中断绝不回滚。
+    if (finalState == MigrationState::Failed && !m_backupPath.isEmpty()) {
+        MigrationBackup backup(m_dbPath, m_backupDir);
+        const BackupResult rr = backup.restoreFromBackup(m_backupPath);
+        if (!rr.success) {
+            qCWarning(lcMigrationOrchestrator) << "finalize: restoreFromBackup failed:" << rr.message;
+        }
+    }
+
+    // 报告：仅终态（Completed/PartialCompleted/Failed）产出一次；NotNeeded 不出报告（D15）。
+    QString reportPath;
+    if (finalState != MigrationState::NotNeeded) {
+        MigrationReportInput input;
+        input.totalCount = m_scanTotalCount;
+        input.needMigrateCount = m_scanNeedMigrateCount;
+        input.alreadyTiptapCount = m_scanAlreadyTiptapCount;
+        input.abnormalCount = m_scanAbnormalCount;
+        input.abnormalNoteIds = m_scanAbnormalNoteIds;
+        input.writeResults = m_writeResults;
+        input.backupPath = m_backupPath;
+        input.elapsedMs = m_timer.elapsed();
+        input.finalState = finalState;
+        input.cancelled = m_state.isCancelled();
+
+        MigrationReport report(m_reportDir);
+        const ReportResult rr = report.generate(input);
+        reportPath = rr.reportPath;
+        if (!rr.success) {
+            qCWarning(lcMigrationOrchestrator) << "finalize: report generate failed:" << rr.message;
+        }
+    }
+
+    m_finishedEmitted.store(true);
+    emit finished(finalState, reportPath);
+}
+
+// --- 取消通道 ---
+
+void MigrationOrchestrator::requestCancel()
+{
+    m_cancelRequested.store(true);
+    qCInfo(lcMigrationOrchestrator) << "requestCancel: cancel requested";
+}
+
+// --- 进度查询 ---
+
+MigrationOrchestrator::ProgressSnapshot MigrationOrchestrator::progressSnapshot() const
+{
+    return m_snapshot;
+}
+
+// --- 测试钩子 ---
+
+bool MigrationOrchestrator::simulateInterrupt(int processedCount)
+{
+    Q_UNUSED(processedCount)
+    return false;
+}
+
+// --- 私有辅助 ---
+
+void MigrationOrchestrator::emitProgress()
+{
+    emit progressChanged(m_snapshot);
+}
+
+void MigrationOrchestrator::emitStage(MigrationState stage)
+{
+    m_snapshot.stage = stage;
+    emit stageChanged(stage);
+}
+
+void MigrationOrchestrator::persistCursor()
+{
+    QJsonObject scan;
+    scan[QStringLiteral("totalCount")] = m_scanTotalCount;
+    scan[QStringLiteral("needMigrateCount")] = m_scanNeedMigrateCount;
+    scan[QStringLiteral("alreadyTiptapCount")] = m_scanAlreadyTiptapCount;
+    scan[QStringLiteral("abnormalCount")] = m_scanAbnormalCount;
+    QJsonArray abnormalIds;
+    for (qint32 id : m_scanAbnormalNoteIds) {
+        abnormalIds.append(id);
+    }
+    scan[QStringLiteral("abnormalNoteIds")] = abnormalIds;
+
+    QJsonObject cursor;
+    cursor[QStringLiteral("backupPath")] = m_backupPath;
+    QJsonArray ids;
+    for (qint32 id : m_noteIds) {
+        ids.append(id);
+    }
+    cursor[QStringLiteral("noteIds")] = ids;
+    cursor[QStringLiteral("nextIndex")] = m_nextIndex;
+    cursor[QStringLiteral("processed")] = m_processed;
+    cursor[QStringLiteral("success")] = m_success;
+    cursor[QStringLiteral("fail")] = m_fail;
+    cursor[QStringLiteral("total")] = m_total;
+    cursor[QStringLiteral("scan")] = scan;
+
+    m_state.setCursor(cursor);
+}
+
+void MigrationOrchestrator::restoreCursorFromState()
+{
+    const QJsonObject c = m_state.cursor();
+    m_backupPath = c.value(QStringLiteral("backupPath")).toString();
+
+    m_noteIds.clear();
+    const QJsonArray ids = c.value(QStringLiteral("noteIds")).toArray();
+    for (const QJsonValue &v : ids) {
+        m_noteIds.append(static_cast<qint32>(v.toInt()));
+    }
+
+    m_nextIndex = c.value(QStringLiteral("nextIndex")).toInt();
+    m_processed = c.value(QStringLiteral("processed")).toInt();
+    m_success = c.value(QStringLiteral("success")).toInt();
+    m_fail = c.value(QStringLiteral("fail")).toInt();
+    m_total = c.value(QStringLiteral("total")).toInt();
+
+    const QJsonObject scan = c.value(QStringLiteral("scan")).toObject();
+    m_scanTotalCount = scan.value(QStringLiteral("totalCount")).toInt();
+    m_scanNeedMigrateCount = scan.value(QStringLiteral("needMigrateCount")).toInt();
+    m_scanAlreadyTiptapCount = scan.value(QStringLiteral("alreadyTiptapCount")).toInt();
+    m_scanAbnormalCount = scan.value(QStringLiteral("abnormalCount")).toInt();
+
+    m_scanAbnormalNoteIds.clear();
+    const QJsonArray abnormalIds = scan.value(QStringLiteral("abnormalNoteIds")).toArray();
+    for (const QJsonValue &v : abnormalIds) {
+        m_scanAbnormalNoteIds.append(static_cast<qint32>(v.toInt()));
+    }
+}

--- a/src/importolddata/dbmigration/migrationorchestrator.cpp
+++ b/src/importolddata/dbmigration/migrationorchestrator.cpp
@@ -289,6 +289,10 @@ bool MigrationOrchestrator::doMigrating()
 {
     emitStage(MigrationState::Migrating);
 
+    // 入口 nextIndex>0 表示部分条目已在先前运行写回（不在本次 m_writeResults 内），
+    // 终态报告的 failedNoteIds/warnings/downgraded 明细仅含本次续传段。
+    m_writeResultsPartial = (m_nextIndex > 0);
+
     m_snapshot.stage = MigrationState::Migrating;
     m_snapshot.total = m_total;
     m_snapshot.processed = m_processed;
@@ -396,6 +400,13 @@ void MigrationOrchestrator::finalize(MigrationState finalState)
         input.abnormalCount = m_scanAbnormalCount;
         input.abnormalNoteIds = m_scanAbnormalNoteIds;
         input.writeResults = m_writeResults;
+        // success/failed 使用从游标恢复 + 本次段累计的全量计数，与 total/needMigrate
+        // 同为全量口径（writeResults 在续传段仅含本次明细）。
+        input.cumulativeSuccess = m_success;
+        input.cumulativeFail = m_fail;
+        input.writeResultsScope = m_writeResultsPartial
+                                      ? QStringLiteral("resumed-segment")
+                                      : QStringLiteral("full");
         input.backupPath = m_backupPath;
         input.elapsedMs = m_timer.elapsed();
         input.finalState = finalState;

--- a/src/importolddata/dbmigration/migrationorchestrator.h
+++ b/src/importolddata/dbmigration/migrationorchestrator.h
@@ -49,7 +49,9 @@ public:
 
     // 静态启动入口（D20/T3）：若 currentState()==Pending 或 isResumable() 则在独立
     // QThread 启动 run()（不阻塞调用线程），否则不启动。应用启动 DB 就绪后单行调用。
-    static void startIfNeeded();
+    // signalConsumer 非空时，在后台线程启动前以 Qt::QueuedConnection 把进度/阶段/
+    // 终态/中断信号连接到 consumer（TTP-021 控制器），返回编排器指针；不启动时返回 nullptr。
+    static MigrationOrchestrator *startIfNeeded(QObject *signalConsumer = nullptr);
 
     // 后台主循环：串行推进各阶段。可在任意线程同步调用（测试直接调用以确定性验证）。
     // 由 startIfNeeded() 在独立 QThread 内触发。
@@ -72,6 +74,9 @@ signals:
     void stageChanged(MigrationState stage);
     // 终态信号：finalState 为终态，reportPath 为报告路径（NotNeeded 时为空）。
     void finished(MigrationState finalState, const QString &reportPath);
+    // 终态伴生信号（TTP-021）：紧邻 finished 发出，额外携带 backupPath，供进度界面展示
+    // 备份/报告位置。不改 finished 签名以保持现有监听者兼容。NotNeeded 终态路径均为空。
+    void terminalInfo(MigrationState finalState, const QString &backupPath, const QString &reportPath);
     // 非终态退出信号：run() 因取消留中间态待续传、启动决策无操作、状态转换失败或
     // 测试模拟中断而未进入终态时发出。startIfNeeded() 据此退出后台 QThread
     // （P2：保证线程与 orchestrator 总是回收，不留空转事件循环）。

--- a/src/importolddata/dbmigration/migrationorchestrator.h
+++ b/src/importolddata/dbmigration/migrationorchestrator.h
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONORCHESTRATOR_H
+#define MIGRATIONORCHESTRATOR_H
+
+#include "migrationstate.h"  // MigrationState / MigrationSubstage / MigrationStateMachine
+#include "migrationwriter.h"  // WriteResult（累计写回回报成员）
+
+#include <QElapsedTimer>
+#include <QObject>
+#include <QString>
+#include <QVector>
+
+#include <atomic>
+
+// TTP-020: 后台全量迁移任务编排层。
+//
+// 自身不实现备份/扫描/转换/校验/写回/报告/状态记录/进度 UI 中任何一项内部逻辑，
+// 只把同组 TTP-015 状态机、TTP-016 备份、TTP-017 扫描、TTP-018 写回、TTP-019 报告
+// 按固定顺序串成一条可运行的后台任务链：
+//   Pending → BackingUp → Scanning → Migrating → 终态(Completed/PartialCompleted/Failed/NotNeeded)+报告
+//
+// 驱动状态机流转、维护断点续传游标（与状态同载体原子持久化）、暴露只读进度查询与
+// 独立取消通道、决定终态与报告触发时机（D15：仅终态报告，无中间报告）。不接编辑器 UI
+// （进度展示归 TTP-021）。
+class MigrationOrchestrator : public QObject
+{
+    Q_OBJECT
+
+public:
+    // 对外只读进度快照（TTP-021 契约）。仅 Migrating 阶段计数有意义，
+    // 其余阶段计数为 0/占位。
+    struct ProgressSnapshot {
+        MigrationState stage = MigrationState::Pending;
+        int processed = 0;
+        int total = 0;
+        int success = 0;
+        int fail = 0;
+    };
+
+    // 默认构造：使用各模块默认路径定位（业务库 / 状态文件 / 备份目录 / 报告目录）。
+    explicit MigrationOrchestrator(QObject *parent = nullptr);
+    // 注入路径（测试用）：dbPath 指向业务库，stateFilePath 指向 migration-state.json，
+    // backupDir / reportDir 指向备份与报告目录。
+    MigrationOrchestrator(const QString &dbPath, const QString &stateFilePath,
+                          const QString &backupDir, const QString &reportDir,
+                          QObject *parent = nullptr);
+
+    // 静态启动入口（D20/T3）：若 currentState()==Pending 或 isResumable() 则在独立
+    // QThread 启动 run()（不阻塞调用线程），否则不启动。应用启动 DB 就绪后单行调用。
+    static void startIfNeeded();
+
+    // 后台主循环：串行推进各阶段。可在任意线程同步调用（测试直接调用以确定性验证）。
+    // 由 startIfNeeded() 在独立 QThread 内触发。
+    // 包装 runInternal()：若内部未发 finished（非终态退出），补发 aborted() 以保证
+    // 后台 QThread 总是退出回收（P2）。
+    void run();
+
+    // 只读进度查询（TTP-021 进度展示消费）。
+    ProgressSnapshot progressSnapshot() const;
+
+    // 取消通道（独立通道，不经过进度查询接口）：置原子标志，编排器在阶段入口/条目边界
+    // 检查。Migrating 命中→停后续条目→markCancelled() 转 PartialCompleted；
+    // BackingUp/Scanning 命中→等当前环节同步返回后转 PartialCompleted 或留中间态待续传。
+    void requestCancel();
+
+signals:
+    // 进度变更推送（D19 事件推送为主）。每条写回结束发一次。
+    void progressChanged(const MigrationOrchestrator::ProgressSnapshot &snapshot);
+    // 阶段变更推送。
+    void stageChanged(MigrationState stage);
+    // 终态信号：finalState 为终态，reportPath 为报告路径（NotNeeded 时为空）。
+    void finished(MigrationState finalState, const QString &reportPath);
+    // 非终态退出信号：run() 因取消留中间态待续传、启动决策无操作、状态转换失败或
+    // 测试模拟中断而未进入终态时发出。startIfNeeded() 据此退出后台 QThread
+    // （P2：保证线程与 orchestrator 总是回收，不留空转事件循环）。
+    void aborted();
+
+protected:
+    // 测试钩子：在 Migrating 阶段每处理完一条后调用，返回 true 时模拟进程中断——
+    // 立即停止循环且不做终态处理，状态留在 Migrating、游标保留 nextIndex，供续传测试。
+    // 默认实现始终返回 false（生产不中断）。
+    virtual bool simulateInterrupt(int processedCount);
+
+private:
+    // run() 的内部实现，含多个提前返回路径（终态路径经 finalize 发 finished，
+    // 非终态路径直接返回由 run() 补发 aborted()）。
+    void runInternal();
+
+    // 是否应当启动：Pending 或可续传（BackingUp/Scanning/Migrating/PartialCompleted）。
+    bool shouldRun() const;
+
+    // 阶段推进。返回 false 表示该阶段已处理终态或非终态退出（runInternal 据此提前返回）。
+    bool doBackingUp();
+    bool doScanning();
+    bool doMigrating();
+
+    // 终态处理：按需回滚（仅 Failed）+ 组装报告（NotNeeded 不出报告）+ 发 finished。
+    void finalize(MigrationState finalState);
+
+    // 游标读写（与状态同载体原子持久化，schema 见实现）。
+    void persistCursor();
+    void restoreCursorFromState();
+
+    // 进度快照内部更新 + 推送。
+    void emitProgress();
+    void emitStage(MigrationState stage);
+
+    MigrationStateMachine m_state;
+    QString m_dbPath;
+    QString m_backupDir;
+    QString m_reportDir;
+
+    std::atomic<bool> m_cancelRequested { false };
+    // finalize 发 finished 后置 true，run() 据此判断是否补发 aborted()（P2）。
+    std::atomic<bool> m_finishedEmitted { false };
+
+    // 运行期数据（部分从游标恢复，部分在阶段中累积）。
+    QString m_backupPath;                 // 当前备份路径（游标 backupPath）
+    QVector<qint32> m_noteIds;            // 待迁移 note_id 清单（游标 noteIds）
+    int m_nextIndex = 0;                  // 下一条待处理索引（游标 nextIndex）
+    int m_processed = 0;
+    int m_success = 0;
+    int m_fail = 0;
+    int m_total = 0;
+
+    // 扫描计数（报告用，从游标 scan 恢复或扫描阶段填充）。
+    int m_scanTotalCount = 0;
+    int m_scanNeedMigrateCount = 0;
+    int m_scanAlreadyTiptapCount = 0;
+    int m_scanAbnormalCount = 0;
+    QVector<qint32> m_scanAbnormalNoteIds;
+
+    // 累计写回回报（含 warnings，报告用）。
+    // 注意（Info）：游标 schema 不含 writeResults，故续传运行的终态报告仅含本次续传段
+    // 的 writeResults，首段已落盘写回不在内；counts.needMigrate/total 来自游标 scan 为全量，
+    // success/failed/failedNoteIds 仅反映续传段——两者口径不一致，属断点续传固有限制。
+    QVector<WriteResult> m_writeResults;
+
+    ProgressSnapshot m_snapshot;
+
+    QElapsedTimer m_timer;
+};
+
+Q_DECLARE_METATYPE(MigrationOrchestrator::ProgressSnapshot)
+
+#endif // MIGRATIONORCHESTRATOR_H

--- a/src/importolddata/dbmigration/migrationorchestrator.h
+++ b/src/importolddata/dbmigration/migrationorchestrator.h
@@ -139,9 +139,13 @@ private:
 
     // 累计写回回报（含 warnings，报告用）。
     // 注意（Info）：游标 schema 不含 writeResults，故续传运行的终态报告仅含本次续传段
-    // 的 writeResults，首段已落盘写回不在内；counts.needMigrate/total 来自游标 scan 为全量，
-    // success/failed/failedNoteIds 仅反映续传段——两者口径不一致，属断点续传固有限制。
+    // 的 writeResults，首段已落盘写回不在内。报告 success/failed 改用从游标恢复的
+    // m_success/m_fail 全量累计计数（见 finalize），failedNoteIds/warnings/downgraded
+    // 等明细仅反映续传段，由 m_writeResultsPartial 标注 writeResultsScope。
     QVector<WriteResult> m_writeResults;
+    // 本次运行是否为续传 Migrating 段（入口 nextIndex>0）：true 时 writeResults 仅含
+    // 续传段明细，报告 writeResultsScope 标注为 "resumed-segment"。
+    bool m_writeResultsPartial = false;
 
     ProgressSnapshot m_snapshot;
 

--- a/src/importolddata/dbmigration/migrationreport.cpp
+++ b/src/importolddata/dbmigration/migrationreport.cpp
@@ -157,6 +157,16 @@ QJsonObject MigrationReport::buildReportObject(const MigrationReportInput &input
         }
     }
 
+    // 续传累计计数优先：success/failed 使用从游标恢复的全量计数，保证与
+    // total/needMigrate 同为全量口径（writeResults 在续传段仅含本次明细）。
+    // cumulativeSuccess/cumulativeFail < 0 表示未提供，回退到上方重算值。
+    if (input.cumulativeSuccess >= 0) {
+        success = input.cumulativeSuccess;
+    }
+    if (input.cumulativeFail >= 0) {
+        failed = input.cumulativeFail;
+    }
+
     // --- counts ---
     QJsonObject counts;
     counts.insert(QStringLiteral("total"), input.totalCount);
@@ -184,6 +194,7 @@ QJsonObject MigrationReport::buildReportObject(const MigrationReportInput &input
     report.insert(QStringLiteral("backupPath"), input.backupPath);
     report.insert(QStringLiteral("finalState"), finalStateName(input.finalState));
     report.insert(QStringLiteral("cancelled"), input.cancelled);
+    report.insert(QStringLiteral("writeResultsScope"), input.writeResultsScope);
     return report;
 }
 

--- a/src/importolddata/dbmigration/migrationreport.cpp
+++ b/src/importolddata/dbmigration/migrationreport.cpp
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "migrationreport.h"
+
+#include "migrationhtmlcodes.h"  // warning 码词汇表（只读引用，不改义）
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QSet>
+#include <QStandardPaths>
+
+#include <cerrno>       // errno
+#include <cstdio>       // std::rename
+#include <cstring>      // strerror
+
+namespace {
+
+const char *kTmpSuffix = ".tmp";
+const int kSchemaVersion = 1;
+
+// D17=A 降级码显式集合（前缀 downgraded- 之外的额外码）。
+// 只读引用 migrationhtmlcodes.h 的常量，不改义；skipped-non-text-block 为
+// 词汇表未列但 D17 口径纳入的降级码，以本地字面量补充。
+const QSet<QString> &extraDowngradeCodes()
+{
+    static const QSet<QString> codes {
+        kCodeDangerousHtmlNode,
+        kCodeDangerousHtmlAttribute,
+        kCodeMissingHtmlImageSrc,
+        kCodeUnsafeHtmlImageSrc,
+        QStringLiteral("skipped-non-text-block")
+    };
+    return codes;
+}
+
+// 终态判定：Completed / PartialCompleted / Failed（D15 单次迁移终态）。
+bool isTerminalState(MigrationState state)
+{
+    return state == MigrationState::Completed
+        || state == MigrationState::PartialCompleted
+        || state == MigrationState::Failed;
+}
+
+// 终态名序列化（与 migrationStateToString 复用同一词汇）。
+QString finalStateName(MigrationState state)
+{
+    return migrationStateToString(state);
+}
+
+}  // namespace
+
+MigrationReport::MigrationReport()
+{
+}
+
+MigrationReport::MigrationReport(const QString &reportDir)
+    : m_reportDir(reportDir)
+{
+}
+
+QString MigrationReport::defaultReportDir()
+{
+    const QString appData = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    return appData + QDir::separator() + QStringLiteral("migration/report");
+}
+
+QString MigrationReport::reportDir() const
+{
+    return m_reportDir;
+}
+
+QString MigrationReport::effectiveReportDir() const
+{
+    return m_reportDir.isEmpty() ? defaultReportDir() : m_reportDir;
+}
+
+QString MigrationReport::generateReportName() const
+{
+    const QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd-HHmmss"));
+    return QStringLiteral("migration-report.%1.json").arg(timestamp);
+}
+
+QString MigrationReport::resolveUniquePath(const QString &dir, const QString &baseName) const
+{
+    // 落盘不覆盖：同名时追加序号，直到找到一个不存在的路径。
+    QString path = dir + QDir::separator() + baseName;
+    if (!QFileInfo::exists(path)) {
+        return path;
+    }
+
+    const QString prefix = QStringLiteral("migration-report.");
+    const QString suffix = QStringLiteral(".json");
+    // 从基础名中提取时间戳部分，构造 <name>.<seq>.json
+    const int prefixLen = prefix.size();
+    const int suffixLen = suffix.size();
+    QString stamp = baseName.mid(prefixLen, baseName.size() - prefixLen - suffixLen);
+
+    int seq = 2;
+    while (true) {
+        const QString name = QStringLiteral("migration-report.%1.%2.json").arg(stamp).arg(seq);
+        path = dir + QDir::separator() + name;
+        if (!QFileInfo::exists(path)) {
+            return path;
+        }
+        ++seq;
+    }
+}
+
+bool MigrationReport::isDowngradeWarningCode(const QString &code)
+{
+    // D17=A 口径：前缀 downgraded- 命中，或属于显式降级码集合。
+    return code.startsWith(QStringLiteral("downgraded-")) || extraDowngradeCodes().contains(code);
+}
+
+QJsonObject MigrationReport::buildReportObject(const MigrationReportInput &input)
+{
+    // --- 从 writeResults 计算 success / failed / failedNoteIds / downgraded ---
+    int success = 0;
+    int failed = 0;
+    QJsonArray failedNoteIds;
+    QJsonArray warnings;
+    int downgraded = 0;
+
+    for (const WriteResult &result : input.writeResults) {
+        if (result.success) {
+            ++success;
+        } else {
+            ++failed;
+            failedNoteIds.append(result.noteId);
+        }
+
+        // 逐条遍历 warnings 标注 noteId；同时判定该 note 是否含降级码。
+        bool noteDowngraded = false;
+        for (const MigrationWarning &warning : result.warnings) {
+            QJsonObject entry;
+            entry.insert(QStringLiteral("noteId"), result.noteId);
+            entry.insert(QStringLiteral("path"), warning.path);
+            entry.insert(QStringLiteral("code"), warning.code);
+            entry.insert(QStringLiteral("message"), warning.message);
+            warnings.append(entry);
+
+            if (isDowngradeWarningCode(warning.code)) {
+                noteDowngraded = true;
+            }
+        }
+        // D17=A：凡 note 存在任意降级码即计一次 downgraded
+        // （降级但成功者同时计入 success 与 downgraded）。
+        if (noteDowngraded) {
+            ++downgraded;
+        }
+    }
+
+    // --- counts ---
+    QJsonObject counts;
+    counts.insert(QStringLiteral("total"), input.totalCount);
+    counts.insert(QStringLiteral("needMigrate"), input.needMigrateCount);
+    counts.insert(QStringLiteral("success"), success);
+    counts.insert(QStringLiteral("failed"), failed);
+    counts.insert(QStringLiteral("downgraded"), downgraded);
+    counts.insert(QStringLiteral("skipped"), input.alreadyTiptapCount);
+    counts.insert(QStringLiteral("abnormal"), input.abnormalCount);
+
+    // --- abnormalNoteIds ---
+    QJsonArray abnormalNoteIds;
+    for (qint32 id : input.abnormalNoteIds) {
+        abnormalNoteIds.append(id);
+    }
+
+    // --- 顶层 schemaVersion:1 ---
+    QJsonObject report;
+    report.insert(QStringLiteral("schemaVersion"), kSchemaVersion);
+    report.insert(QStringLiteral("counts"), counts);
+    report.insert(QStringLiteral("failedNoteIds"), failedNoteIds);
+    report.insert(QStringLiteral("abnormalNoteIds"), abnormalNoteIds);
+    report.insert(QStringLiteral("warnings"), warnings);
+    report.insert(QStringLiteral("elapsedMs"), input.elapsedMs);
+    report.insert(QStringLiteral("backupPath"), input.backupPath);
+    report.insert(QStringLiteral("finalState"), finalStateName(input.finalState));
+    report.insert(QStringLiteral("cancelled"), input.cancelled);
+    return report;
+}
+
+bool MigrationReport::atomicWrite(const QString &path, const QByteArray &payload)
+{
+    // 原子写：写临时文件后 rename 覆盖目标（与 migrationstatepersistent.cpp 一致）。
+    // Qt 的 QFile::rename 在目标已存在时返回 false 不覆盖，故用 std::rename。
+    const QString tmpPath = path + QLatin1String(kTmpSuffix);
+    {
+        QFile tmp(tmpPath);
+        if (!tmp.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            qWarning("MigrationReport: open tmp failed: %s (%s)",
+                     qPrintable(tmpPath), qPrintable(tmp.errorString()));
+            return false;
+        }
+        if (tmp.write(payload) != payload.size()) {
+            qWarning("MigrationReport: write tmp failed: %s (%s)",
+                     qPrintable(tmpPath), qPrintable(tmp.errorString()));
+            tmp.close();
+            QFile::remove(tmpPath);
+            return false;
+        }
+        tmp.flush();
+        tmp.close();
+    }
+
+    if (std::rename(QFile::encodeName(tmpPath).constData(),
+                    QFile::encodeName(path).constData()) != 0) {
+        qWarning("MigrationReport: rename failed: %s -> %s (%s)",
+                 qPrintable(tmpPath), qPrintable(path),
+                 qPrintable(QString::fromLocal8Bit(strerror(errno))));
+        QFile::remove(tmpPath);
+        return false;
+    }
+    return true;
+}
+
+ReportResult MigrationReport::generate(const MigrationReportInput &input)
+{
+    ReportResult result;
+
+    // 1. 校验 finalState 为终态（D15：仅终态产出报告）。
+    if (!isTerminalState(input.finalState)) {
+        result.code = ReportErrorCode::InputInvalid;
+        result.message = QStringLiteral("finalState is not terminal: %1")
+                             .arg(finalStateName(input.finalState));
+        qWarning("MigrationReport: %s", qPrintable(result.message));
+        return result;
+    }
+
+    // 2. 聚合报告对象。
+    const QJsonObject reportObject = buildReportObject(input);
+
+    // 3. 序列化（QJsonDocument::Indented，便于人工排查）。
+    const QByteArray payload = QJsonDocument(reportObject).toJson(QJsonDocument::Indented);
+
+    // 4. 确保报告目录存在。
+    const QString dir = effectiveReportDir();
+    if (!QDir().exists(dir) && !QDir().mkpath(dir)) {
+        result.code = ReportErrorCode::DirCreateFailed;
+        result.message = QStringLiteral("Failed to create report directory: %1").arg(dir);
+        qWarning("MigrationReport: %s", qPrintable(result.message));
+        return result;
+    }
+
+    // 5. 时间戳命名 + 落盘不覆盖。
+    const QString baseName = generateReportName();
+    const QString path = resolveUniquePath(dir, baseName);
+
+    // 6. 原子写（临时文件 + rename）。
+    if (!atomicWrite(path, payload)) {
+        result.code = ReportErrorCode::WriteFailed;
+        result.message = QStringLiteral("Failed to write report: %1").arg(path);
+        qWarning("MigrationReport: %s", qPrintable(result.message));
+        return result;
+    }
+
+    result.success = true;
+    result.reportPath = path;
+    result.code = ReportErrorCode::None;
+    result.message = QStringLiteral("Report generated: %1").arg(path);
+    qInfo("MigrationReport: %s", qPrintable(result.message));
+    return result;
+}

--- a/src/importolddata/dbmigration/migrationreport.h
+++ b/src/importolddata/dbmigration/migrationreport.h
@@ -44,6 +44,18 @@ struct MigrationReportInput {
     // TTP-018 逐条写回回报（含 warnings）
     QVector<WriteResult> writeResults;
 
+    // 续传累计计数（从游标恢复 + 本次段累计）。
+    // 续传场景 writeResults 仅含本次续传段，从其重算 success/failed 会与全量
+    // total/needMigrate 口径不一致；故报告优先使用此处累计计数。
+    // 默认 -1 表示未提供，回退到从 writeResults 重算（兼容旧调用方/单测）。
+    int cumulativeSuccess = -1;
+    int cumulativeFail = -1;
+
+    // writeResults 范围标注："full"=含全部写回明细；
+    // "resumed-segment"=仅本次续传段明细（续传时 m_writeResults 不入游标，
+    // failedNoteIds/warnings/downgraded 仅反映续传段）。
+    QString writeResultsScope = QStringLiteral("full");
+
     // TTP-016 备份路径
     QString backupPath;
 

--- a/src/importolddata/dbmigration/migrationreport.h
+++ b/src/importolddata/dbmigration/migrationreport.h
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MIGRATIONREPORT_H
+#define MIGRATIONREPORT_H
+
+#include "migrationstate.h"   // MigrationState 终态枚举
+#include "migrationwriter.h"  // WriteResult / MigrationWarning（GAP-2 锁定结构）
+
+#include <QJsonObject>
+#include <QString>
+#include <QVector>
+
+// TTP-019: 迁移报告落盘错误码。
+// 对齐集成数据契约「报告结果」：失败时给出可区分原因码 + 描述，不抛异常。
+enum class ReportErrorCode {
+    None,             // 无错误（成功）
+    InputInvalid,     // finalState 非终态（Completed/PartialCompleted/Failed）
+    DirCreateFailed,  // 报告目录创建失败
+    WriteFailed       // 临时文件写 / rename 失败
+};
+
+// TTP-019: 报告落盘结果。
+// success=true 时 reportPath 为生成的报告文件路径；失败时 code/message 给出原因。
+struct ReportResult {
+    bool success = false;
+    QString reportPath;
+    ReportErrorCode code = ReportErrorCode::None;
+    QString message;
+};
+
+// TTP-019: 报告输入。
+// 聚合 TTP-017 扫描计数 + abnormalNoteIds、TTP-018 逐条写回回报（含 warnings）、
+// TTP-016 备份路径、TTP-020 耗时、TTP-015 终态 + 取消标记。
+// 不持 meta_data / envelope / htmlCode（隐私边界，D15 单次迁移）。
+struct MigrationReportInput {
+    // TTP-017 扫描计数
+    int totalCount = 0;
+    int needMigrateCount = 0;
+    int alreadyTiptapCount = 0;
+    int abnormalCount = 0;
+    QVector<qint32> abnormalNoteIds;  // 异常 note_id 清单（仅 id）
+
+    // TTP-018 逐条写回回报（含 warnings）
+    QVector<WriteResult> writeResults;
+
+    // TTP-016 备份路径
+    QString backupPath;
+
+    // TTP-020 迁移耗时（毫秒）
+    qint64 elapsedMs = 0;
+
+    // TTP-015 终态 + 取消标记（D3 取消映射 PartialCompleted）
+    MigrationState finalState = MigrationState::Pending;
+    bool cancelled = false;
+};
+
+// TTP-019: 迁移报告模块。
+// 在迁移链路进入终态（Completed / PartialCompleted / Failed）时，由 TTP-020 编排层
+// 调用 generate()，聚合终态及迁移过程数据，产出一份可落盘、不含隐私正文的 JSON
+// 迁移报告（含总数 / 需迁移数 / 成功 / 跳过 / 降级 / 失败计数 + 失败 note id 清单 +
+// warning 列表 + 耗时 + 备份路径 + cancelled 标记），落盘不覆盖，供用户反馈和问题排查。
+//
+// 边界：只提供「终态报告」生成能力；不扫描 / 写回 / 备份 / 改状态 / 调度 / 接 UI；
+// 不读笔记正文 / meta_data / envelope / htmlCode；不跨次累计、不产中间报告（D15）。
+// 落盘失败仅记日志返回 ReportErrorCode，不抛异常、不影响迁移结果。
+class MigrationReport
+{
+public:
+    // 默认构造：使用 defaultReportDir() 定位报告目录。
+    MigrationReport();
+    // 注入报告目录（测试用，便于指向 QTemporaryDir）。
+    explicit MigrationReport(const QString &reportDir);
+
+    // 生成并落盘报告：校验终态 → 聚合 → 序列化 → 确保目录 → 时间戳命名 →
+    // 临时文件 + rename 原子写。落盘失败仅记日志返回 ReportErrorCode，不抛异常。
+    ReportResult generate(const MigrationReportInput &input);
+
+    // 默认报告目录：<AppDataLocation>/migration/report（与 TTP-016 backup 同根）。
+    static QString defaultReportDir();
+
+    // 聚合报告 JSON 对象（schemaVersion:1）。纯函数，单测直接校验计数 / 降级口径。
+    static QJsonObject buildReportObject(const MigrationReportInput &input);
+    // 判定 warning 码是否为降级码（D17=A：前缀 downgraded- + 显式集合）。
+    // 只读引用 migrationhtmlcodes.h 词汇表，不自创 / 不改义。
+    static bool isDowngradeWarningCode(const QString &code);
+
+    QString reportDir() const;
+
+private:
+    // 解析当前生效的报告目录（注入优先，否则 defaultReportDir()）。
+    QString effectiveReportDir() const;
+    // 生成时间戳报告文件名：migration-report.<yyyyMMdd-HHmmss>.json
+    QString generateReportName() const;
+    // 在目录下解析一个不与已有文件冲突的最终路径（落盘不覆盖）。
+    QString resolveUniquePath(const QString &dir, const QString &baseName) const;
+    // 原子写：写临时文件后 rename 覆盖目标（与 migrationstatepersistent.cpp 一致）。
+    // 失败时清理临时文件并返回 false。
+    bool atomicWrite(const QString &path, const QByteArray &payload);
+
+    QString m_reportDir;
+};
+
+#endif  // MIGRATIONREPORT_H

--- a/src/importolddata/dbmigration/migrationstate.h
+++ b/src/importolddata/dbmigration/migrationstate.h
@@ -7,6 +7,7 @@
 #include <QJsonObject>
 #include <QVector>
 #include <QString>
+#include <QMetaType>
 
 // TTP-015: 迁移状态机状态集合（D1=A，不含独立 RollbackRequired）。
 // 回滚动作由 TTP-016 在 Failed 态执行，状态机本身不设回滚态。
@@ -29,6 +30,10 @@ enum class MigrationSubstage {
     ScanDone,        // 扫描已完成（续传不重扫）
     MigratingCursor  // 游标推进中
 };
+
+// 跨线程 QueuedConnection 投递 MigrationState（TTP-021 控制器在主线程消费
+// stageChanged/terminalInfo）需注册为 metatype。
+Q_DECLARE_METATYPE(MigrationState)
 
 // 变更日志条目，随状态同载体持久化（D4 单一载体）。
 struct HistoryEntry {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,8 @@
 #include "common/imageprovider.h"
 #include "common/vtextspeechandtrmanager.h"
 
-#include "importolddata/dbmigration/migrationorchestrator.h"  // TTP-020 后台全量迁移任务启动入口
+#include "importolddata/dbmigration/migrationorchestrator.h"  // TTP-020 后台全量迁移任务编排层
+#include "common/migrationviewcontroller.h"  // TTP-021 升级进度界面控制器
 #include "config.h"
 
 #include <QQmlApplicationEngine>
@@ -139,7 +140,8 @@ int main(int argc, char *argv[])
     qInfo() << "Note manager initialized";
 
     // TTP-020: DB 就绪后单行启动后台 Tiptap 全量迁移任务（两套状态独立，不干扰旧库升级）。
-    MigrationOrchestrator::startIfNeeded();
+    // TTP-021: 通过升级进度界面控制器启动迁移（内部拉起 TTP-020 编排器并消费进度/终态信号）。
+    MigrationViewController::instance()->start();
 
     DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "common/imageprovider.h"
 #include "common/vtextspeechandtrmanager.h"
 
+#include "importolddata/dbmigration/migrationorchestrator.h"  // TTP-020 后台全量迁移任务启动入口
 #include "config.h"
 
 #include <QQmlApplicationEngine>
@@ -136,6 +137,9 @@ int main(int argc, char *argv[])
 
     VNoteMainManager::instance()->initNote();
     qInfo() << "Note manager initialized";
+
+    // TTP-020: DB 就绪后单行启动后台 Tiptap 全量迁移任务（两套状态独立，不干扰旧库升级）。
+    MigrationOrchestrator::startIfNeeded();
 
     DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();

--- a/tests/src/importolddata/dbmigration/ut_migrationorchestrator.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationorchestrator.cpp
@@ -512,6 +512,18 @@ TEST(UT_MigrationOrchestrator, ResumeAfterInterrupt)
     EXPECT_TRUE(isTiptap(dbPath, 3));
     EXPECT_TRUE(isTiptap(dbPath, 4));
 
+    // 续传报告口径：success/failed 应为全量累计计数（4），而非仅本次续传段（2）。
+    const QJsonObject report = loadReport(reportDir);
+    const QJsonObject counts = report.value(QStringLiteral("counts")).toObject();
+    EXPECT_EQ(counts.value(QStringLiteral("success")).toInt(), 4);
+    EXPECT_EQ(counts.value(QStringLiteral("failed")).toInt(), 0);
+    EXPECT_EQ(counts.value(QStringLiteral("needMigrate")).toInt(),
+              counts.value(QStringLiteral("success")).toInt()
+                  + counts.value(QStringLiteral("failed")).toInt());
+    // 续传段明细范围标注。
+    EXPECT_EQ(report.value(QStringLiteral("writeResultsScope")).toString(),
+              QStringLiteral("resumed-segment"));
+
     MigrationStateMachine sm(statePath);
     ASSERT_TRUE(sm.load());
     EXPECT_EQ(sm.currentState(), MigrationState::Completed);

--- a/tests/src/importolddata/dbmigration/ut_migrationorchestrator.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationorchestrator.cpp
@@ -677,3 +677,73 @@ TEST(UT_MigrationOrchestrator, ShouldRunDecision)
         EXPECT_FALSE(emitted);
     }
 }
+
+// --- terminalInfo 伴生信号（TTP-021 前置改动）：紧邻 finished 发出，携带 backupPath ---
+
+TEST(UT_MigrationOrchestrator, TerminalInfoCarriedWithFinished)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    MigrationState terminalState = MigrationState::Pending;
+    QString terminalBackup;
+    QString terminalReport;
+    MigrationState finishedState = MigrationState::Pending;
+    QString finishedReport;
+    QObject::connect(&o, &MigrationOrchestrator::terminalInfo,
+                     [&](MigrationState s, const QString &backup, const QString &report) {
+                         terminalState = s;
+                         terminalBackup = backup;
+                         terminalReport = report;
+                     });
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &p) { finishedState = s; finishedReport = p; });
+    o.run();
+
+    // terminalInfo 与 finished 携带一致的终态与报告路径。
+    EXPECT_EQ(terminalState, MigrationState::Completed);
+    EXPECT_EQ(finishedState, MigrationState::Completed);
+    EXPECT_EQ(terminalReport, finishedReport);
+    EXPECT_FALSE(terminalReport.isEmpty());
+    // Completed 终态 backupPath 非空（备份阶段已产出）。
+    EXPECT_FALSE(terminalBackup.isEmpty());
+    EXPECT_TRUE(QFile::exists(terminalBackup));
+}
+
+// --- terminalInfo：NotNeeded 终态 backupPath/reportPath 均为空 ---
+
+TEST(UT_MigrationOrchestrator, TerminalInfoNotNeededIsEmpty)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    // 全部已是 Tiptap 信封（已迁移）→ 扫描无需迁移 → NotNeeded。
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"format\":\"tiptap\",\"content\":{}}")));
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    MigrationState terminalState = MigrationState::Pending;
+    QString terminalBackup = QStringLiteral("sentinel");
+    QString terminalReport = QStringLiteral("sentinel");
+    QObject::connect(&o, &MigrationOrchestrator::terminalInfo,
+                     [&](MigrationState s, const QString &backup, const QString &report) {
+                         terminalState = s;
+                         terminalBackup = backup;
+                         terminalReport = report;
+                     });
+    o.run();
+
+    EXPECT_EQ(terminalState, MigrationState::NotNeeded);
+    EXPECT_TRUE(terminalBackup.isEmpty());
+    EXPECT_TRUE(terminalReport.isEmpty());
+}

--- a/tests/src/importolddata/dbmigration/ut_migrationorchestrator.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationorchestrator.cpp
@@ -1,0 +1,679 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "importolddata/dbmigration/migrationorchestrator.h"
+#include "importolddata/dbmigration/migrationbackup.h"
+#include "importolddata/dbmigration/migrationstate.h"
+#include "importolddata/dbmigration/migrationwriter.h"
+#include "importolddata/tiptapmigration/legacyformatdetector.h"
+
+#include "gtest/gtest.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QTemporaryDir>
+#include <QVector>
+
+namespace {
+
+QString uniqueConn(const char *prefix)
+{
+    return QStringLiteral("%1_%2").arg(QLatin1String(prefix),
+                                       QDateTime::currentDateTime().toMSecsSinceEpoch());
+}
+
+bool createTable(QSqlQuery &q)
+{
+    return q.exec(QStringLiteral(
+        "CREATE TABLE vnote_items_tbl ("
+        "note_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "folder_id INTEGER, "
+        "note_type INTEGER, "
+        "note_title TEXT, "
+        "meta_data TEXT, "
+        "note_state INTEGER, "
+        "create_time TEXT, "
+        "modify_time TEXT, "
+        "delete_time TEXT, "
+        "expand_filed1 INTEGER, "
+        "expand_filed2 INTEGER)"));
+}
+
+bool createDb(const QString &path)
+{
+    const QString conn = uniqueConn("ut_orch_mk");
+    bool ok = false;
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return false;
+        }
+        QSqlQuery q(db);
+        ok = createTable(q);
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return ok;
+}
+
+bool insertNoteInto(const QString &path, qint32 noteId, const QString &metaData, int encrypt = 0)
+{
+    const QString conn = uniqueConn("ut_orch_ins");
+    bool ok = false;
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return false;
+        }
+        QSqlQuery q(db);
+        q.prepare(QStringLiteral("INSERT INTO vnote_items_tbl "
+                                  "(note_id, folder_id, note_type, note_title, meta_data, "
+                                  "note_state, create_time, modify_time, delete_time, "
+                                  "expand_filed1, expand_filed2) "
+                                  "VALUES (?, 0, 0, 't', ?, 0, '', '2026-01-01 00:00:00', '', 0, ?)"));
+        q.addBindValue(noteId);
+        q.addBindValue(metaData);
+        q.addBindValue(encrypt);
+        ok = q.exec();
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return ok;
+}
+
+struct NoteRow {
+    bool found = false;
+    QString metaData;
+};
+
+NoteRow readNote(const QString &path, qint32 noteId)
+{
+    NoteRow row;
+    const QString conn = uniqueConn("ut_orch_rd");
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return row;
+        }
+        QSqlQuery q(db);
+        q.prepare(QStringLiteral("SELECT meta_data FROM vnote_items_tbl WHERE note_id=?"));
+        q.addBindValue(noteId);
+        if (q.exec() && q.next()) {
+            row.found = true;
+            row.metaData = q.value(0).toString();
+        }
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return row;
+}
+
+bool isTiptap(const QString &path, qint32 noteId)
+{
+    const NoteRow row = readNote(path, noteId);
+    return row.found
+           && LegacyFormatDetector::detect(row.metaData) == LegacyFormat::TiptapEnvelope;
+}
+
+// 备份目录下 .db 文件计数（验证是否新增备份）。
+int backupFileCount(const QString &backupDir)
+{
+    QDir dir(backupDir);
+    if (!dir.exists()) {
+        return 0;
+    }
+    const QStringList files = dir.entryList(QStringList() << QStringLiteral("*.db"),
+                                            QDir::Files);
+    return files.size();
+}
+
+// 报告目录下首份报告 JSON 路径（验证报告是否生成）。
+QString firstReportPath(const QString &reportDir)
+{
+    QDir dir(reportDir);
+    if (!dir.exists()) {
+        return QString();
+    }
+    const QStringList files = dir.entryList(QStringList() << QStringLiteral("migration-report.*.json"),
+                                            QDir::Files);
+    if (files.isEmpty()) {
+        return QString();
+    }
+    return dir.absoluteFilePath(files.first());
+}
+
+QJsonObject loadReport(const QString &reportDir)
+{
+    const QString path = firstReportPath(reportDir);
+    if (path.isEmpty()) {
+        return QJsonObject();
+    }
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly)) {
+        return QJsonObject();
+    }
+    const QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+    return doc.object();
+}
+
+// 直接写一份 migration-state.json（续传测试用）。
+bool writeStateFile(const QString &path, const QString &stateName, const QString &substageName,
+                    const QJsonObject &cursor, bool cancelled = false)
+{
+    QJsonObject root;
+    root[QStringLiteral("state")] = stateName;
+    root[QStringLiteral("substage")] = substageName;
+    root[QStringLiteral("cursor")] = cursor;
+    root[QStringLiteral("cancelled")] = cancelled;
+    root[QStringLiteral("updatedAt")] = QStringLiteral("2026-07-25T00:00:00");
+    root[QStringLiteral("history")] = QJsonArray();
+
+    const QFileInfo info(path);
+    QDir().mkpath(info.absolutePath());
+
+    const QByteArray payload = QJsonDocument(root).toJson(QJsonDocument::Compact);
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        return false;
+    }
+    f.write(payload);
+    f.close();
+    return true;
+}
+
+QJsonObject makeScanObject(int total, int need, int already, int abnormal,
+                           const QVector<qint32> &abnormalIds)
+{
+    QJsonObject scan;
+    scan[QStringLiteral("totalCount")] = total;
+    scan[QStringLiteral("needMigrateCount")] = need;
+    scan[QStringLiteral("alreadyTiptapCount")] = already;
+    scan[QStringLiteral("abnormalCount")] = abnormal;
+    QJsonArray ids;
+    for (qint32 id : abnormalIds) {
+        ids.append(id);
+    }
+    scan[QStringLiteral("abnormalNoteIds")] = ids;
+    return scan;
+}
+
+QJsonObject makeCursor(const QString &backupPath, const QVector<qint32> &noteIds,
+                       int nextIndex, int processed, int success, int fail, int total,
+                       const QJsonObject &scan)
+{
+    QJsonObject cursor;
+    cursor[QStringLiteral("backupPath")] = backupPath;
+    QJsonArray ids;
+    for (qint32 id : noteIds) {
+        ids.append(id);
+    }
+    cursor[QStringLiteral("noteIds")] = ids;
+    cursor[QStringLiteral("nextIndex")] = nextIndex;
+    cursor[QStringLiteral("processed")] = processed;
+    cursor[QStringLiteral("success")] = success;
+    cursor[QStringLiteral("fail")] = fail;
+    cursor[QStringLiteral("total")] = total;
+    cursor[QStringLiteral("scan")] = scan;
+    return cursor;
+}
+
+// 可中断编排器：处理到第 stopAfter 条后模拟进程中断（用于续传测试）。
+class InterruptableOrchestrator : public MigrationOrchestrator
+{
+public:
+    int stopAfter = -1;
+    explicit InterruptableOrchestrator(const QString &dbPath, const QString &stateFilePath,
+                                       const QString &backupDir, const QString &reportDir)
+        : MigrationOrchestrator(dbPath, stateFilePath, backupDir, reportDir)
+    {
+    }
+
+protected:
+    bool simulateInterrupt(int processedCount) override
+    {
+        return stopAfter > 0 && processedCount >= stopAfter;
+    }
+};
+
+}  // namespace
+
+// --- 场景 1：全量成功迁移 ---
+
+TEST(UT_MigrationOrchestrator, FullMigrationCompleted)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 2, QStringLiteral("{\"htmlCode\":\"<p>b</p>\"}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 3, QStringLiteral("plain text")));
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    MigrationState finalState = MigrationState::Pending;
+    QString reportPath;
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &p) { finalState = s; reportPath = p; });
+    o.run();
+
+    EXPECT_EQ(finalState, MigrationState::Completed);
+    EXPECT_FALSE(reportPath.isEmpty());
+    EXPECT_TRUE(QFile::exists(reportPath));
+    EXPECT_EQ(o.progressSnapshot().success, 3);
+
+    EXPECT_TRUE(isTiptap(dbPath, 1));
+    EXPECT_TRUE(isTiptap(dbPath, 2));
+    EXPECT_TRUE(isTiptap(dbPath, 3));
+
+    const QJsonObject report = loadReport(reportDir);
+    EXPECT_EQ(report.value(QStringLiteral("finalState")).toString(), QStringLiteral("Completed"));
+    EXPECT_EQ(report.value(QStringLiteral("counts")).toObject().value(QStringLiteral("success")).toInt(), 3);
+}
+
+// --- 场景 2：部分完成（单条失败隔离）---
+
+TEST(UT_MigrationOrchestrator, PartialCompletedWithSingleFailureIsolation)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 2, QStringLiteral("{\"htmlCode\":\"<p>b</p>\"}")));
+    // ProseMirror 含不支持节点：扫描归为需迁移，写回校验失败（ValidationFailed）。
+    ASSERT_TRUE(insertNoteInto(dbPath, 3, QStringLiteral("{\"type\":\"doc\",\"content\":[{\"type\":\"unknownNode\"}]}")));
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    MigrationState finalState = MigrationState::Pending;
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &) { finalState = s; });
+    o.run();
+
+    EXPECT_EQ(finalState, MigrationState::PartialCompleted);
+    EXPECT_EQ(o.progressSnapshot().success, 2);
+    EXPECT_EQ(o.progressSnapshot().fail, 1);
+
+    // 失败条目隔离：其他条目仍成功写回。
+    EXPECT_TRUE(isTiptap(dbPath, 1));
+    EXPECT_TRUE(isTiptap(dbPath, 2));
+    // 失败条目原数据保留。
+    const NoteRow row = readNote(dbPath, 3);
+    ASSERT_TRUE(row.found);
+    EXPECT_EQ(row.metaData, QStringLiteral("{\"type\":\"doc\",\"content\":[{\"type\":\"unknownNode\"}]}"));
+
+    // 报告含失败 note_id。
+    const QJsonObject report = loadReport(reportDir);
+    const QJsonArray failedIds = report.value(QStringLiteral("failedNoteIds")).toArray();
+    ASSERT_EQ(failedIds.size(), 1);
+    EXPECT_EQ(failedIds.at(0).toInt(), 3);
+}
+
+// --- 场景 3：备份失败直接 Failed（不进 Scanning/Migrating + 报告 + 不写回）---
+
+TEST(UT_MigrationOrchestrator, BackupFailureGoesFailed)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+
+    // 备份目录父级为普通文件，mkpath 失败 → DestDirCreateFailed。
+    const QString blocker = dir.path() + QStringLiteral("/blocker");
+    {
+        QFile f(blocker);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write("x");
+        f.close();
+    }
+    const QString badBackupDir = blocker + QStringLiteral("/backup");
+
+    MigrationOrchestrator o(dbPath, statePath, badBackupDir, reportDir);
+    MigrationState finalState = MigrationState::Pending;
+    QString reportPath;
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &p) { finalState = s; reportPath = p; });
+    o.run();
+
+    EXPECT_EQ(finalState, MigrationState::Failed);
+    EXPECT_FALSE(reportPath.isEmpty());
+
+    // 不写回任何笔记。
+    EXPECT_FALSE(isTiptap(dbPath, 1));
+    EXPECT_EQ(o.progressSnapshot().success, 0);
+
+    const QJsonObject report = loadReport(reportDir);
+    EXPECT_EQ(report.value(QStringLiteral("finalState")).toString(), QStringLiteral("Failed"));
+}
+
+// --- 场景 4：扫描判定无需迁移（NotNeeded + 不出报告 + 不写回）---
+
+TEST(UT_MigrationOrchestrator, NotNeededWhenAllTiptap)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"format\":\"tiptap\",\"content\":{}}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 2, QStringLiteral("{\"format\":\"tiptap\",\"content\":{}}")));
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    MigrationState finalState = MigrationState::Pending;
+    QString reportPath;
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &p) { finalState = s; reportPath = p; });
+    o.run();
+
+    EXPECT_EQ(finalState, MigrationState::NotNeeded);
+    // 不出报告。
+    EXPECT_TRUE(reportPath.isEmpty());
+    EXPECT_TRUE(firstReportPath(reportDir).isEmpty());
+    // 不写回：笔记仍为 Tiptap（未被改写）。
+    EXPECT_TRUE(isTiptap(dbPath, 1));
+    EXPECT_TRUE(isTiptap(dbPath, 2));
+    EXPECT_EQ(o.progressSnapshot().success, 0);
+
+    MigrationStateMachine sm(statePath);
+    ASSERT_TRUE(sm.load());
+    EXPECT_EQ(sm.currentState(), MigrationState::NotNeeded);
+}
+
+// --- 场景 5：用户取消（Migrating 第 2 条后 requestCancel → PartialCompleted）---
+
+TEST(UT_MigrationOrchestrator, UserCancelInMigrating)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 2, QStringLiteral("{\"htmlCode\":\"<p>b</p>\"}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 3, QStringLiteral("plain three")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 4, QStringLiteral("plain four")));
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    // 第 2 条处理完后请求取消。
+    QObject::connect(&o, &MigrationOrchestrator::progressChanged,
+                     [&](const MigrationOrchestrator::ProgressSnapshot &snap) {
+                         if (snap.processed == 2) {
+                             o.requestCancel();
+                         }
+                     });
+    MigrationState finalState = MigrationState::Pending;
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &) { finalState = s; });
+    o.run();
+
+    EXPECT_EQ(finalState, MigrationState::PartialCompleted);
+
+    // isCancelled == true（从状态文件）。
+    MigrationStateMachine sm(statePath);
+    ASSERT_TRUE(sm.load());
+    EXPECT_TRUE(sm.isCancelled());
+    EXPECT_EQ(sm.currentState(), MigrationState::PartialCompleted);
+
+    // 已处理条目写回，未处理条目保留原数据。
+    EXPECT_TRUE(isTiptap(dbPath, 1));
+    EXPECT_TRUE(isTiptap(dbPath, 2));
+    EXPECT_FALSE(isTiptap(dbPath, 3));
+    EXPECT_FALSE(isTiptap(dbPath, 4));
+
+    // 报告 cancelled==true。
+    const QJsonObject report = loadReport(reportDir);
+    EXPECT_EQ(report.value(QStringLiteral("cancelled")).toBool(), true);
+    EXPECT_EQ(report.value(QStringLiteral("finalState")).toString(), QStringLiteral("PartialCompleted"));
+}
+
+// --- 场景 6：中断后续传（跑到第 2 条后销毁编排器 → 新编排器从 nextIndex=2 续传）---
+
+TEST(UT_MigrationOrchestrator, ResumeAfterInterrupt)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 2, QStringLiteral("{\"htmlCode\":\"<p>b</p>\"}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 3, QStringLiteral("plain three")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 4, QStringLiteral("plain four")));
+
+    // 第一阶段：跑到第 2 条后模拟中断，状态留 Migrating、游标 nextIndex=2。
+    {
+        InterruptableOrchestrator first(dbPath, statePath, backupDir, reportDir);
+        first.stopAfter = 2;
+        first.run();
+        // 销毁 first（保留状态文件）。
+    }
+
+    // 中断后状态为 Migrating、可续传。
+    {
+        MigrationStateMachine sm(statePath);
+        ASSERT_TRUE(sm.load());
+        EXPECT_EQ(sm.currentState(), MigrationState::Migrating);
+        EXPECT_TRUE(sm.isResumable());
+        EXPECT_EQ(sm.cursor().value(QStringLiteral("nextIndex")).toInt(), 2);
+    }
+
+    // 第二阶段：新编排器从 nextIndex=2 续传。
+    QVector<MigrationOrchestrator::ProgressSnapshot> snaps;
+    MigrationOrchestrator second(dbPath, statePath, backupDir, reportDir);
+    QObject::connect(&second, &MigrationOrchestrator::progressChanged,
+                     [&](const MigrationOrchestrator::ProgressSnapshot &s) { snaps.append(s); });
+    MigrationState finalState = MigrationState::Pending;
+    QObject::connect(&second, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &) { finalState = s; });
+    second.run();
+
+    EXPECT_EQ(finalState, MigrationState::Completed);
+
+    // 续传从 nextIndex=2 起，不重复已成功条目：第二条 run 不会出现 processed==1。
+    bool restartedFromZero = false;
+    for (const auto &s : snaps) {
+        if (s.processed == 1) {
+            restartedFromZero = true;
+        }
+    }
+    EXPECT_FALSE(restartedFromZero);
+
+    // 全部 4 条最终都已被迁移（1,2 来自首段，3,4 来自续传）。
+    EXPECT_TRUE(isTiptap(dbPath, 1));
+    EXPECT_TRUE(isTiptap(dbPath, 2));
+    EXPECT_TRUE(isTiptap(dbPath, 3));
+    EXPECT_TRUE(isTiptap(dbPath, 4));
+
+    MigrationStateMachine sm(statePath);
+    ASSERT_TRUE(sm.load());
+    EXPECT_EQ(sm.currentState(), MigrationState::Completed);
+}
+
+// --- 场景 7a：续传跳过备份（BackupDone 不调 backup）---
+
+TEST(UT_MigrationOrchestrator, ResumeSkipsBackup)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+
+    // 预置备份目录 + 一个已有备份文件，状态为 BackingUp/BackupDone。
+    QDir().mkpath(backupDir);
+    const QString preBackup = backupDir + QStringLiteral("/pre.db");
+    {
+        QFile f(preBackup);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write("backup");
+        f.close();
+    }
+    const QJsonObject cursor = makeCursor(preBackup, {}, 0, 0, 0, 0, 0,
+                                          makeScanObject(0, 0, 0, 0, {}));
+    ASSERT_TRUE(writeStateFile(statePath, QStringLiteral("BackingUp"),
+                               QStringLiteral("BackupDone"), cursor));
+    const int before = backupFileCount(backupDir);
+    ASSERT_EQ(before, 1);
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    MigrationState finalState = MigrationState::Pending;
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &) { finalState = s; });
+    o.run();
+
+    EXPECT_EQ(finalState, MigrationState::Completed);
+    // 未新增备份文件（backup 被跳过，沿用游标 backupPath）。
+    EXPECT_EQ(backupFileCount(backupDir), 1);
+    EXPECT_TRUE(isTiptap(dbPath, 1));
+}
+
+// --- 场景 7b：续传跳过扫描（ScanDone 不调 scan）---
+
+TEST(UT_MigrationOrchestrator, ResumeSkipsScan)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    // 库中实际有 4 条需迁移笔记。
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 2, QStringLiteral("{\"htmlCode\":\"<p>b</p>\"}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 3, QStringLiteral("plain three")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 4, QStringLiteral("plain four")));
+
+    QDir().mkpath(backupDir);
+    const QString preBackup = backupDir + QStringLiteral("/pre.db");
+    {
+        QFile f(preBackup);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write("backup");
+        f.close();
+    }
+    // 游标清单只含 [1,2]：若扫描被跳过，仅迁移 1,2；若扫描重跑，会迁移 1,2,3,4。
+    const QJsonObject cursor = makeCursor(preBackup, {1, 2}, 0, 0, 0, 0, 2,
+                                          makeScanObject(4, 2, 0, 0, {}));
+    ASSERT_TRUE(writeStateFile(statePath, QStringLiteral("Scanning"),
+                               QStringLiteral("ScanDone"), cursor));
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    MigrationState finalState = MigrationState::Pending;
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &) { finalState = s; });
+    o.run();
+
+    EXPECT_EQ(finalState, MigrationState::Completed);
+    // 扫描被跳过：仅处理游标清单 [1,2]，3,4 未被迁移（仍是旧格式）。
+    EXPECT_EQ(o.progressSnapshot().success, 2);
+    EXPECT_TRUE(isTiptap(dbPath, 1));
+    EXPECT_TRUE(isTiptap(dbPath, 2));
+    EXPECT_FALSE(isTiptap(dbPath, 3));
+    EXPECT_FALSE(isTiptap(dbPath, 4));
+}
+
+// --- 场景 8：异常项不写回（Invalid 进报告 abnormalNoteIds，不参与 Migrating）---
+
+TEST(UT_MigrationOrchestrator, AbnormalNotWrittenBack)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+    ASSERT_TRUE(insertNoteInto(dbPath, 2, QStringLiteral("{\"htmlCode\":\"<p>b</p>\"}")));
+    // Invalid 格式：扫描归为异常（不进需迁移清单）。
+    ASSERT_TRUE(insertNoteInto(dbPath, 3, QStringLiteral("{\"unknown\":\"obj\"}")));
+
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    MigrationState finalState = MigrationState::Pending;
+    QObject::connect(&o, &MigrationOrchestrator::finished,
+                     [&](MigrationState s, const QString &) { finalState = s; });
+    o.run();
+
+    EXPECT_EQ(finalState, MigrationState::Completed);
+    // 异常项不参与 Migrating：仅 2 条成功。
+    EXPECT_EQ(o.progressSnapshot().success, 2);
+    EXPECT_EQ(o.progressSnapshot().fail, 0);
+
+    // 异常项原数据保留（未写回）。
+    const NoteRow row = readNote(dbPath, 3);
+    ASSERT_TRUE(row.found);
+    EXPECT_EQ(row.metaData, QStringLiteral("{\"unknown\":\"obj\"}"));
+
+    // 报告 abnormalNoteIds 含异常 note_id。
+    const QJsonObject report = loadReport(reportDir);
+    const QJsonArray abnormalIds = report.value(QStringLiteral("abnormalNoteIds")).toArray();
+    ASSERT_EQ(abnormalIds.size(), 1);
+    EXPECT_EQ(abnormalIds.at(0).toInt(), 3);
+    EXPECT_EQ(report.value(QStringLiteral("counts")).toObject().value(QStringLiteral("abnormal")).toInt(), 1);
+}
+
+// --- 启动决策：Completed 不启动 / Pending 启动 ---
+
+TEST(UT_MigrationOrchestrator, ShouldRunDecision)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+
+    // 初始 Pending → shouldRun true。
+    {
+        MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+        // shouldRun 为私有，通过公开行为间接验证：Pending 运行后进入终态。
+        MigrationState fs = MigrationState::Pending;
+        QObject::connect(&o, &MigrationOrchestrator::finished,
+                         [&](MigrationState s, const QString &) { fs = s; });
+        o.run();
+        EXPECT_NE(fs, MigrationState::Pending);
+    }
+
+    // 终态 Completed 后，新编排器不再推进（finished 不发）。
+    {
+        MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+        bool emitted = false;
+        QObject::connect(&o, &MigrationOrchestrator::finished,
+                         [&]() { emitted = true; });
+        o.run();
+        EXPECT_FALSE(emitted);
+    }
+}

--- a/tests/src/importolddata/dbmigration/ut_migrationreport.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationreport.cpp
@@ -1,0 +1,355 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "importolddata/dbmigration/migrationreport.h"
+#include "importolddata/dbmigration/migrationstate.h"
+#include "importolddata/dbmigration/migrationwriter.h"
+
+#include "gtest/gtest.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QRegularExpression>
+#include <QTemporaryDir>
+
+#include <sys/stat.h>  // chmod
+#include <unistd.h>    // getuid
+
+namespace {
+
+// 构造一条写回回报。
+WriteResult makeResult(qint32 noteId, bool success, WriteErrorCode code,
+                       const QVector<MigrationWarning> &warnings = {})
+{
+    WriteResult r;
+    r.noteId = noteId;
+    r.success = success;
+    r.code = code;
+    r.message = success ? QStringLiteral("ok") : QStringLiteral("fail");
+    r.originalDataPreserved = true;
+    r.warnings = warnings;
+    return r;
+}
+
+MigrationWarning makeWarning(const QString &code, const QString &path = QStringLiteral("p"),
+                             const QString &message = QStringLiteral("m"))
+{
+    MigrationWarning w;
+    w.path = path;
+    w.code = code;
+    w.message = message;
+    return w;
+}
+
+// 构造一份典型输入：3 成功（1 降级）/ 1 失败 / 1 异常。
+MigrationReportInput makeSampleInput()
+{
+    MigrationReportInput input;
+    input.totalCount = 5;
+    input.needMigrateCount = 4;   // 3 success + 1 failed
+    input.alreadyTiptapCount = 1; // skipped
+    input.abnormalCount = 1;
+    input.abnormalNoteIds = { 99 };
+    input.backupPath = QStringLiteral("/tmp/backup/test.db.20260725-100000");
+    input.elapsedMs = 12345;
+    input.finalState = MigrationState::Completed;
+    input.cancelled = false;
+
+    QVector<WriteResult> results;
+    results.append(makeResult(1, true, WriteErrorCode::None));
+    // note 2: 成功但含降级码 → 同时计入 success 与 downgraded
+    results.append(makeResult(2, true, WriteErrorCode::None,
+                              { makeWarning(QStringLiteral("downgraded-html-block")) }));
+    results.append(makeResult(3, true, WriteErrorCode::None,
+                              { makeWarning(QStringLiteral("unsupported-html-style")) }));
+    // note 4: 失败
+    results.append(makeResult(4, false, WriteErrorCode::ConvertFailed,
+                              { makeWarning(QStringLiteral("dangerous-html-node")) }));
+    input.writeResults = results;
+    return input;
+}
+
+}  // namespace
+
+// --- 默认路径定位 ---
+
+TEST(UT_MigrationReport, DefaultReportDirSameRootAsBackup)
+{
+    const QString dir = MigrationReport::defaultReportDir();
+    EXPECT_FALSE(dir.isEmpty());
+    EXPECT_TRUE(dir.endsWith(QStringLiteral("migration/report")));
+}
+
+// --- isDowngradeWarningCode 表驱动（D17=A 口径） ---
+
+TEST(UT_MigrationReport, IsDowngradeWarningCodeTableDriven)
+{
+    // 前缀 downgraded- 命中
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("downgraded-html-block")));
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("downgraded-inline-element")));
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("downgraded-base64-image")));
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("downgraded-html-link")));
+
+    // 显式集合
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("dangerous-html-node")));
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("dangerous-html-attribute")));
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("missing-html-image-src")));
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("unsafe-html-image-src")));
+    EXPECT_TRUE(MigrationReport::isDowngradeWarningCode(QStringLiteral("skipped-non-text-block")));
+
+    // 非降级码
+    EXPECT_FALSE(MigrationReport::isDowngradeWarningCode(QStringLiteral("unsupported-html-style")));
+    EXPECT_FALSE(MigrationReport::isDowngradeWarningCode(QStringLiteral("invalid-html-style-value")));
+    EXPECT_FALSE(MigrationReport::isDowngradeWarningCode(QStringLiteral("depth-exceeded")));
+    EXPECT_FALSE(MigrationReport::isDowngradeWarningCode(QStringLiteral("parse-failed")));
+    EXPECT_FALSE(MigrationReport::isDowngradeWarningCode(QStringLiteral("missing-voicebox-jsonkey")));
+    EXPECT_FALSE(MigrationReport::isDowngradeWarningCode(QString()));
+}
+
+// --- buildReportObject 计数正确性 ---
+
+TEST(UT_MigrationReport, BuildReportObjectCounts)
+{
+    const MigrationReportInput input = makeSampleInput();
+    const QJsonObject report = MigrationReport::buildReportObject(input);
+
+    EXPECT_EQ(report.value(QStringLiteral("schemaVersion")).toInt(), 1);
+
+    const QJsonObject counts = report.value(QStringLiteral("counts")).toObject();
+    EXPECT_EQ(counts.value(QStringLiteral("total")).toInt(), 5);
+    EXPECT_EQ(counts.value(QStringLiteral("needMigrate")).toInt(), 4);
+    EXPECT_EQ(counts.value(QStringLiteral("success")).toInt(), 3);
+    EXPECT_EQ(counts.value(QStringLiteral("failed")).toInt(), 1);
+    EXPECT_EQ(counts.value(QStringLiteral("downgraded")).toInt(), 2); // note2 + note4
+    EXPECT_EQ(counts.value(QStringLiteral("skipped")).toInt(), 1);
+    EXPECT_EQ(counts.value(QStringLiteral("abnormal")).toInt(), 1);
+
+    // 不变量：needMigrate == success + failed
+    EXPECT_EQ(counts.value(QStringLiteral("needMigrate")).toInt(),
+              counts.value(QStringLiteral("success")).toInt()
+                  + counts.value(QStringLiteral("failed")).toInt());
+
+    // 降级口径：降级但成功者（note2）同时计入 success 与 downgraded
+    EXPECT_GE(counts.value(QStringLiteral("success")).toInt(), 1);
+    EXPECT_GE(counts.value(QStringLiteral("downgraded")).toInt(), 1);
+}
+
+// --- buildReportObject failedNoteIds / abnormalNoteIds / cancelled ---
+
+TEST(UT_MigrationReport, BuildReportObjectIdsAndCancelled)
+{
+    MigrationReportInput input = makeSampleInput();
+    input.finalState = MigrationState::PartialCompleted;
+    input.cancelled = true;
+
+    const QJsonObject report = MigrationReport::buildReportObject(input);
+
+    const QJsonArray failedIds = report.value(QStringLiteral("failedNoteIds")).toArray();
+    ASSERT_EQ(failedIds.size(), 1);
+    EXPECT_EQ(failedIds.at(0).toInt(), 4);
+
+    const QJsonArray abnormalIds = report.value(QStringLiteral("abnormalNoteIds")).toArray();
+    ASSERT_EQ(abnormalIds.size(), 1);
+    EXPECT_EQ(abnormalIds.at(0).toInt(), 99);
+
+    EXPECT_EQ(report.value(QStringLiteral("cancelled")).toBool(), true);
+    EXPECT_EQ(report.value(QStringLiteral("finalState")).toString(),
+              QStringLiteral("PartialCompleted"));
+    EXPECT_EQ(report.value(QStringLiteral("elapsedMs")).toInt(), 12345);
+    EXPECT_EQ(report.value(QStringLiteral("backupPath")).toString(), input.backupPath);
+}
+
+// --- buildReportObject warnings 聚合带 noteId + 隐私断言 ---
+
+TEST(UT_MigrationReport, BuildReportObjectWarningsAndPrivacy)
+{
+    const MigrationReportInput input = makeSampleInput();
+    const QJsonObject report = MigrationReport::buildReportObject(input);
+
+    const QJsonArray warnings = report.value(QStringLiteral("warnings")).toArray();
+    // note2(1) + note3(1) + note4(1) = 3 条
+    ASSERT_EQ(warnings.size(), 3);
+
+    // 每条 warning 带 noteId + path + code + message
+    for (const QJsonValue &value : warnings) {
+        const QJsonObject entry = value.toObject();
+        EXPECT_TRUE(entry.contains(QStringLiteral("noteId")));
+        EXPECT_TRUE(entry.contains(QStringLiteral("path")));
+        EXPECT_TRUE(entry.contains(QStringLiteral("code")));
+        EXPECT_TRUE(entry.contains(QStringLiteral("message")));
+    }
+
+    // note2 的 warning 标注了正确 noteId
+    const QJsonObject first = warnings.at(0).toObject();
+    EXPECT_EQ(first.value(QStringLiteral("noteId")).toInt(), 2);
+    EXPECT_EQ(first.value(QStringLiteral("code")).toString(), QStringLiteral("downgraded-html-block"));
+
+    // 隐私断言：报告整体不含正文 / meta_data / envelope / htmlCode 键
+    const QByteArray serialized = QJsonDocument(report).toJson(QJsonDocument::Compact);
+    const QString text = QString::fromUtf8(serialized);
+    EXPECT_FALSE(text.contains(QStringLiteral("meta_data"), Qt::CaseInsensitive));
+    EXPECT_FALSE(text.contains(QStringLiteral("envelope"), Qt::CaseInsensitive));
+    EXPECT_FALSE(text.contains(QStringLiteral("htmlCode"), Qt::CaseInsensitive));
+    EXPECT_FALSE(text.contains(QStringLiteral("content"), Qt::CaseInsensitive));
+    EXPECT_FALSE(text.contains(QStringLiteral("metaData"), Qt::CaseInsensitive));
+}
+
+// --- generate 落盘成功（QTemporaryDir 注入、可解析 JSON、命名匹配） ---
+
+TEST(UT_MigrationReport, GenerateWritesParseableJson)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    MigrationReport report(dir.path());
+    const ReportResult result = report.generate(makeSampleInput());
+
+    EXPECT_TRUE(result.success) << qPrintable(result.message);
+    EXPECT_EQ(result.code, ReportErrorCode::None);
+    EXPECT_TRUE(QFileInfo::exists(result.reportPath));
+
+    // 命名匹配 migration-report.<yyyyMMdd-HHmmss>.json
+    const QString name = QFileInfo(result.reportPath).fileName();
+    const QRegularExpression re(QStringLiteral("^migration-report\\.\\d{8}-\\d{6}(\\.\\d+)?\\.json$"));
+    EXPECT_TRUE(re.match(name).hasMatch()) << qPrintable(name);
+
+    // 可解析 JSON，关键字段在位
+    QFile f(result.reportPath);
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    const QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+    f.close();
+    ASSERT_TRUE(doc.isObject());
+    const QJsonObject obj = doc.object();
+    EXPECT_EQ(obj.value(QStringLiteral("schemaVersion")).toInt(), 1);
+    EXPECT_EQ(obj.value(QStringLiteral("finalState")).toString(), QStringLiteral("Completed"));
+    EXPECT_FALSE(obj.value(QStringLiteral("cancelled")).toBool());
+}
+
+// --- generate 连续两次不覆盖 ---
+
+TEST(UT_MigrationReport, GenerateDoesNotOverwrite)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    MigrationReport report(dir.path());
+    const MigrationReportInput input = makeSampleInput();
+
+    const ReportResult first = report.generate(input);
+    ASSERT_TRUE(first.success) << qPrintable(first.message);
+
+    // 同秒内连续第二次：不应覆盖第一份
+    const ReportResult second = report.generate(input);
+    ASSERT_TRUE(second.success) << qPrintable(second.message);
+
+    EXPECT_NE(first.reportPath, second.reportPath);
+    EXPECT_TRUE(QFileInfo::exists(first.reportPath));
+    EXPECT_TRUE(QFileInfo::exists(second.reportPath));
+
+    // 两份均可独立解析
+    for (const QString &path : { first.reportPath, second.reportPath }) {
+        QFile f(path);
+        ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+        const QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+        f.close();
+        EXPECT_TRUE(doc.isObject());
+    }
+}
+
+// --- 失败：非终态 InputInvalid ---
+
+TEST(UT_MigrationReport, GenerateRejectsNonTerminalState)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    MigrationReportInput input = makeSampleInput();
+    input.finalState = MigrationState::Migrating;  // 非终态
+
+    MigrationReport report(dir.path());
+    const ReportResult result = report.generate(input);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.code, ReportErrorCode::InputInvalid);
+    // 不产任何文件
+    EXPECT_FALSE(QFileInfo::exists(result.reportPath));
+}
+
+TEST(UT_MigrationReport, GenerateRejectsPendingState)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    MigrationReportInput input = makeSampleInput();
+    input.finalState = MigrationState::Pending;
+
+    MigrationReport report(dir.path());
+    const ReportResult result = report.generate(input);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.code, ReportErrorCode::InputInvalid);
+}
+
+// --- 失败：目录不可创建 DirCreateFailed（父级是普通文件） ---
+
+TEST(UT_MigrationReport, GenerateDirCreateFailed)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    // 报告目录路径的父级是一个普通文件，mkpath 无法在其下创建目录
+    const QString blocker = dir.path() + QStringLiteral("/blocker");
+    {
+        QFile f(blocker);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write("x");
+        f.close();
+    }
+    const QString badDir = blocker + QStringLiteral("/report");
+
+    MigrationReport report(badDir);
+    const ReportResult result = report.generate(makeSampleInput());
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.code, ReportErrorCode::DirCreateFailed);
+    // 不产半文件
+    EXPECT_FALSE(QFileInfo::exists(badDir + QStringLiteral("/migration-report.json")));
+}
+
+// --- 失败：目录只读 WriteFailed（不抛异常、不产半文件） ---
+
+TEST(UT_MigrationReport, GenerateWriteFailedReadOnlyDir)
+{
+    // root 绕过文件权限，无法触发只读失败
+    if (getuid() == 0) {
+        GTEST_SKIP() << "chmod 0500 ineffective as root; run as non-root user";
+    }
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const QString reportDir = dir.path() + QStringLiteral("/ro");
+    ASSERT_TRUE(QDir().mkpath(reportDir));
+    // 只读目录：可在其下查找但不可创建文件
+    chmod(QFile::encodeName(reportDir).constData(), 0500);
+
+    MigrationReport report(reportDir);
+    const ReportResult result = report.generate(makeSampleInput());
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.code, ReportErrorCode::WriteFailed);
+
+    // 不产半文件：无 .json 也无 .tmp 残留
+    QDir d(reportDir);
+    const QStringList entries = d.entryList(QStringList() << QStringLiteral("*.json") << QStringLiteral("*.tmp"));
+    EXPECT_TRUE(entries.isEmpty()) << qPrintable(entries.join(QStringLiteral(", ")));
+
+    // 恢复权限以便 QTemporaryDir 清理
+    chmod(QFile::encodeName(reportDir).constData(), 0700);
+}

--- a/tests/src/importolddata/dbmigration/ut_migrationreport.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationreport.cpp
@@ -140,6 +140,69 @@ TEST(UT_MigrationReport, BuildReportObjectCounts)
     EXPECT_GE(counts.value(QStringLiteral("downgraded")).toInt(), 1);
 }
 
+// --- buildReportObject 续传累计计数优先（success/failed 用全量计数）---
+
+TEST(UT_MigrationReport, BuildReportObjectUsesCumulativeCountsOnResume)
+{
+    // 模拟续传场景：全量 needMigrate=4，首段已成功 2 条，本次续传段 writeResults
+    // 仅含 2 条（1 成功 + 1 失败）。若从 writeResults 重算，success=1/failed=1，
+    // 与全量 total/needMigrate 口径不一致；传入累计计数后应使用全量值。
+    MigrationReportInput input;
+    input.totalCount = 5;
+    input.needMigrateCount = 4;
+    input.alreadyTiptapCount = 1;
+    input.abnormalCount = 0;
+    input.finalState = MigrationState::PartialCompleted;
+    input.cancelled = false;
+
+    QVector<WriteResult> results;
+    results.append(makeResult(3, true, WriteErrorCode::None));
+    results.append(makeResult(4, false, WriteErrorCode::ConvertFailed));
+    input.writeResults = results;
+
+    // 从游标恢复的全量累计计数：首段 success=2 + 本次段 success=1 = 3；
+    // 首段 fail=0 + 本次段 fail=1 = 1。
+    input.cumulativeSuccess = 3;
+    input.cumulativeFail = 1;
+    input.writeResultsScope = QStringLiteral("resumed-segment");
+
+    const QJsonObject report = MigrationReport::buildReportObject(input);
+    const QJsonObject counts = report.value(QStringLiteral("counts")).toObject();
+
+    // success/failed 使用全量累计计数，而非从续传段 writeResults 重算（1/1）。
+    EXPECT_EQ(counts.value(QStringLiteral("success")).toInt(), 3);
+    EXPECT_EQ(counts.value(QStringLiteral("failed")).toInt(), 1);
+
+    // 口径一致：needMigrate == success + failed == total - skipped
+    EXPECT_EQ(counts.value(QStringLiteral("needMigrate")).toInt(),
+              counts.value(QStringLiteral("success")).toInt()
+                  + counts.value(QStringLiteral("failed")).toInt());
+
+    // 明细范围标注：续传段明细。
+    EXPECT_EQ(report.value(QStringLiteral("writeResultsScope")).toString(),
+              QStringLiteral("resumed-segment"));
+
+    // failedNoteIds 仅含续传段失败明细（note 4），不与全量 failed 计数冲突。
+    const QJsonArray failedIds = report.value(QStringLiteral("failedNoteIds")).toArray();
+    ASSERT_EQ(failedIds.size(), 1);
+    EXPECT_EQ(failedIds.at(0).toInt(), 4);
+}
+
+// --- buildReportObject 默认回退：未提供累计计数时从 writeResults 重算 ---
+
+TEST(UT_MigrationReport, BuildReportObjectFallsBackToRecomputeWithoutCumulative)
+{
+    // cumulativeSuccess/cumulativeFail 保持默认 -1，应回退到从 writeResults 重算。
+    const MigrationReportInput input = makeSampleInput();
+    const QJsonObject report = MigrationReport::buildReportObject(input);
+
+    const QJsonObject counts = report.value(QStringLiteral("counts")).toObject();
+    EXPECT_EQ(counts.value(QStringLiteral("success")).toInt(), 3);
+    EXPECT_EQ(counts.value(QStringLiteral("failed")).toInt(), 1);
+    EXPECT_EQ(report.value(QStringLiteral("writeResultsScope")).toString(),
+              QStringLiteral("full"));
+}
+
 // --- buildReportObject failedNoteIds / abnormalNoteIds / cancelled ---
 
 TEST(UT_MigrationReport, BuildReportObjectIdsAndCancelled)

--- a/tests/src/importolddata/dbmigration/ut_migrationviewcontroller.cpp
+++ b/tests/src/importolddata/dbmigration/ut_migrationviewcontroller.cpp
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// TTP-021: MigrationViewController 单元测试。
+// 复用 ut_migrationorchestrator 的注入式编排器（构造带 dbPath/stateFilePath/backupDir/
+// reportDir）+ 直接驱动控制器公开槽；测试构建开启 -fno-access-control，可注入私有
+// m_orchestrator 与 m_migrationActive 以构造可测状态。
+
+#include "importolddata/dbmigration/migrationorchestrator.h"
+#include "importolddata/dbmigration/migrationstate.h"
+#include "common/migrationviewcontroller.h"
+
+#include "gtest/gtest.h"
+
+#include <QDateTime>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QTemporaryDir>
+
+namespace {
+
+QString uniqueConn(const char *prefix)
+{
+    return QStringLiteral("%1_%2").arg(QLatin1String(prefix),
+                                       QDateTime::currentDateTime().toMSecsSinceEpoch());
+}
+
+bool createTable(QSqlQuery &q)
+{
+    return q.exec(QStringLiteral(
+        "CREATE TABLE vnote_items_tbl ("
+        "note_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "folder_id INTEGER, "
+        "note_type INTEGER, "
+        "note_title TEXT, "
+        "meta_data TEXT, "
+        "note_state INTEGER, "
+        "create_time TEXT, "
+        "modify_time TEXT, "
+        "delete_time TEXT, "
+        "expand_filed1 INTEGER, "
+        "expand_filed2 INTEGER)"));
+}
+
+bool createDb(const QString &path)
+{
+    const QString conn = uniqueConn("ut_vc_mk");
+    bool ok = false;
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return false;
+        }
+        QSqlQuery q(db);
+        ok = createTable(q);
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return ok;
+}
+
+bool insertNoteInto(const QString &path, qint32 noteId, const QString &metaData)
+{
+    const QString conn = uniqueConn("ut_vc_ins");
+    bool ok = false;
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), conn);
+        db.setDatabaseName(path);
+        if (!db.open()) {
+            QSqlDatabase::removeDatabase(conn);
+            return false;
+        }
+        QSqlQuery q(db);
+        q.prepare(QStringLiteral("INSERT INTO vnote_items_tbl "
+                                  "(note_id, folder_id, note_type, note_title, meta_data, "
+                                  "note_state, create_time, modify_time, delete_time, "
+                                  "expand_filed1, expand_filed2) "
+                                  "VALUES (?, 0, 0, 't', ?, 0, '', '2026-01-01 00:00:00', '', 0, 0)"));
+        q.addBindValue(noteId);
+        q.addBindValue(metaData);
+        ok = q.exec();
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(conn);
+    return ok;
+}
+
+// 注入式编排器：可重写 simulateInterrupt 以模拟进程中断（aborted 路径）。
+class InterruptableOrchestrator : public MigrationOrchestrator
+{
+public:
+    InterruptableOrchestrator(const QString &dbPath, const QString &statePath,
+                              const QString &backupDir, const QString &reportDir)
+        : MigrationOrchestrator(dbPath, statePath, backupDir, reportDir)
+    {
+    }
+
+    void setInterruptAfter(int count) { m_interruptAfter = count; }
+
+protected:
+    bool simulateInterrupt(int processedCount) override
+    {
+        return m_interruptAfter > 0 && processedCount >= m_interruptAfter;
+    }
+
+private:
+    int m_interruptAfter = 0;
+};
+
+} // namespace
+
+// --- 信号→属性映射 ---
+
+TEST(UT_MigrationViewController, SignalToPropertyMapping)
+{
+    MigrationViewController ctrl;
+
+    MigrationOrchestrator::ProgressSnapshot snap;
+    snap.stage = MigrationState::Migrating;
+    snap.processed = 3;
+    snap.total = 5;
+    snap.success = 2;
+    snap.fail = 1;
+    ctrl.onProgressChanged(snap);
+
+    EXPECT_EQ(ctrl.processed(), 3);
+    EXPECT_EQ(ctrl.total(), 5);
+    EXPECT_EQ(ctrl.success(), 2);
+    EXPECT_EQ(ctrl.fail(), 1);
+
+    ctrl.onStageChanged(MigrationState::Migrating);
+    EXPECT_EQ(ctrl.stage().toStdString(), "Migrating");
+
+    ctrl.onStageChanged(MigrationState::BackingUp);
+    EXPECT_EQ(ctrl.stage().toStdString(), "BackingUp");
+}
+
+// --- 取消转发：requestCancel 置 cancelling 并转发到编排器 ---
+
+TEST(UT_MigrationViewController, CancelForwarding)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+
+    MigrationViewController ctrl;
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    ctrl.m_orchestrator = &o;  // -fno-access-control：注入编排器
+
+    EXPECT_FALSE(ctrl.cancelling());
+    ctrl.requestCancel();
+    EXPECT_TRUE(ctrl.cancelling());
+    // 转发到编排器：取消原子标志已置位。
+    EXPECT_TRUE(o.m_cancelRequested.load());
+
+    // 重复 requestCancel 不再转发（cancelling 已为 true）。
+    ctrl.requestCancel();
+}
+
+// --- NotNeeded 放行：不展示终态视图，migrationActive 翻 false ---
+
+TEST(UT_MigrationViewController, NotNeededRelease)
+{
+    MigrationViewController ctrl;
+    ctrl.m_migrationActive = true;  // -fno-access-control
+
+    ctrl.onTerminalInfo(MigrationState::NotNeeded, QString(), QString());
+
+    EXPECT_FALSE(ctrl.migrationActive());
+    EXPECT_TRUE(ctrl.terminalState().isEmpty());
+    EXPECT_TRUE(ctrl.backupPath().isEmpty());
+    EXPECT_TRUE(ctrl.reportPath().isEmpty());
+    EXPECT_FALSE(ctrl.cancelling());
+}
+
+// --- 终态填充：Completed 终态 backupPath/reportPath 填充、migrationActive 翻 false、QPointer 清空 ---
+
+TEST(UT_MigrationViewController, TerminalFillCompleted)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+
+    MigrationViewController ctrl;
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    // 连接编排器信号→控制器槽（同线程，直接调用路径）。
+    QObject::connect(&o, &MigrationOrchestrator::progressChanged, &ctrl,
+                     &MigrationViewController::onProgressChanged);
+    QObject::connect(&o, &MigrationOrchestrator::stageChanged, &ctrl,
+                     &MigrationViewController::onStageChanged);
+    QObject::connect(&o, &MigrationOrchestrator::terminalInfo, &ctrl,
+                     &MigrationViewController::onTerminalInfo);
+    QObject::connect(&o, &MigrationOrchestrator::aborted, &ctrl,
+                     &MigrationViewController::onAborted);
+    ctrl.m_migrationActive = true;  // -fno-access-control
+    ctrl.m_orchestrator = &o;       // -fno-access-control
+
+    o.run();  // → Completed，emit terminalInfo
+
+    EXPECT_EQ(ctrl.terminalState().toStdString(), "Completed");
+    EXPECT_FALSE(ctrl.backupPath().isEmpty());
+    EXPECT_FALSE(ctrl.reportPath().isEmpty());
+    EXPECT_FALSE(ctrl.migrationActive());
+    EXPECT_FALSE(ctrl.cancelling());
+    // QPointer 已在 onTerminalInfo 内清空。
+    EXPECT_EQ(ctrl.m_orchestrator.data(), nullptr);
+    // Migrating 计数已映射。
+    EXPECT_EQ(ctrl.success(), 1);
+    EXPECT_EQ(ctrl.fail(), 0);
+}
+
+// --- Failed 终态：backupPath/reportPath 填充 ---
+
+TEST(UT_MigrationViewController, TerminalFillFailed)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    // 无需迁移笔记但有异常项 → Failed（无需迁移且 abnormalCount>0）。
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"unknown\":\"obj\"}")));
+
+    MigrationViewController ctrl;
+    MigrationOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    QObject::connect(&o, &MigrationOrchestrator::terminalInfo, &ctrl,
+                     &MigrationViewController::onTerminalInfo);
+    ctrl.m_migrationActive = true;
+    ctrl.m_orchestrator = &o;
+
+    o.run();  // → Failed
+
+    EXPECT_EQ(ctrl.terminalState().toStdString(), "Failed");
+    EXPECT_FALSE(ctrl.migrationActive());
+    EXPECT_FALSE(ctrl.backupPath().isEmpty());
+    EXPECT_FALSE(ctrl.reportPath().isEmpty());
+}
+
+// --- aborted 放行：模拟中断 → migrationActive 翻 false、QPointer 清空 ---
+
+TEST(UT_MigrationViewController, AbortedRelease)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString dbPath = dir.path() + QStringLiteral("/notes.db");
+    const QString statePath = dir.path() + QStringLiteral("/state/migration-state.json");
+    const QString backupDir = dir.path() + QStringLiteral("/backup");
+    const QString reportDir = dir.path() + QStringLiteral("/report");
+    ASSERT_TRUE(createDb(dbPath));
+    ASSERT_TRUE(insertNoteInto(dbPath, 1, QStringLiteral("{\"noteDatas\":[{\"type\":1,\"text\":\"a\"}]}")));
+
+    MigrationViewController ctrl;
+    InterruptableOrchestrator o(dbPath, statePath, backupDir, reportDir);
+    o.setInterruptAfter(1);  // 处理完第 1 条后中断 → aborted
+    QObject::connect(&o, &MigrationOrchestrator::aborted, &ctrl,
+                     &MigrationViewController::onAborted);
+    QObject::connect(&o, &MigrationOrchestrator::terminalInfo, &ctrl,
+                     &MigrationViewController::onTerminalInfo);
+    ctrl.m_migrationActive = true;
+    ctrl.m_orchestrator = &o;
+
+    o.run();  // → simulateInterrupt → aborted
+
+    EXPECT_FALSE(ctrl.migrationActive());
+    EXPECT_TRUE(ctrl.terminalState().isEmpty());  // 非终态，无终态视图
+    EXPECT_EQ(ctrl.m_orchestrator.data(), nullptr);
+}
+
+// --- enterApp 放行：终态后收起终态视图 ---
+
+TEST(UT_MigrationViewController, EnterAppDismissesTerminal)
+{
+    MigrationViewController ctrl;
+    ctrl.m_migrationActive = false;
+    ctrl.m_terminalState = QStringLiteral("Completed");
+    ctrl.m_backupPath = QStringLiteral("/tmp/backup.db");
+    ctrl.m_reportPath = QStringLiteral("/tmp/report.json");
+
+    ctrl.enterApp();
+
+    EXPECT_FALSE(ctrl.migrationActive());
+    EXPECT_TRUE(ctrl.terminalState().isEmpty());
+    EXPECT_TRUE(ctrl.backupPath().isEmpty());
+    EXPECT_TRUE(ctrl.reportPath().isEmpty());
+}


### PR DESCRIPTION
## Migration infrastructure: report, orchestrator, and progress view

This PR adds the final batch of the Tiptap content migration infrastructure: report generation, background task orchestration, and the upgrade progress UI.

### Commits

1. **feat(migration): implement migration report generation and persistence** — `MigrationReport` module that aggregates the final migration state, scan counts, per-note write-back results (including warnings), backup path, and elapsed time into a JSON report persisted to disk. Contains no note body content.
2. **feat(migration): orchestrate background full migration task** — `MigrationOrchestrator` chaining the state machine, backup, scanner, writer, and report modules into a single runnable background task (Pending → BackingUp → Scanning → Migrating → terminal state + report). Supports resume, cancel, and progress queries. Wired into `main.cpp` startup.
3. **feat(migration): implement upgrade progress view** — `MigrationViewController` singleton bridging orchestrator signals to QML, `MigrationProgressView.qml` showing stage/progress/error states, and migration gate wired into `MainWindow` startup flow to block entry until migration completes.
4. **fix(migration): use cumulative counts in resume report** — After a resume, `m_writeResults` only contains the current segment's details while `m_success`/`m_fail` are full cumulative counts from the cursor. The report now prefers cumulative counts, keeping `success+failed == needMigrate` invariant. Per-note details are annotated with `writeResultsScope` (`full` or `resumed-segment`).

### New modules

- `migrationreport.{h,cpp}` — report generation and persistence
- `migrationorchestrator.{h,cpp}` — background task orchestration
- `migrationviewcontroller.{h,cpp}` — UI bridge singleton
- `MigrationProgressView.qml` — progress view

### Tests

- `ut_migrationreport.cpp` — 13 cases (aggregation, classification, atomic write, error paths, cumulative counts on resume)
- `ut_migrationorchestrator.cpp` — stage progression, cancel, resume, terminal report, thread lifecycle
- `ut_migrationviewcontroller.cpp` — controller and migration gate
