### PR TITLE
test(at): stabilize voice note AT suite setup

### DIFF
--- a/tests/at/setup_voice_note_at.sh
+++ b/tests/at/setup_voice_note_at.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -u
+
+APP_NAME="deepin-voice-note"
+
+if [[ -z "${HOME:-}" || "${HOME}" == "/" ]]; then
+    echo "Invalid HOME: ${HOME:-<empty>}" >&2
+    exit 1
+fi
+
+DATA_DIR="${HOME}/.local/share/deepin/deepin-voice-note"
+CONFIG_DIR="${HOME}/.config/deepin/deepin-voice-note"
+DB_PATH="${DATA_DIR}/deepin-voice-note1.0.db"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/deepin-voice-note-init.XXXXXX.log")"
+
+cleanup_log()
+{
+    rm -f "${LOG_FILE}"
+}
+trap cleanup_log EXIT
+
+stop_app()
+{
+    killall -q "${APP_NAME}" 2>/dev/null || true
+}
+
+wait_for_schema()
+{
+    local i
+    for i in {1..80}; do
+        if [[ -f "${DB_PATH}" ]] \
+            && [[ "$(sqlite3 "${DB_PATH}" \
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='vnote_folder_tbl';" \
+                2>/dev/null || true)" == "vnote_folder_tbl" ]]; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    echo "Timed out waiting for ${APP_NAME} database schema" >&2
+    return 1
+}
+
+seed_default_notebook()
+{
+    sqlite3 "${DB_PATH}" \
+        "INSERT INTO vnote_folder_tbl(category_id, folder_name, default_icon, folder_state, max_noteid) VALUES(0, '记事本1', 0, 0, 0);"
+}
+
+stop_app
+rm -rf -- "${DATA_DIR}" "${CONFIG_DIR}"
+
+"${APP_NAME}" >"${LOG_FILE}" 2>&1 &
+INIT_PID=$!
+
+if ! wait_for_schema; then
+    kill "${INIT_PID}" 2>/dev/null || true
+    stop_app
+    exit 1
+fi
+
+kill "${INIT_PID}" 2>/dev/null || true
+stop_app
+
+seed_default_notebook
+
+exec "${APP_NAME}"

--- a/tests/at/yaml/_V25_2500_语音记事本_语音记事本102x_工具栏(#115117)_case_1635223_s1/_V25_2500_语音记事本_语音记事本102x_工具栏(#115117)_case_1635223_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500_语音记事本_语音记事本102x_工具栏(#115117)_case_1635223_s1/_V25_2500_语音记事本_语音记事本102x_工具栏(#115117)_case_1635223_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/_V25_2500_语音记事本_语音记事本1050_标题栏(#115179)_case_1625247_s1/_V25_2500_语音记事本_语音记事本1050_标题栏(#115179)_case_1625247_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500_语音记事本_语音记事本1050_标题栏(#115179)_case_1625247_s1/_V25_2500_语音记事本_语音记事本1050_标题栏(#115179)_case_1625247_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/_V25_2500_语音记事本_语音记事本1050_记事本条目(#115181)_case_1625243_s1/_V25_2500_语音记事本_语音记事本1050_记事本条目(#115181)_case_1625243_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500_语音记事本_语音记事本1050_记事本条目(#115181)_case_1625243_s1/_V25_2500_语音记事本_语音记事本1050_记事本条目(#115181)_case_1625243_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/压力测试(#115107)_case_1635299_s1/压力测试(#115107)_case_1635299_s1.suite.yaml
+++ b/tests/at/yaml/压力测试(#115107)_case_1635299_s1/压力测试(#115107)_case_1635299_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:
@@ -17,6 +17,11 @@ suites:
   description: ''
   tags: []
   steps:
+  - action: element_action
+    selector:
+      name: 新建记事本
+      role: button
+    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1

--- a/tests/at/yaml/压力测试(#115107)_case_1635301_s1/压力测试(#115107)_case_1635301_s1.suite.yaml
+++ b/tests/at/yaml/压力测试(#115107)_case_1635301_s1/压力测试(#115107)_case_1635301_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/启用语音记事本(#115131)_case_1634837_s1/启用语音记事本(#115131)_case_1634837_s1.suite.yaml
+++ b/tests/at/yaml/启用语音记事本(#115131)_case_1634837_s1/启用语音记事本(#115131)_case_1634837_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/快捷键(#115195)_case_1624611_s1/快捷键(#115195)_case_1624611_s1.suite.yaml
+++ b/tests/at/yaml/快捷键(#115195)_case_1624611_s1/快捷键(#115195)_case_1624611_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635259_s1/快捷键使用(#115113)_case_1635259_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635259_s1/快捷键使用(#115113)_case_1635259_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635261_s1/快捷键使用(#115113)_case_1635261_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635261_s1/快捷键使用(#115113)_case_1635261_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635263_s1/快捷键使用(#115113)_case_1635263_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635263_s1/快捷键使用(#115113)_case_1635263_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635271_s1/快捷键使用(#115113)_case_1635271_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635271_s1/快捷键使用(#115113)_case_1635271_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635277_s1/快捷键使用(#115113)_case_1635277_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635277_s1/快捷键使用(#115113)_case_1635277_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635279_s1/快捷键使用(#115113)_case_1635279_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635279_s1/快捷键使用(#115113)_case_1635279_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635281_s1/快捷键使用(#115113)_case_1635281_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635281_s1/快捷键使用(#115113)_case_1635281_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/搜索功能(#115119)_case_1635179_s1/搜索功能(#115119)_case_1635179_s1.suite.yaml
+++ b/tests/at/yaml/搜索功能(#115119)_case_1635179_s1/搜索功能(#115119)_case_1635179_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/搜索功能(#115119)_case_1635181_s1/搜索功能(#115119)_case_1635181_s1.suite.yaml
+++ b/tests/at/yaml/搜索功能(#115119)_case_1635181_s1/搜索功能(#115119)_case_1635181_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/搜索功能(#115119)_case_1635183_s1/搜索功能(#115119)_case_1635183_s1.suite.yaml
+++ b/tests/at/yaml/搜索功能(#115119)_case_1635183_s1/搜索功能(#115119)_case_1635183_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/搜索功能(#115119)_case_1635187_s1/搜索功能(#115119)_case_1635187_s1.suite.yaml
+++ b/tests/at/yaml/搜索功能(#115119)_case_1635187_s1/搜索功能(#115119)_case_1635187_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634891_s1/文本笔记详情页(#115125)_case_1634891_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634891_s1/文本笔记详情页(#115125)_case_1634891_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634893_s1/文本笔记详情页(#115125)_case_1634893_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634893_s1/文本笔记详情页(#115125)_case_1634893_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634895_s1/文本笔记详情页(#115125)_case_1634895_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634895_s1/文本笔记详情页(#115125)_case_1634895_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634903_s1/文本笔记详情页(#115125)_case_1634903_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634903_s1/文本笔记详情页(#115125)_case_1634903_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634905_s1/文本笔记详情页(#115125)_case_1634905_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634905_s1/文本笔记详情页(#115125)_case_1634905_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634907_s1/文本笔记详情页(#115125)_case_1634907_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634907_s1/文本笔记详情页(#115125)_case_1634907_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634953_s1/文本笔记详情页(#115125)_case_1634953_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634953_s1/文本笔记详情页(#115125)_case_1634953_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634955_s1/文本笔记详情页(#115125)_case_1634955_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634955_s1/文本笔记详情页(#115125)_case_1634955_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634957_s1/文本笔记详情页(#115125)_case_1634957_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634957_s1/文本笔记详情页(#115125)_case_1634957_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634959_s1/文本笔记详情页(#115125)_case_1634959_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634959_s1/文本笔记详情页(#115125)_case_1634959_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/记事本条目(#115181)_case_1625233_s1/记事本条目(#115181)_case_1625233_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目(#115181)_case_1625233_s1/记事本条目(#115181)_case_1625233_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:
@@ -17,6 +17,11 @@ suites:
   description: ''
   tags: []
   steps:
+  - action: element_action
+    selector:
+      name: 新建记事本
+      role: button
+    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634839_s1/记事本条目管理(#115129)_case_1634839_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634839_s1/记事本条目管理(#115129)_case_1634839_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634841_s1/记事本条目管理(#115129)_case_1634841_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634841_s1/记事本条目管理(#115129)_case_1634841_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634843_s1/记事本条目管理(#115129)_case_1634843_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634843_s1/记事本条目管理(#115129)_case_1634843_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634845_s1/记事本条目管理(#115129)_case_1634845_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634845_s1/记事本条目管理(#115129)_case_1634845_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634849_s1/记事本条目管理(#115129)_case_1634849_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634849_s1/记事本条目管理(#115129)_case_1634849_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:
@@ -17,6 +17,11 @@ suites:
   description: ''
   tags: []
   steps:
+  - action: element_action
+    selector:
+      name: 新建记事本
+      role: button
+    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
@@ -30,5 +35,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: abc
+      name: 记事本1
       role: label

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634851_s1/记事本条目管理(#115129)_case_1634851_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634851_s1/记事本条目管理(#115129)_case_1634851_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634853_s1/记事本条目管理(#115129)_case_1634853_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634853_s1/记事本条目管理(#115129)_case_1634853_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:
@@ -17,6 +17,11 @@ suites:
   description: ''
   tags: []
   steps:
+  - action: element_action
+    selector:
+      name: 新建记事本
+      role: button
+    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634857_s1/记事本条目管理(#115129)_case_1634857_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634857_s1/记事本条目管理(#115129)_case_1634857_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634863_s1/记事本条目管理(#115129)_case_1634863_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634863_s1/记事本条目管理(#115129)_case_1634863_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/详情页编辑区(#115193)_case_1624639_s1/详情页编辑区(#115193)_case_1624639_s1.suite.yaml
+++ b/tests/at/yaml/详情页编辑区(#115193)_case_1624639_s1/详情页编辑区(#115193)_case_1624639_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音(#115191)_case_1624807_s1/语音(#115191)_case_1624807_s1.suite.yaml
+++ b/tests/at/yaml/语音(#115191)_case_1624807_s1/语音(#115191)_case_1624807_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676213_s1/语音记事本V25(#117769)_case_1676213_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676213_s1/语音记事本V25(#117769)_case_1676213_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676215_s1/语音记事本V25(#117769)_case_1676215_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676215_s1/语音记事本V25(#117769)_case_1676215_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676341_s1/语音记事本V25(#117769)_case_1676341_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676341_s1/语音记事本V25(#117769)_case_1676341_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676385_s1/语音记事本V25(#117769)_case_1676385_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676385_s1/语音记事本V25(#117769)_case_1676385_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676411_s1/语音记事本V25(#117769)_case_1676411_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676411_s1/语音记事本V25(#117769)_case_1676411_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676423_s1/语音记事本V25(#117769)_case_1676423_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676423_s1/语音记事本V25(#117769)_case_1676423_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676425_s1/语音记事本V25(#117769)_case_1676425_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676425_s1/语音记事本V25(#117769)_case_1676425_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676573_s1/语音记事本V25(#117769)_case_1676573_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676573_s1/语音记事本V25(#117769)_case_1676573_s1.suite.yaml
@@ -7,8 +7,8 @@ fast_fail: false
 env_check: []
 setup:
 - action: session_start
-  command: deepin-voice-note
-  wait: 3.0
+  command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
+  wait: 6.0
 teardown:
 - action: session_stop
 suites:


### PR DESCRIPTION
Seed default notebook data before each AT suite run.

每个AT套件运行前初始化默认记事本数据。

Log: 稳定语音记事本AT用例前置环境

Influence: 修复清空环境后缺少记事本1导致右键菜单用例失败的问题。

## Summary by Sourcery

Tests:
- Seed default notebook/notebook-1 baseline data in voice note AT suites to prevent failures when running on a cleared environment.