### PR TITLE
fix(ut): 修复5个失败的单元测试用例，补全语音记事本单测首批

### DIFF
--- a/tests/src/common/ut_metadataparser.cpp
+++ b/tests/src/common/ut_metadataparser.cpp
@@ -80,7 +80,7 @@ TEST_F(UT_MetaDataParser, UT_MetaDataParser_makeMetaData_001)
     metadataparser.parse(metadata, noteData);
     metadata = "";
     metadataparser.makeMetaData(noteData, metadata);
-    EXPECT_EQ("{\"dataCount\":1,\"noteDatas\":[{\"text\":\"sdfgsgssrgstg\",\"type\":1}],\"voiceMaxId\":0}", metadata) << "htmlCode is empty";
+    EXPECT_EQ(QByteArrayLiteral("{\"dataCount\":1,\"noteDatas\":[{\"text\":\"sdfgsgssrgstg\",\"type\":1}],\"voiceMaxId\":0}"), metadata.toByteArray()) << "htmlCode is empty";
 
     noteData->htmlCode = "abc";
     metadataparser.makeMetaData(noteData, metadata);

--- a/tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp
@@ -196,7 +196,7 @@ TEST(UT_MigrationJsonBuilder, GeneratedEnvelopePassesSchemaValidator)
     const QString path = writeTempEnvelope(envelope);
     QProcess validator;
     validator.setWorkingDirectory(findRepoRoot());
-    validator.start(QStringLiteral("node"), { QStringLiteral("web-editor/scripts/validate-envelope.mjs"), path });
+    validator.start(QStringLiteral("node"), { QStringLiteral("--import"), QStringLiteral("./web-editor/scripts/css-inline-loader.mjs"), QStringLiteral("web-editor/scripts/validate-envelope.mjs"), path });
     ASSERT_TRUE(validator.waitForFinished(30000));
     EXPECT_EQ(0, validator.exitCode()) << validator.readAllStandardError().toStdString();
     QFile::remove(path);

--- a/tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp
@@ -91,7 +91,7 @@ void expectPassesValidators(const QJsonObject &envelope)
 
     QProcess validator;
     validator.setWorkingDirectory(repoRoot);
-    validator.start(QStringLiteral("node"), { QStringLiteral("web-editor/scripts/validate-envelope.mjs"), envelopeFile.fileName() });
+    validator.start(QStringLiteral("node"), { QStringLiteral("--import"), QStringLiteral("./web-editor/scripts/css-inline-loader.mjs"), QStringLiteral("web-editor/scripts/validate-envelope.mjs"), envelopeFile.fileName() });
     ASSERT_TRUE(validator.waitForFinished(30000));
     EXPECT_EQ(0, validator.exitCode()) << validator.readAllStandardError().toStdString();
 }

--- a/tests/src/task/ut_exportnoteworker.cpp
+++ b/tests/src/task/ut_exportnoteworker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,10 +8,12 @@
 #include "common/vnoteitem.h"
 
 #include <QApplication>
+#include <QDir>
 #include <QList>
 
 void UT_ExportNoteWorker::SetUp()
 {
+    QDir().mkpath(QStringLiteral("test"));
     VNOTE_ALL_NOTES_MAP *notes = VNoteDataManager::instance()->getAllNotesInFolder();
     if (notes && !notes->notes.isEmpty()) {
         VNOTE_ITEMS_MAP *tmp = notes->notes.first();
@@ -33,6 +35,7 @@ void UT_ExportNoteWorker::SetUp()
 void UT_ExportNoteWorker::TearDown()
 {
     delete note;
+    QDir("test").removeRecursively();
 }
 
 UT_ExportNoteWorker::UT_ExportNoteWorker()

--- a/web-editor/scripts/css-inline-loader.mjs
+++ b/web-editor/scripts/css-inline-loader.mjs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Entry module for `node --import`: registers the CSS loader hook below so
+// that validate-envelope.mjs can import create-schema.js (which transitively
+// imports voice-block.css?inline) without a bundler.
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const hookURL = new URL('./css-loader-hook.mjs', import.meta.url);
+register(pathToFileURL(hookURL.pathname));

--- a/web-editor/scripts/css-loader-hook.mjs
+++ b/web-editor/scripts/css-loader-hook.mjs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ESM loader hook: intercepts Vite-style CSS inline imports so that the
+// validator can run under plain Node.js (no bundler). Returns an empty
+// string for the CSS module default export.
+export async function load(url, context, nextLoad) {
+  if (url.includes('.css')) {
+    return {
+      format: 'module',
+      source: 'export default ""',
+      shortCircuit: true,
+    };
+  }
+  return nextLoad(url, context);
+}


### PR DESCRIPTION
## 背景

补充语音记事本单元测试，提升函数覆盖率至100%（Refs: V-1329）。

本批为**第1批**，目标：修复现有5个失败用例，确保全部用例无失败无崩溃。

## 修改内容（6个文件）

1. **tests/src/common/ut_metadataparser.cpp** — 修复 `UT_MetaDataParser_makeMetaData_001`：`EXPECT_EQ` 类型不匹配（`const char*` vs `QVariant`），改用 `QByteArray` 比较。

2. **tests/src/task/ut_exportnoteworker.cpp** — 修复 `UT_ExportNoteWorker_exportAsHtml_001`：导出路径 `test` 目录未创建导致写文件失败。`SetUp` 创建目录，`TearDown` 清理。

3. **tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp** — 修复 `GeneratedEnvelopePassesSchemaValidator`：node 验证器导入 `voice-block.css?inline` 失败，添加 CSS inline loader。

4. **tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp** — 修复 `ComparesGoldenJsonAndPassesValidators`、`ConvertsVoiceBlockGoldenAndPassesValidators`：同上 CSS 导入问题。

5. **web-editor/scripts/css-inline-loader.mjs**（新增）— Node.js ESM loader 入口，注册 CSS 加载钩子，使 `validate-envelope.mjs` 可在无 bundler 环境下导入含 `.css?inline` 的模块。

6. **web-editor/scripts/css-loader-hook.mjs**（新增）— ESM load 钩子，将 CSS 导入返回为空字符串默认导出。

## 验证结果

- 编译通过（Debug 模式）
- 全部 **444 个测试用例通过，0 失败 0 崩溃**
- 函数覆盖率：63.9%（661/1034）— 本批仅修复失败用例，后续批次将补充新测试提升覆盖率

## 后续计划

后续将分批次（每批5~7个文件）补充缺失测试，逐步提升函数覆盖率至100%，等待本批合入后再继续。

## Summary by Sourcery

Fix failing unit tests for metadata parsing, note export, and tiptap migration validators, and introduce a Node.js CSS loader hook to allow schema validation scripts to run without a bundler.

Bug Fixes:
- Ensure UT_ExportNoteWorker tests create and clean up the test export directory to prevent file write failures.
- Align UT_MetaDataParser expectations with the QVariant metadata representation to avoid type mismatches in assertions.
- Update tiptap migration validator tests to invoke Node.js with a custom import loader for CSS-inlined modules so schema validation processes complete successfully.

Enhancements:
- Add a Node.js ESM CSS loader hook and loader entry script so validation scripts can import Vite-style CSS inline modules under plain Node.js.