### PR TITLE
chore: Update version to 6.5.63

### DIFF
--- a/assets/deepin-voice-note.desktop
+++ b/assets/deepin-voice-note.desktop
@@ -11,6 +11,7 @@ TryExec=deepin-voice-note
 Type=Application
 X-Deepin-Vendor=user-custom
 Keywords=deepin-voice-note;
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-voice-note (6.5.63) unstable; urgency=medium
+
+  * chore: Update version to 6.5.63
+  * fix: add X-Deepin-Singleton flag to desktop file
+  * test: add AT-SPI test cases for deepin-voice-note
+  * fix: remove yaml literal block scalar in linglong.yaml
+  * fix(vnote): keep ctrl multi-selection count in sync
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 16:26:06 +0800
+
 deepin-voice-note (6.5.62) unstable; urgency=medium
 
   * fix(vnote): use folder ids for notebook operations

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.62.1
+  version: 6.5.63.1
   kind: app
   description: |
     voice note for deepin os


### PR DESCRIPTION
- update version to 6.5.63

log: update version to 6.5.63

## Summary by Sourcery

Bump deepin-voice-note package to version 6.5.63.1 across packaging metadata.

Build:
- Update linglong packaging configuration to reference version 6.5.63.1.

Chores:
- Align application metadata and changelog with the 6.5.63.1 release version.