### PR TITLE
fix(ut): decouple migration validator tests from npm install

### DIFF
--- a/tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationjsonbuilder.cpp
@@ -34,7 +34,9 @@ QString findRepoRoot()
 {
     QDir dir(QDir::currentPath());
     for (int depth = 0; depth < 8; ++depth) {
-        if (QFile::exists(dir.filePath(QStringLiteral("web-editor/scripts/validate-envelope.mjs")))) {
+        // 校验器现走 dist/validate-envelope.mjs 自包含 bundle，
+        // 不再依赖 web-editor/node_modules，以 dist 产物存在作为定位标志
+        if (QFile::exists(dir.filePath(QStringLiteral("web-editor/dist/validate-envelope.mjs")))) {
             return dir.absolutePath();
         }
         if (!dir.cdUp()) {
@@ -196,7 +198,9 @@ TEST(UT_MigrationJsonBuilder, GeneratedEnvelopePassesSchemaValidator)
     const QString path = writeTempEnvelope(envelope);
     QProcess validator;
     validator.setWorkingDirectory(findRepoRoot());
-    validator.start(QStringLiteral("node"), { QStringLiteral("--import"), QStringLiteral("./web-editor/scripts/css-inline-loader.mjs"), QStringLiteral("web-editor/scripts/validate-envelope.mjs"), path });
+    // dist/validate-envelope.mjs 已把 @tiptap/* 全部 inline，
+    // 无需 --import css-inline-loader.mjs，也不要求 npm install
+    validator.start(QStringLiteral("node"), { QStringLiteral("web-editor/dist/validate-envelope.mjs"), path });
     ASSERT_TRUE(validator.waitForFinished(30000));
     EXPECT_EQ(0, validator.exitCode()) << validator.readAllStandardError().toStdString();
     QFile::remove(path);

--- a/tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp
+++ b/tests/src/importolddata/tiptapmigration/ut_migrationnotedataconverter.cpp
@@ -63,7 +63,9 @@ QString findRepoRoot()
 {
     QDir dir(QDir::currentPath());
     for (int depth = 0; depth < 8; ++depth) {
-        if (QFile::exists(dir.filePath(QStringLiteral("web-editor/scripts/validate-envelope.mjs")))) {
+        // 校验器现走 dist/validate-envelope.mjs 自包含 bundle，
+        // 不再依赖 web-editor/node_modules，以 dist 产物存在作为定位标志
+        if (QFile::exists(dir.filePath(QStringLiteral("web-editor/dist/validate-envelope.mjs")))) {
             return dir.absolutePath();
         }
         if (!dir.cdUp()) {
@@ -91,7 +93,9 @@ void expectPassesValidators(const QJsonObject &envelope)
 
     QProcess validator;
     validator.setWorkingDirectory(repoRoot);
-    validator.start(QStringLiteral("node"), { QStringLiteral("--import"), QStringLiteral("./web-editor/scripts/css-inline-loader.mjs"), QStringLiteral("web-editor/scripts/validate-envelope.mjs"), envelopeFile.fileName() });
+    // dist/validate-envelope.mjs 已把 @tiptap/* 全部 inline，
+    // 无需 --import css-inline-loader.mjs，也不要求 npm install
+    validator.start(QStringLiteral("node"), { QStringLiteral("web-editor/dist/validate-envelope.mjs"), envelopeFile.fileName() });
     ASSERT_TRUE(validator.waitForFinished(30000));
     EXPECT_EQ(0, validator.exitCode()) << validator.readAllStandardError().toStdString();
 }

--- a/web-editor/dist/validate-envelope.mjs
+++ b/web-editor/dist/validate-envelope.mjs
@@ -1,0 +1,13549 @@
+#!/usr/bin/env node
+/*!
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Bundled runtime: @tiptap/* and ProseMirror (MIT).
+ */
+import fs from "node:fs";
+import process from "node:process";
+function OrderedMap(content) {
+  this.content = content;
+}
+OrderedMap.prototype = {
+  constructor: OrderedMap,
+  find: function(key) {
+    for (var i = 0; i < this.content.length; i += 2)
+      if (this.content[i] === key) return i;
+    return -1;
+  },
+  // :: (string) → ?any
+  // Retrieve the value stored under `key`, or return undefined when
+  // no such key exists.
+  get: function(key) {
+    var found2 = this.find(key);
+    return found2 == -1 ? void 0 : this.content[found2 + 1];
+  },
+  // :: (string, any, ?string) → OrderedMap
+  // Create a new map by replacing the value of `key` with a new
+  // value, or adding a binding to the end of the map. If `newKey` is
+  // given, the key of the binding will be replaced with that key.
+  update: function(key, value, newKey) {
+    var self = newKey && newKey != key ? this.remove(newKey) : this;
+    var found2 = self.find(key), content = self.content.slice();
+    if (found2 == -1) {
+      content.push(newKey || key, value);
+    } else {
+      content[found2 + 1] = value;
+      if (newKey) content[found2] = newKey;
+    }
+    return new OrderedMap(content);
+  },
+  // :: (string) → OrderedMap
+  // Return a map with the given key removed, if it existed.
+  remove: function(key) {
+    var found2 = this.find(key);
+    if (found2 == -1) return this;
+    var content = this.content.slice();
+    content.splice(found2, 2);
+    return new OrderedMap(content);
+  },
+  // :: (string, any) → OrderedMap
+  // Add a new key to the start of the map.
+  addToStart: function(key, value) {
+    return new OrderedMap([key, value].concat(this.remove(key).content));
+  },
+  // :: (string, any) → OrderedMap
+  // Add a new key to the end of the map.
+  addToEnd: function(key, value) {
+    var content = this.remove(key).content.slice();
+    content.push(key, value);
+    return new OrderedMap(content);
+  },
+  // :: (string, string, any) → OrderedMap
+  // Add a key after the given key. If `place` is not found, the new
+  // key is added to the end.
+  addBefore: function(place, key, value) {
+    var without = this.remove(key), content = without.content.slice();
+    var found2 = without.find(place);
+    content.splice(found2 == -1 ? content.length : found2, 0, key, value);
+    return new OrderedMap(content);
+  },
+  // :: ((key: string, value: any))
+  // Call the given function for each key/value pair in the map, in
+  // order.
+  forEach: function(f) {
+    for (var i = 0; i < this.content.length; i += 2)
+      f(this.content[i], this.content[i + 1]);
+  },
+  // :: (union<Object, OrderedMap>) → OrderedMap
+  // Create a new map by prepending the keys in this map that don't
+  // appear in `map` before the keys in `map`.
+  prepend: function(map) {
+    map = OrderedMap.from(map);
+    if (!map.size) return this;
+    return new OrderedMap(map.content.concat(this.subtract(map).content));
+  },
+  // :: (union<Object, OrderedMap>) → OrderedMap
+  // Create a new map by appending the keys in this map that don't
+  // appear in `map` after the keys in `map`.
+  append: function(map) {
+    map = OrderedMap.from(map);
+    if (!map.size) return this;
+    return new OrderedMap(this.subtract(map).content.concat(map.content));
+  },
+  // :: (union<Object, OrderedMap>) → OrderedMap
+  // Create a map containing all the keys in this map that don't
+  // appear in `map`.
+  subtract: function(map) {
+    var result = this;
+    map = OrderedMap.from(map);
+    for (var i = 0; i < map.content.length; i += 2)
+      result = result.remove(map.content[i]);
+    return result;
+  },
+  // :: () → Object
+  // Turn ordered map into a plain object.
+  toObject: function() {
+    var result = {};
+    this.forEach(function(key, value) {
+      result[key] = value;
+    });
+    return result;
+  },
+  // :: number
+  // The amount of keys in this map.
+  get size() {
+    return this.content.length >> 1;
+  }
+};
+OrderedMap.from = function(value) {
+  if (value instanceof OrderedMap) return value;
+  var content = [];
+  if (value) for (var prop in value) content.push(prop, value[prop]);
+  return new OrderedMap(content);
+};
+function findDiffStart(a, b, pos) {
+  for (let i = 0; ; i++) {
+    if (i == a.childCount || i == b.childCount)
+      return a.childCount == b.childCount ? null : pos;
+    let childA = a.child(i), childB = b.child(i);
+    if (childA == childB) {
+      pos += childA.nodeSize;
+      continue;
+    }
+    if (!childA.sameMarkup(childB))
+      return pos;
+    if (childA.isText && childA.text != childB.text) {
+      let tA = childA.text, tB = childB.text, j = 0;
+      for (; tA[j] == tB[j]; j++)
+        pos++;
+      if (j && j < tA.length && j < tB.length && surrogateHigh(tA.charCodeAt(j - 1)) && surrogateLow(tA.charCodeAt(j)))
+        pos--;
+      return pos;
+    }
+    if (childA.content.size || childB.content.size) {
+      let inner = findDiffStart(childA.content, childB.content, pos + 1);
+      if (inner != null)
+        return inner;
+    }
+    pos += childA.nodeSize;
+  }
+}
+function findDiffEnd(a, b, posA, posB) {
+  for (let iA = a.childCount, iB = b.childCount; ; ) {
+    if (iA == 0 || iB == 0)
+      return iA == iB ? null : { a: posA, b: posB };
+    let childA = a.child(--iA), childB = b.child(--iB), size = childA.nodeSize;
+    if (childA == childB) {
+      posA -= size;
+      posB -= size;
+      continue;
+    }
+    if (!childA.sameMarkup(childB))
+      return { a: posA, b: posB };
+    if (childA.isText && childA.text != childB.text) {
+      let tA = childA.text, tB = childB.text, iA2 = tA.length, iB2 = tB.length;
+      while (iA2 > 0 && iB2 > 0 && tA[iA2 - 1] == tB[iB2 - 1]) {
+        iA2--;
+        iB2--;
+        posA--;
+        posB--;
+      }
+      if (iA2 && iB2 && iA2 < tA.length && surrogateHigh(tA.charCodeAt(iA2 - 1)) && surrogateLow(tA.charCodeAt(iA2))) {
+        posA++;
+        posB++;
+      }
+      return { a: posA, b: posB };
+    }
+    if (childA.content.size || childB.content.size) {
+      let inner = findDiffEnd(childA.content, childB.content, posA - 1, posB - 1);
+      if (inner)
+        return inner;
+    }
+    posA -= size;
+    posB -= size;
+  }
+}
+function surrogateLow(ch) {
+  return ch >= 56320 && ch < 57344;
+}
+function surrogateHigh(ch) {
+  return ch >= 55296 && ch < 56320;
+}
+class Fragment {
+  /**
+  @internal
+  */
+  constructor(content, size) {
+    this.content = content;
+    this.size = size || 0;
+    if (size == null)
+      for (let i = 0; i < content.length; i++)
+        this.size += content[i].nodeSize;
+  }
+  /**
+  Invoke a callback for all descendant nodes between the given two
+  positions (relative to start of this fragment). Doesn't descend
+  into a node when the callback returns `false`.
+  */
+  nodesBetween(from, to, f, nodeStart = 0, parent) {
+    for (let i = 0, pos = 0; pos < to; i++) {
+      let child = this.content[i], end = pos + child.nodeSize;
+      if (end > from && f(child, nodeStart + pos, parent || null, i) !== false && child.content.size) {
+        let start = pos + 1;
+        child.nodesBetween(Math.max(0, from - start), Math.min(child.content.size, to - start), f, nodeStart + start);
+      }
+      pos = end;
+    }
+  }
+  /**
+  Call the given callback for every descendant node. `pos` will be
+  relative to the start of the fragment. The callback may return
+  `false` to prevent traversal of a given node's children.
+  */
+  descendants(f) {
+    this.nodesBetween(0, this.size, f);
+  }
+  /**
+  Extract the text between `from` and `to`. See the same method on
+  [`Node`](https://prosemirror.net/docs/ref/#model.Node.textBetween).
+  */
+  textBetween(from, to, blockSeparator, leafText) {
+    let text = "", first2 = true;
+    this.nodesBetween(from, to, (node, pos) => {
+      let nodeText = node.isText ? node.text.slice(Math.max(from, pos) - pos, to - pos) : !node.isLeaf ? "" : leafText ? typeof leafText === "function" ? leafText(node) : leafText : node.type.spec.leafText ? node.type.spec.leafText(node) : "";
+      if (node.isBlock && (node.isLeaf && nodeText || node.isTextblock) && blockSeparator) {
+        if (first2)
+          first2 = false;
+        else
+          text += blockSeparator;
+      }
+      text += nodeText;
+    }, 0);
+    return text;
+  }
+  /**
+  Create a new fragment containing the combined content of this
+  fragment and the other.
+  */
+  append(other) {
+    if (!other.size)
+      return this;
+    if (!this.size)
+      return other;
+    let last = this.lastChild, first2 = other.firstChild, content = this.content.slice(), i = 0;
+    if (last.isText && last.sameMarkup(first2)) {
+      content[content.length - 1] = last.withText(last.text + first2.text);
+      i = 1;
+    }
+    for (; i < other.content.length; i++)
+      content.push(other.content[i]);
+    return new Fragment(content, this.size + other.size);
+  }
+  /**
+  Cut out the sub-fragment between the two given positions.
+  */
+  cut(from, to = this.size) {
+    if (from == 0 && to == this.size)
+      return this;
+    let result = [], size = 0;
+    if (to > from)
+      for (let i = 0, pos = 0; pos < to; i++) {
+        let child = this.content[i], end = pos + child.nodeSize;
+        if (end > from) {
+          if (pos < from || end > to) {
+            if (child.isText)
+              child = child.cut(Math.max(0, from - pos), Math.min(child.text.length, to - pos));
+            else
+              child = child.cut(Math.max(0, from - pos - 1), Math.min(child.content.size, to - pos - 1));
+          }
+          result.push(child);
+          size += child.nodeSize;
+        }
+        pos = end;
+      }
+    return new Fragment(result, size);
+  }
+  /**
+  @internal
+  */
+  cutByIndex(from, to) {
+    if (from == to)
+      return Fragment.empty;
+    if (from == 0 && to == this.content.length)
+      return this;
+    return new Fragment(this.content.slice(from, to));
+  }
+  /**
+  Create a new fragment in which the node at the given index is
+  replaced by the given node.
+  */
+  replaceChild(index, node) {
+    let current = this.content[index];
+    if (current == node)
+      return this;
+    let copy2 = this.content.slice();
+    let size = this.size + node.nodeSize - current.nodeSize;
+    copy2[index] = node;
+    return new Fragment(copy2, size);
+  }
+  /**
+  Create a new fragment by prepending the given node to this
+  fragment.
+  */
+  addToStart(node) {
+    return new Fragment([node].concat(this.content), this.size + node.nodeSize);
+  }
+  /**
+  Create a new fragment by appending the given node to this
+  fragment.
+  */
+  addToEnd(node) {
+    return new Fragment(this.content.concat(node), this.size + node.nodeSize);
+  }
+  /**
+  Compare this fragment to another one.
+  */
+  eq(other) {
+    if (this.content.length != other.content.length)
+      return false;
+    for (let i = 0; i < this.content.length; i++)
+      if (!this.content[i].eq(other.content[i]))
+        return false;
+    return true;
+  }
+  /**
+  The first child of the fragment, or `null` if it is empty.
+  */
+  get firstChild() {
+    return this.content.length ? this.content[0] : null;
+  }
+  /**
+  The last child of the fragment, or `null` if it is empty.
+  */
+  get lastChild() {
+    return this.content.length ? this.content[this.content.length - 1] : null;
+  }
+  /**
+  The number of child nodes in this fragment.
+  */
+  get childCount() {
+    return this.content.length;
+  }
+  /**
+  Get the child node at the given index. Raise an error when the
+  index is out of range.
+  */
+  child(index) {
+    let found2 = this.content[index];
+    if (!found2)
+      throw new RangeError("Index " + index + " out of range for " + this);
+    return found2;
+  }
+  /**
+  Get the child node at the given index, if it exists.
+  */
+  maybeChild(index) {
+    return this.content[index] || null;
+  }
+  /**
+  Call `f` for every child node, passing the node, its offset
+  into this parent node, and its index.
+  */
+  forEach(f) {
+    for (let i = 0, p = 0; i < this.content.length; i++) {
+      let child = this.content[i];
+      f(child, p, i);
+      p += child.nodeSize;
+    }
+  }
+  /**
+  Find the first position at which this fragment and another
+  fragment differ, or `null` if they are the same.
+  */
+  findDiffStart(other, pos = 0) {
+    return findDiffStart(this, other, pos);
+  }
+  /**
+  Find the first position, searching from the end, at which this
+  fragment and the given fragment differ, or `null` if they are
+  the same. Since this position will not be the same in both
+  nodes, an object with two separate positions is returned.
+  */
+  findDiffEnd(other, pos = this.size, otherPos = other.size) {
+    return findDiffEnd(this, other, pos, otherPos);
+  }
+  /**
+  Find the index and inner offset corresponding to a given relative
+  position in this fragment. The result object will be reused
+  (overwritten) the next time the function is called. @internal
+  */
+  findIndex(pos) {
+    if (pos == 0)
+      return retIndex(0, pos);
+    if (pos == this.size)
+      return retIndex(this.content.length, pos);
+    if (pos > this.size || pos < 0)
+      throw new RangeError(`Position ${pos} outside of fragment (${this})`);
+    for (let i = 0, curPos = 0; ; i++) {
+      let cur = this.child(i), end = curPos + cur.nodeSize;
+      if (end >= pos) {
+        if (end == pos)
+          return retIndex(i + 1, end);
+        return retIndex(i, curPos);
+      }
+      curPos = end;
+    }
+  }
+  /**
+  Return a debugging string that describes this fragment.
+  */
+  toString() {
+    return "<" + this.toStringInner() + ">";
+  }
+  /**
+  @internal
+  */
+  toStringInner() {
+    return this.content.join(", ");
+  }
+  /**
+  Create a JSON-serializeable representation of this fragment.
+  */
+  toJSON() {
+    return this.content.length ? this.content.map((n) => n.toJSON()) : null;
+  }
+  /**
+  Deserialize a fragment from its JSON representation.
+  */
+  static fromJSON(schema, value) {
+    if (!value)
+      return Fragment.empty;
+    if (!Array.isArray(value))
+      throw new RangeError("Invalid input for Fragment.fromJSON");
+    return Fragment.fromArray(value.map(schema.nodeFromJSON));
+  }
+  /**
+  Build a fragment from an array of nodes. Ensures that adjacent
+  text nodes with the same marks are joined together.
+  */
+  static fromArray(array) {
+    if (!array.length)
+      return Fragment.empty;
+    let joined, size = 0;
+    for (let i = 0; i < array.length; i++) {
+      let node = array[i];
+      size += node.nodeSize;
+      if (i && node.isText && array[i - 1].sameMarkup(node)) {
+        if (!joined)
+          joined = array.slice(0, i);
+        joined[joined.length - 1] = node.withText(joined[joined.length - 1].text + node.text);
+      } else if (joined) {
+        joined.push(node);
+      }
+    }
+    return new Fragment(joined || array, size);
+  }
+  /**
+  Create a fragment from something that can be interpreted as a
+  set of nodes. For `null`, it returns the empty fragment. For a
+  fragment, the fragment itself. For a node or array of nodes, a
+  fragment containing those nodes.
+  */
+  static from(nodes) {
+    if (!nodes)
+      return Fragment.empty;
+    if (nodes instanceof Fragment)
+      return nodes;
+    if (Array.isArray(nodes))
+      return this.fromArray(nodes);
+    if (nodes.attrs)
+      return new Fragment([nodes], nodes.nodeSize);
+    throw new RangeError("Can not convert " + nodes + " to a Fragment" + (nodes.nodesBetween ? " (looks like multiple versions of prosemirror-model were loaded)" : ""));
+  }
+}
+Fragment.empty = new Fragment([], 0);
+const found = { index: 0, offset: 0 };
+function retIndex(index, offset) {
+  found.index = index;
+  found.offset = offset;
+  return found;
+}
+function compareDeep(a, b) {
+  if (a === b)
+    return true;
+  if (!(a && typeof a == "object") || !(b && typeof b == "object"))
+    return false;
+  let array = Array.isArray(a);
+  if (Array.isArray(b) != array)
+    return false;
+  if (array) {
+    if (a.length != b.length)
+      return false;
+    for (let i = 0; i < a.length; i++)
+      if (!compareDeep(a[i], b[i]))
+        return false;
+  } else {
+    for (let p in a)
+      if (!(p in b) || !compareDeep(a[p], b[p]))
+        return false;
+    for (let p in b)
+      if (!(p in a))
+        return false;
+  }
+  return true;
+}
+let Mark$1 = class Mark {
+  /**
+  @internal
+  */
+  constructor(type, attrs) {
+    this.type = type;
+    this.attrs = attrs;
+  }
+  /**
+  Given a set of marks, create a new set which contains this one as
+  well, in the right position. If this mark is already in the set,
+  the set itself is returned. If any marks that are set to be
+  [exclusive](https://prosemirror.net/docs/ref/#model.MarkSpec.excludes) with this mark are present,
+  those are replaced by this one.
+  */
+  addToSet(set) {
+    let copy2, placed = false;
+    for (let i = 0; i < set.length; i++) {
+      let other = set[i];
+      if (this.eq(other))
+        return set;
+      if (this.type.excludes(other.type)) {
+        if (!copy2)
+          copy2 = set.slice(0, i);
+      } else if (other.type.excludes(this.type)) {
+        return set;
+      } else {
+        if (!placed && other.type.rank > this.type.rank) {
+          if (!copy2)
+            copy2 = set.slice(0, i);
+          copy2.push(this);
+          placed = true;
+        }
+        if (copy2)
+          copy2.push(other);
+      }
+    }
+    if (!copy2)
+      copy2 = set.slice();
+    if (!placed)
+      copy2.push(this);
+    return copy2;
+  }
+  /**
+  Remove this mark from the given set, returning a new set. If this
+  mark is not in the set, the set itself is returned.
+  */
+  removeFromSet(set) {
+    for (let i = 0; i < set.length; i++)
+      if (this.eq(set[i]))
+        return set.slice(0, i).concat(set.slice(i + 1));
+    return set;
+  }
+  /**
+  Test whether this mark is in the given set of marks.
+  */
+  isInSet(set) {
+    for (let i = 0; i < set.length; i++)
+      if (this.eq(set[i]))
+        return true;
+    return false;
+  }
+  /**
+  Test whether this mark has the same type and attributes as
+  another mark.
+  */
+  eq(other) {
+    return this == other || this.type == other.type && compareDeep(this.attrs, other.attrs);
+  }
+  /**
+  Convert this mark to a JSON-serializeable representation.
+  */
+  toJSON() {
+    let obj = { type: this.type.name };
+    for (let _ in this.attrs) {
+      obj.attrs = this.attrs;
+      break;
+    }
+    return obj;
+  }
+  /**
+  Deserialize a mark from JSON.
+  */
+  static fromJSON(schema, json) {
+    if (!json)
+      throw new RangeError("Invalid input for Mark.fromJSON");
+    let type = schema.marks[json.type];
+    if (!type)
+      throw new RangeError(`There is no mark type ${json.type} in this schema`);
+    let mark = type.create(json.attrs);
+    type.checkAttrs(mark.attrs);
+    return mark;
+  }
+  /**
+  Test whether two sets of marks are identical.
+  */
+  static sameSet(a, b) {
+    if (a == b)
+      return true;
+    if (a.length != b.length)
+      return false;
+    for (let i = 0; i < a.length; i++)
+      if (!a[i].eq(b[i]))
+        return false;
+    return true;
+  }
+  /**
+  Create a properly sorted mark set from null, a single mark, or an
+  unsorted array of marks.
+  */
+  static setFrom(marks) {
+    if (!marks || Array.isArray(marks) && marks.length == 0)
+      return Mark.none;
+    if (marks instanceof Mark)
+      return [marks];
+    let copy2 = marks.slice();
+    copy2.sort((a, b) => a.type.rank - b.type.rank);
+    return copy2;
+  }
+};
+Mark$1.none = [];
+class ReplaceError extends Error {
+}
+class Slice {
+  /**
+  Create a slice. When specifying a non-zero open depth, you must
+  make sure that there are nodes of at least that depth at the
+  appropriate side of the fragment—i.e. if the fragment is an
+  empty paragraph node, `openStart` and `openEnd` can't be greater
+  than 1.
+  
+  It is not necessary for the content of open nodes to conform to
+  the schema's content constraints, though it should be a valid
+  start/end/middle for such a node, depending on which sides are
+  open.
+  */
+  constructor(content, openStart, openEnd) {
+    this.content = content;
+    this.openStart = openStart;
+    this.openEnd = openEnd;
+  }
+  /**
+  The size this slice would add when inserted into a document.
+  */
+  get size() {
+    return this.content.size - this.openStart - this.openEnd;
+  }
+  /**
+  @internal
+  */
+  insertAt(pos, fragment) {
+    let content = insertInto(this.content, pos + this.openStart, fragment, this.openStart + 1, this.openEnd + 1);
+    return content && new Slice(content, this.openStart, this.openEnd);
+  }
+  /**
+  @internal
+  */
+  removeBetween(from, to) {
+    return new Slice(removeRange(this.content, from + this.openStart, to + this.openStart), this.openStart, this.openEnd);
+  }
+  /**
+  Tests whether this slice is equal to another slice.
+  */
+  eq(other) {
+    return this.content.eq(other.content) && this.openStart == other.openStart && this.openEnd == other.openEnd;
+  }
+  /**
+  @internal
+  */
+  toString() {
+    return this.content + "(" + this.openStart + "," + this.openEnd + ")";
+  }
+  /**
+  Convert a slice to a JSON-serializable representation.
+  */
+  toJSON() {
+    if (!this.content.size)
+      return null;
+    let json = { content: this.content.toJSON() };
+    if (this.openStart > 0)
+      json.openStart = this.openStart;
+    if (this.openEnd > 0)
+      json.openEnd = this.openEnd;
+    return json;
+  }
+  /**
+  Deserialize a slice from its JSON representation.
+  */
+  static fromJSON(schema, json) {
+    if (!json)
+      return Slice.empty;
+    let openStart = json.openStart || 0, openEnd = json.openEnd || 0;
+    if (typeof openStart != "number" || typeof openEnd != "number")
+      throw new RangeError("Invalid input for Slice.fromJSON");
+    return new Slice(Fragment.fromJSON(schema, json.content), openStart, openEnd);
+  }
+  /**
+  Create a slice from a fragment by taking the maximum possible
+  open value on both side of the fragment.
+  */
+  static maxOpen(fragment, openIsolating = true) {
+    let openStart = 0, openEnd = 0;
+    for (let n = fragment.firstChild; n && !n.isLeaf && (openIsolating || !n.type.spec.isolating); n = n.firstChild)
+      openStart++;
+    for (let n = fragment.lastChild; n && !n.isLeaf && (openIsolating || !n.type.spec.isolating); n = n.lastChild)
+      openEnd++;
+    return new Slice(fragment, openStart, openEnd);
+  }
+}
+Slice.empty = new Slice(Fragment.empty, 0, 0);
+function removeRange(content, from, to) {
+  let { index, offset } = content.findIndex(from), child = content.maybeChild(index);
+  let { index: indexTo, offset: offsetTo } = content.findIndex(to);
+  if (offset == from || child.isText) {
+    if (offsetTo != to && !content.child(indexTo).isText)
+      throw new RangeError("Removing non-flat range");
+    return content.cut(0, from).append(content.cut(to));
+  }
+  if (index != indexTo)
+    throw new RangeError("Removing non-flat range");
+  return content.replaceChild(index, child.copy(removeRange(child.content, from - offset - 1, to - offset - 1)));
+}
+function insertInto(content, dist, insert, openStart, openEnd, parent) {
+  let { index, offset } = content.findIndex(dist), child = content.maybeChild(index);
+  if (offset == dist || child.isText) {
+    if (parent && openStart <= 0 && openEnd <= 0 && !parent.canReplace(index, index, insert))
+      return null;
+    return content.cut(0, dist).append(insert).append(content.cut(dist));
+  }
+  let inner = insertInto(child.content, dist - offset - 1, insert, index == 0 ? openStart - 1 : 0, index == content.childCount - 1 ? openEnd - 1 : 0, child);
+  return inner && content.replaceChild(index, child.copy(inner));
+}
+function replace($from, $to, slice) {
+  if (slice.openStart > $from.depth)
+    throw new ReplaceError("Inserted content deeper than insertion position");
+  if ($from.depth - slice.openStart != $to.depth - slice.openEnd)
+    throw new ReplaceError("Inconsistent open depths");
+  return replaceOuter($from, $to, slice, 0);
+}
+function replaceOuter($from, $to, slice, depth) {
+  let index = $from.index(depth), node = $from.node(depth);
+  if (index == $to.index(depth) && depth < $from.depth - slice.openStart) {
+    let inner = replaceOuter($from, $to, slice, depth + 1);
+    return node.copy(node.content.replaceChild(index, inner));
+  } else if (!slice.content.size) {
+    return close(node, replaceTwoWay($from, $to, depth));
+  } else if (!slice.openStart && !slice.openEnd && $from.depth == depth && $to.depth == depth) {
+    let parent = $from.parent, content = parent.content;
+    return close(parent, content.cut(0, $from.parentOffset).append(slice.content).append(content.cut($to.parentOffset)));
+  } else {
+    let { start, end } = prepareSliceForReplace(slice, $from);
+    return close(node, replaceThreeWay($from, start, end, $to, depth));
+  }
+}
+function checkJoin(main, sub) {
+  if (!sub.type.compatibleContent(main.type))
+    throw new ReplaceError("Cannot join " + sub.type.name + " onto " + main.type.name);
+}
+function joinable$1($before, $after, depth) {
+  let node = $before.node(depth);
+  checkJoin(node, $after.node(depth));
+  return node;
+}
+function addNode(child, target) {
+  let last = target.length - 1;
+  if (last >= 0 && child.isText && child.sameMarkup(target[last]))
+    target[last] = child.withText(target[last].text + child.text);
+  else
+    target.push(child);
+}
+function addRange($start, $end, depth, target) {
+  let node = ($end || $start).node(depth);
+  let startIndex = 0, endIndex = $end ? $end.index(depth) : node.childCount;
+  if ($start) {
+    startIndex = $start.index(depth);
+    if ($start.depth > depth) {
+      startIndex++;
+    } else if ($start.textOffset) {
+      addNode($start.nodeAfter, target);
+      startIndex++;
+    }
+  }
+  for (let i = startIndex; i < endIndex; i++)
+    addNode(node.child(i), target);
+  if ($end && $end.depth == depth && $end.textOffset)
+    addNode($end.nodeBefore, target);
+}
+function close(node, content) {
+  if (!node.type.validContent(content))
+    throw new ReplaceError("Invalid content for node " + node.type.name);
+  return node.copy(content);
+}
+function replaceThreeWay($from, $start, $end, $to, depth) {
+  let openStart = $from.depth > depth && joinable$1($from, $start, depth + 1);
+  let openEnd = $to.depth > depth && joinable$1($end, $to, depth + 1);
+  let content = [];
+  addRange(null, $from, depth, content);
+  if (openStart && openEnd && $start.index(depth) == $end.index(depth)) {
+    checkJoin(openStart, openEnd);
+    addNode(close(openStart, replaceThreeWay($from, $start, $end, $to, depth + 1)), content);
+  } else {
+    if (openStart)
+      addNode(close(openStart, replaceTwoWay($from, $start, depth + 1)), content);
+    addRange($start, $end, depth, content);
+    if (openEnd)
+      addNode(close(openEnd, replaceTwoWay($end, $to, depth + 1)), content);
+  }
+  addRange($to, null, depth, content);
+  return new Fragment(content);
+}
+function replaceTwoWay($from, $to, depth) {
+  let content = [];
+  addRange(null, $from, depth, content);
+  if ($from.depth > depth) {
+    let type = joinable$1($from, $to, depth + 1);
+    addNode(close(type, replaceTwoWay($from, $to, depth + 1)), content);
+  }
+  addRange($to, null, depth, content);
+  return new Fragment(content);
+}
+function prepareSliceForReplace(slice, $along) {
+  let extra = $along.depth - slice.openStart, parent = $along.node(extra);
+  let node = parent.copy(slice.content);
+  for (let i = extra - 1; i >= 0; i--)
+    node = $along.node(i).copy(Fragment.from(node));
+  return {
+    start: node.resolveNoCache(slice.openStart + extra),
+    end: node.resolveNoCache(node.content.size - slice.openEnd - extra)
+  };
+}
+class ResolvedPos {
+  /**
+  @internal
+  */
+  constructor(pos, path, parentOffset) {
+    this.pos = pos;
+    this.path = path;
+    this.parentOffset = parentOffset;
+    this.depth = path.length / 3 - 1;
+  }
+  /**
+  @internal
+  */
+  resolveDepth(val) {
+    if (val == null)
+      return this.depth;
+    if (val < 0)
+      return this.depth + val;
+    return val;
+  }
+  /**
+  The parent node that the position points into. Note that even if
+  a position points into a text node, that node is not considered
+  the parent—text nodes are ‘flat’ in this model, and have no content.
+  */
+  get parent() {
+    return this.node(this.depth);
+  }
+  /**
+  The root node in which the position was resolved.
+  */
+  get doc() {
+    return this.node(0);
+  }
+  /**
+  The ancestor node at the given level. `p.node(p.depth)` is the
+  same as `p.parent`.
+  */
+  node(depth) {
+    return this.path[this.resolveDepth(depth) * 3];
+  }
+  /**
+  The index into the ancestor at the given level. If this points
+  at the 3rd node in the 2nd paragraph on the top level, for
+  example, `p.index(0)` is 1 and `p.index(1)` is 2.
+  */
+  index(depth) {
+    return this.path[this.resolveDepth(depth) * 3 + 1];
+  }
+  /**
+  The index pointing after this position into the ancestor at the
+  given level.
+  */
+  indexAfter(depth) {
+    depth = this.resolveDepth(depth);
+    return this.index(depth) + (depth == this.depth && !this.textOffset ? 0 : 1);
+  }
+  /**
+  The (absolute) position at the start of the node at the given
+  level.
+  */
+  start(depth) {
+    depth = this.resolveDepth(depth);
+    return depth == 0 ? 0 : this.path[depth * 3 - 1] + 1;
+  }
+  /**
+  The (absolute) position at the end of the node at the given
+  level.
+  */
+  end(depth) {
+    depth = this.resolveDepth(depth);
+    return this.start(depth) + this.node(depth).content.size;
+  }
+  /**
+  The (absolute) position directly before the wrapping node at the
+  given level, or, when `depth` is `this.depth + 1`, the original
+  position.
+  */
+  before(depth) {
+    depth = this.resolveDepth(depth);
+    if (!depth)
+      throw new RangeError("There is no position before the top-level node");
+    return depth == this.depth + 1 ? this.pos : this.path[depth * 3 - 1];
+  }
+  /**
+  The (absolute) position directly after the wrapping node at the
+  given level, or the original position when `depth` is `this.depth + 1`.
+  */
+  after(depth) {
+    depth = this.resolveDepth(depth);
+    if (!depth)
+      throw new RangeError("There is no position after the top-level node");
+    return depth == this.depth + 1 ? this.pos : this.path[depth * 3 - 1] + this.path[depth * 3].nodeSize;
+  }
+  /**
+  When this position points into a text node, this returns the
+  distance between the position and the start of the text node.
+  Will be zero for positions that point between nodes.
+  */
+  get textOffset() {
+    return this.pos - this.path[this.path.length - 1];
+  }
+  /**
+  Get the node directly after the position, if any. If the position
+  points into a text node, only the part of that node after the
+  position is returned.
+  */
+  get nodeAfter() {
+    let parent = this.parent, index = this.index(this.depth);
+    if (index == parent.childCount)
+      return null;
+    let dOff = this.pos - this.path[this.path.length - 1], child = parent.child(index);
+    return dOff ? parent.child(index).cut(dOff) : child;
+  }
+  /**
+  Get the node directly before the position, if any. If the
+  position points into a text node, only the part of that node
+  before the position is returned.
+  */
+  get nodeBefore() {
+    let index = this.index(this.depth);
+    let dOff = this.pos - this.path[this.path.length - 1];
+    if (dOff)
+      return this.parent.child(index).cut(0, dOff);
+    return index == 0 ? null : this.parent.child(index - 1);
+  }
+  /**
+  Get the position at the given index in the parent node at the
+  given depth (which defaults to `this.depth`).
+  */
+  posAtIndex(index, depth) {
+    depth = this.resolveDepth(depth);
+    let node = this.path[depth * 3], pos = depth == 0 ? 0 : this.path[depth * 3 - 1] + 1;
+    for (let i = 0; i < index; i++)
+      pos += node.child(i).nodeSize;
+    return pos;
+  }
+  /**
+  Get the marks at this position, factoring in the surrounding
+  marks' [`inclusive`](https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive) property. If the
+  position is at the start of a non-empty node, the marks of the
+  node after it (if any) are returned.
+  */
+  marks() {
+    let parent = this.parent, index = this.index();
+    if (parent.content.size == 0)
+      return Mark$1.none;
+    if (this.textOffset)
+      return parent.child(index).marks;
+    let main = parent.maybeChild(index - 1), other = parent.maybeChild(index);
+    if (!main) {
+      let tmp = main;
+      main = other;
+      other = tmp;
+    }
+    let marks = main.marks;
+    for (var i = 0; i < marks.length; i++)
+      if (marks[i].type.spec.inclusive === false && (!other || !marks[i].isInSet(other.marks)))
+        marks = marks[i--].removeFromSet(marks);
+    return marks;
+  }
+  /**
+  Get the marks after the current position, if any, except those
+  that are non-inclusive and not present at position `$end`. This
+  is mostly useful for getting the set of marks to preserve after a
+  deletion. Will return `null` if this position is at the end of
+  its parent node or its parent node isn't a textblock (in which
+  case no marks should be preserved).
+  */
+  marksAcross($end) {
+    let after = this.parent.maybeChild(this.index());
+    if (!after || !after.isInline)
+      return null;
+    let marks = after.marks, next = $end.parent.maybeChild($end.index());
+    for (var i = 0; i < marks.length; i++)
+      if (marks[i].type.spec.inclusive === false && (!next || !marks[i].isInSet(next.marks)))
+        marks = marks[i--].removeFromSet(marks);
+    return marks;
+  }
+  /**
+  The depth up to which this position and the given (non-resolved)
+  position share the same parent nodes.
+  */
+  sharedDepth(pos) {
+    for (let depth = this.depth; depth > 0; depth--)
+      if (this.start(depth) <= pos && this.end(depth) >= pos)
+        return depth;
+    return 0;
+  }
+  /**
+  Returns a range based on the place where this position and the
+  given position diverge around block content. If both point into
+  the same textblock, for example, a range around that textblock
+  will be returned. If they point into different blocks, the range
+  around those blocks in their shared ancestor is returned. You can
+  pass in an optional predicate that will be called with a parent
+  node to see if a range into that parent is acceptable.
+  */
+  blockRange(other = this, pred) {
+    if (other.pos < this.pos)
+      return other.blockRange(this);
+    for (let d = this.depth - (this.parent.inlineContent || this.pos == other.pos ? 1 : 0); d >= 0; d--)
+      if (other.pos <= this.end(d) && (!pred || pred(this.node(d))))
+        return new NodeRange(this, other, d);
+    return null;
+  }
+  /**
+  Query whether the given position shares the same parent node.
+  */
+  sameParent(other) {
+    return this.pos - this.parentOffset == other.pos - other.parentOffset;
+  }
+  /**
+  Return the greater of this and the given position.
+  */
+  max(other) {
+    return other.pos > this.pos ? other : this;
+  }
+  /**
+  Return the smaller of this and the given position.
+  */
+  min(other) {
+    return other.pos < this.pos ? other : this;
+  }
+  /**
+  @internal
+  */
+  toString() {
+    let str = "";
+    for (let i = 1; i <= this.depth; i++)
+      str += (str ? "/" : "") + this.node(i).type.name + "_" + this.index(i - 1);
+    return str + ":" + this.parentOffset;
+  }
+  /**
+  @internal
+  */
+  static resolve(doc, pos) {
+    if (!(pos >= 0 && pos <= doc.content.size))
+      throw new RangeError("Position " + pos + " out of range");
+    let path = [];
+    let start = 0, parentOffset = pos;
+    for (let node = doc; ; ) {
+      let { index, offset } = node.content.findIndex(parentOffset);
+      let rem = parentOffset - offset;
+      path.push(node, index, start + offset);
+      if (!rem)
+        break;
+      node = node.child(index);
+      if (node.isText)
+        break;
+      parentOffset = rem - 1;
+      start += offset + 1;
+    }
+    return new ResolvedPos(pos, path, parentOffset);
+  }
+  /**
+  @internal
+  */
+  static resolveCached(doc, pos) {
+    let cache = resolveCache.get(doc);
+    if (cache) {
+      for (let i = 0; i < cache.elts.length; i++) {
+        let elt = cache.elts[i];
+        if (elt.pos == pos)
+          return elt;
+      }
+    } else {
+      resolveCache.set(doc, cache = new ResolveCache());
+    }
+    let result = cache.elts[cache.i] = ResolvedPos.resolve(doc, pos);
+    cache.i = (cache.i + 1) % resolveCacheSize;
+    return result;
+  }
+}
+class ResolveCache {
+  constructor() {
+    this.elts = [];
+    this.i = 0;
+  }
+}
+const resolveCacheSize = 12, resolveCache = /* @__PURE__ */ new WeakMap();
+class NodeRange {
+  /**
+  Construct a node range. `$from` and `$to` should point into the
+  same node until at least the given `depth`, since a node range
+  denotes an adjacent set of nodes in a single parent node.
+  */
+  constructor($from, $to, depth) {
+    this.$from = $from;
+    this.$to = $to;
+    this.depth = depth;
+  }
+  /**
+  The position at the start of the range.
+  */
+  get start() {
+    return this.$from.before(this.depth + 1);
+  }
+  /**
+  The position at the end of the range.
+  */
+  get end() {
+    return this.$to.after(this.depth + 1);
+  }
+  /**
+  The parent node that the range points into.
+  */
+  get parent() {
+    return this.$from.node(this.depth);
+  }
+  /**
+  The start index of the range in the parent node.
+  */
+  get startIndex() {
+    return this.$from.index(this.depth);
+  }
+  /**
+  The end index of the range in the parent node.
+  */
+  get endIndex() {
+    return this.$to.indexAfter(this.depth);
+  }
+}
+const emptyAttrs = /* @__PURE__ */ Object.create(null);
+class Node {
+  /**
+  @internal
+  */
+  constructor(type, attrs, content, marks = Mark$1.none) {
+    this.type = type;
+    this.attrs = attrs;
+    this.marks = marks;
+    this.content = content || Fragment.empty;
+  }
+  /**
+  The array of this node's child nodes.
+  */
+  get children() {
+    return this.content.content;
+  }
+  /**
+  The size of this node, as defined by the integer-based [indexing
+  scheme](https://prosemirror.net/docs/guide/#doc.indexing). For text nodes, this is the
+  amount of characters. For other leaf nodes, it is one. For
+  non-leaf nodes, it is the size of the content plus two (the
+  start and end token).
+  */
+  get nodeSize() {
+    return this.isLeaf ? 1 : 2 + this.content.size;
+  }
+  /**
+  The number of children that the node has.
+  */
+  get childCount() {
+    return this.content.childCount;
+  }
+  /**
+  Get the child node at the given index. Raises an error when the
+  index is out of range.
+  */
+  child(index) {
+    return this.content.child(index);
+  }
+  /**
+  Get the child node at the given index, if it exists.
+  */
+  maybeChild(index) {
+    return this.content.maybeChild(index);
+  }
+  /**
+  Call `f` for every child node, passing the node, its offset
+  into this parent node, and its index.
+  */
+  forEach(f) {
+    this.content.forEach(f);
+  }
+  /**
+  Invoke a callback for all descendant nodes recursively overlapping
+  the given two positions that are relative to start of this
+  node's content. This includes all ancestors of the nodes
+  containing the two positions. The callback is invoked with the
+  node, its position relative to the original node (method receiver),
+  its parent node, and its child index. When the callback returns
+  false for a given node, that node's children will not be
+  recursed over. The last parameter can be used to specify a
+  starting position to count from.
+  */
+  nodesBetween(from, to, f, startPos = 0) {
+    this.content.nodesBetween(from, to, f, startPos, this);
+  }
+  /**
+  Call the given callback for every descendant node. Doesn't
+  descend into a node when the callback returns `false`.
+  */
+  descendants(f) {
+    this.nodesBetween(0, this.content.size, f);
+  }
+  /**
+  Concatenates all the text nodes found in this fragment and its
+  children.
+  */
+  get textContent() {
+    return this.isLeaf && this.type.spec.leafText ? this.type.spec.leafText(this) : this.textBetween(0, this.content.size, "");
+  }
+  /**
+  Get all text between positions `from` and `to`. When
+  `blockSeparator` is given, it will be inserted to separate text
+  from different block nodes. If `leafText` is given, it'll be
+  inserted for every non-text leaf node encountered, otherwise
+  [`leafText`](https://prosemirror.net/docs/ref/#model.NodeSpec.leafText) will be used.
+  */
+  textBetween(from, to, blockSeparator, leafText) {
+    return this.content.textBetween(from, to, blockSeparator, leafText);
+  }
+  /**
+  Returns this node's first child, or `null` if there are no
+  children.
+  */
+  get firstChild() {
+    return this.content.firstChild;
+  }
+  /**
+  Returns this node's last child, or `null` if there are no
+  children.
+  */
+  get lastChild() {
+    return this.content.lastChild;
+  }
+  /**
+  Test whether two nodes represent the same piece of document.
+  */
+  eq(other) {
+    return this == other || this.sameMarkup(other) && this.content.eq(other.content);
+  }
+  /**
+  Compare the markup (type, attributes, and marks) of this node to
+  those of another. Returns `true` if both have the same markup.
+  */
+  sameMarkup(other) {
+    return this.hasMarkup(other.type, other.attrs, other.marks);
+  }
+  /**
+  Check whether this node's markup correspond to the given type,
+  attributes, and marks.
+  */
+  hasMarkup(type, attrs, marks) {
+    return this.type == type && compareDeep(this.attrs, attrs || type.defaultAttrs || emptyAttrs) && Mark$1.sameSet(this.marks, marks || Mark$1.none);
+  }
+  /**
+  Create a new node with the same markup as this node, containing
+  the given content (or empty, if no content is given).
+  */
+  copy(content = null) {
+    if (content == this.content)
+      return this;
+    return new Node(this.type, this.attrs, content, this.marks);
+  }
+  /**
+  Create a copy of this node, with the given set of marks instead
+  of the node's own marks.
+  */
+  mark(marks) {
+    return marks == this.marks ? this : new Node(this.type, this.attrs, this.content, marks);
+  }
+  /**
+  Create a copy of this node with only the content between the
+  given positions. If `to` is not given, it defaults to the end of
+  the node.
+  */
+  cut(from, to = this.content.size) {
+    if (from == 0 && to == this.content.size)
+      return this;
+    return this.copy(this.content.cut(from, to));
+  }
+  /**
+  Cut out the part of the document between the given positions, and
+  return it as a `Slice` object.
+  */
+  slice(from, to = this.content.size, includeParents = false) {
+    if (from == to)
+      return Slice.empty;
+    let $from = this.resolve(from), $to = this.resolve(to);
+    let depth = includeParents ? 0 : $from.sharedDepth(to);
+    let start = $from.start(depth), node = $from.node(depth);
+    let content = node.content.cut($from.pos - start, $to.pos - start);
+    return new Slice(content, $from.depth - depth, $to.depth - depth);
+  }
+  /**
+  Replace the part of the document between the given positions with
+  the given slice. The slice must 'fit', meaning its open sides
+  must be able to connect to the surrounding content, and its
+  content nodes must be valid children for the node they are placed
+  into. If any of this is violated, an error of type
+  [`ReplaceError`](https://prosemirror.net/docs/ref/#model.ReplaceError) is thrown.
+  */
+  replace(from, to, slice) {
+    return replace(this.resolve(from), this.resolve(to), slice);
+  }
+  /**
+  Find the node directly after the given position.
+  */
+  nodeAt(pos) {
+    for (let node = this; ; ) {
+      let { index, offset } = node.content.findIndex(pos);
+      node = node.maybeChild(index);
+      if (!node)
+        return null;
+      if (offset == pos || node.isText)
+        return node;
+      pos -= offset + 1;
+    }
+  }
+  /**
+  Find the (direct) child node after the given offset, if any,
+  and return it along with its index and offset relative to this
+  node.
+  */
+  childAfter(pos) {
+    let { index, offset } = this.content.findIndex(pos);
+    return { node: this.content.maybeChild(index), index, offset };
+  }
+  /**
+  Find the (direct) child node before the given offset, if any,
+  and return it along with its index and offset relative to this
+  node.
+  */
+  childBefore(pos) {
+    if (pos == 0)
+      return { node: null, index: 0, offset: 0 };
+    let { index, offset } = this.content.findIndex(pos);
+    if (offset < pos)
+      return { node: this.content.child(index), index, offset };
+    let node = this.content.child(index - 1);
+    return { node, index: index - 1, offset: offset - node.nodeSize };
+  }
+  /**
+  Resolve the given position in the document, returning an
+  [object](https://prosemirror.net/docs/ref/#model.ResolvedPos) with information about its context.
+  */
+  resolve(pos) {
+    return ResolvedPos.resolveCached(this, pos);
+  }
+  /**
+  @internal
+  */
+  resolveNoCache(pos) {
+    return ResolvedPos.resolve(this, pos);
+  }
+  /**
+  Test whether a given mark or mark type occurs in this document
+  between the two given positions.
+  */
+  rangeHasMark(from, to, type) {
+    let found2 = false;
+    if (to > from)
+      this.nodesBetween(from, to, (node) => {
+        if (type.isInSet(node.marks))
+          found2 = true;
+        return !found2;
+      });
+    return found2;
+  }
+  /**
+  True when this is a block (non-inline node)
+  */
+  get isBlock() {
+    return this.type.isBlock;
+  }
+  /**
+  True when this is a textblock node, a block node with inline
+  content.
+  */
+  get isTextblock() {
+    return this.type.isTextblock;
+  }
+  /**
+  True when this node allows inline content.
+  */
+  get inlineContent() {
+    return this.type.inlineContent;
+  }
+  /**
+  True when this is an inline node (a text node or a node that can
+  appear among text).
+  */
+  get isInline() {
+    return this.type.isInline;
+  }
+  /**
+  True when this is a text node.
+  */
+  get isText() {
+    return this.type.isText;
+  }
+  /**
+  True when this is a leaf node.
+  */
+  get isLeaf() {
+    return this.type.isLeaf;
+  }
+  /**
+  True when this is an atom, i.e. when it does not have directly
+  editable content. This is usually the same as `isLeaf`, but can
+  be configured with the [`atom` property](https://prosemirror.net/docs/ref/#model.NodeSpec.atom)
+  on a node's spec (typically used when the node is displayed as
+  an uneditable [node view](https://prosemirror.net/docs/ref/#view.NodeView)).
+  */
+  get isAtom() {
+    return this.type.isAtom;
+  }
+  /**
+  Return a string representation of this node for debugging
+  purposes.
+  */
+  toString() {
+    if (this.type.spec.toDebugString)
+      return this.type.spec.toDebugString(this);
+    let name = this.type.name;
+    if (this.content.size)
+      name += "(" + this.content.toStringInner() + ")";
+    return wrapMarks(this.marks, name);
+  }
+  /**
+  Get the content match in this node at the given index.
+  */
+  contentMatchAt(index) {
+    let match = this.type.contentMatch.matchFragment(this.content, 0, index);
+    if (!match)
+      throw new Error("Called contentMatchAt on a node with invalid content");
+    return match;
+  }
+  /**
+  Test whether replacing the range between `from` and `to` (by
+  child index) with the given replacement fragment (which defaults
+  to the empty fragment) would leave the node's content valid. You
+  can optionally pass `start` and `end` indices into the
+  replacement fragment.
+  */
+  canReplace(from, to, replacement = Fragment.empty, start = 0, end = replacement.childCount) {
+    let one = this.contentMatchAt(from).matchFragment(replacement, start, end);
+    let two = one && one.matchFragment(this.content, to);
+    if (!two || !two.validEnd)
+      return false;
+    for (let i = start; i < end; i++)
+      if (!this.type.allowsMarks(replacement.child(i).marks))
+        return false;
+    return true;
+  }
+  /**
+  Test whether replacing the range `from` to `to` (by index) with
+  a node of the given type would leave the node's content valid.
+  */
+  canReplaceWith(from, to, type, marks) {
+    if (marks && !this.type.allowsMarks(marks))
+      return false;
+    let start = this.contentMatchAt(from).matchType(type);
+    let end = start && start.matchFragment(this.content, to);
+    return end ? end.validEnd : false;
+  }
+  /**
+  Test whether the given node's content could be appended to this
+  node. If that node is empty, this will only return true if there
+  is at least one node type that can appear in both nodes (to avoid
+  merging completely incompatible nodes).
+  */
+  canAppend(other) {
+    if (other.content.size)
+      return this.canReplace(this.childCount, this.childCount, other.content);
+    else
+      return this.type.compatibleContent(other.type);
+  }
+  /**
+  Check whether this node and its descendants conform to the
+  schema, and raise an exception when they do not.
+  */
+  check() {
+    this.type.checkContent(this.content);
+    this.type.checkAttrs(this.attrs);
+    let copy2 = Mark$1.none;
+    for (let i = 0; i < this.marks.length; i++) {
+      let mark = this.marks[i];
+      mark.type.checkAttrs(mark.attrs);
+      copy2 = mark.addToSet(copy2);
+    }
+    if (!Mark$1.sameSet(copy2, this.marks))
+      throw new RangeError(`Invalid collection of marks for node ${this.type.name}: ${this.marks.map((m) => m.type.name)}`);
+    this.content.forEach((node) => node.check());
+  }
+  /**
+  Return a JSON-serializeable representation of this node.
+  */
+  toJSON() {
+    let obj = { type: this.type.name };
+    for (let _ in this.attrs) {
+      obj.attrs = this.attrs;
+      break;
+    }
+    if (this.content.size)
+      obj.content = this.content.toJSON();
+    if (this.marks.length)
+      obj.marks = this.marks.map((n) => n.toJSON());
+    return obj;
+  }
+  /**
+  Deserialize a node from its JSON representation.
+  */
+  static fromJSON(schema, json) {
+    if (!json)
+      throw new RangeError("Invalid input for Node.fromJSON");
+    let marks = void 0;
+    if (json.marks) {
+      if (!Array.isArray(json.marks))
+        throw new RangeError("Invalid mark data for Node.fromJSON");
+      marks = json.marks.map(schema.markFromJSON);
+    }
+    if (json.type == "text") {
+      if (typeof json.text != "string")
+        throw new RangeError("Invalid text node in JSON");
+      return schema.text(json.text, marks);
+    }
+    let content = Fragment.fromJSON(schema, json.content);
+    let node = schema.nodeType(json.type).create(json.attrs, content, marks);
+    node.type.checkAttrs(node.attrs);
+    return node;
+  }
+}
+Node.prototype.text = void 0;
+class TextNode extends Node {
+  /**
+  @internal
+  */
+  constructor(type, attrs, content, marks) {
+    super(type, attrs, null, marks);
+    if (!content)
+      throw new RangeError("Empty text nodes are not allowed");
+    this.text = content;
+  }
+  toString() {
+    if (this.type.spec.toDebugString)
+      return this.type.spec.toDebugString(this);
+    return wrapMarks(this.marks, JSON.stringify(this.text));
+  }
+  get textContent() {
+    return this.text;
+  }
+  textBetween(from, to) {
+    return this.text.slice(from, to);
+  }
+  get nodeSize() {
+    return this.text.length;
+  }
+  mark(marks) {
+    return marks == this.marks ? this : new TextNode(this.type, this.attrs, this.text, marks);
+  }
+  withText(text) {
+    if (text == this.text)
+      return this;
+    return new TextNode(this.type, this.attrs, text, this.marks);
+  }
+  cut(from = 0, to = this.text.length) {
+    if (from == 0 && to == this.text.length)
+      return this;
+    return this.withText(this.text.slice(from, to));
+  }
+  eq(other) {
+    return this.sameMarkup(other) && this.text == other.text;
+  }
+  toJSON() {
+    let base = super.toJSON();
+    base.text = this.text;
+    return base;
+  }
+}
+function wrapMarks(marks, str) {
+  for (let i = marks.length - 1; i >= 0; i--)
+    str = marks[i].type.name + "(" + str + ")";
+  return str;
+}
+class ContentMatch {
+  /**
+  @internal
+  */
+  constructor(validEnd) {
+    this.validEnd = validEnd;
+    this.next = [];
+    this.wrapCache = [];
+  }
+  /**
+  @internal
+  */
+  static parse(string, nodeTypes) {
+    let stream = new TokenStream(string, nodeTypes);
+    if (stream.next == null)
+      return ContentMatch.empty;
+    let expr = parseExpr(stream);
+    if (stream.next)
+      stream.err("Unexpected trailing text");
+    let match = dfa(nfa(expr));
+    checkForDeadEnds(match, stream);
+    return match;
+  }
+  /**
+  Match a node type, returning a match after that node if
+  successful.
+  */
+  matchType(type) {
+    for (let i = 0; i < this.next.length; i++)
+      if (this.next[i].type == type)
+        return this.next[i].next;
+    return null;
+  }
+  /**
+  Try to match a fragment. Returns the resulting match when
+  successful.
+  */
+  matchFragment(frag, start = 0, end = frag.childCount) {
+    let cur = this;
+    for (let i = start; cur && i < end; i++)
+      cur = cur.matchType(frag.child(i).type);
+    return cur;
+  }
+  /**
+  @internal
+  */
+  get inlineContent() {
+    return this.next.length != 0 && this.next[0].type.isInline;
+  }
+  /**
+  Get the first matching node type at this match position that can
+  be generated.
+  */
+  get defaultType() {
+    for (let i = 0; i < this.next.length; i++) {
+      let { type } = this.next[i];
+      if (!(type.isText || type.hasRequiredAttrs()))
+        return type;
+    }
+    return null;
+  }
+  /**
+  @internal
+  */
+  compatible(other) {
+    for (let i = 0; i < this.next.length; i++)
+      for (let j = 0; j < other.next.length; j++)
+        if (this.next[i].type == other.next[j].type)
+          return true;
+    return false;
+  }
+  /**
+  Try to match the given fragment, and if that fails, see if it can
+  be made to match by inserting nodes in front of it. When
+  successful, return a fragment of inserted nodes (which may be
+  empty if nothing had to be inserted). When `toEnd` is true, only
+  return a fragment if the resulting match goes to the end of the
+  content expression.
+  */
+  fillBefore(after, toEnd = false, startIndex = 0) {
+    let seen = [this];
+    function search(match, types) {
+      let finished = match.matchFragment(after, startIndex);
+      if (finished && (!toEnd || finished.validEnd))
+        return Fragment.from(types.map((tp) => tp.createAndFill()));
+      for (let i = 0; i < match.next.length; i++) {
+        let { type, next } = match.next[i];
+        if (!(type.isText || type.hasRequiredAttrs()) && seen.indexOf(next) == -1) {
+          seen.push(next);
+          let found2 = search(next, types.concat(type));
+          if (found2)
+            return found2;
+        }
+      }
+      return null;
+    }
+    return search(this, []);
+  }
+  /**
+  Find a set of wrapping node types that would allow a node of the
+  given type to appear at this position. The result may be empty
+  (when it fits directly) and will be null when no such wrapping
+  exists.
+  */
+  findWrapping(target) {
+    for (let i = 0; i < this.wrapCache.length; i += 2)
+      if (this.wrapCache[i] == target)
+        return this.wrapCache[i + 1];
+    let computed = this.computeWrapping(target);
+    this.wrapCache.push(target, computed);
+    return computed;
+  }
+  /**
+  @internal
+  */
+  computeWrapping(target) {
+    let seen = /* @__PURE__ */ Object.create(null), active = [{ match: this, type: null, via: null }];
+    while (active.length) {
+      let current = active.shift(), match = current.match;
+      if (match.matchType(target)) {
+        let result = [];
+        for (let obj = current; obj.type; obj = obj.via)
+          result.push(obj.type);
+        return result.reverse();
+      }
+      for (let i = 0; i < match.next.length; i++) {
+        let { type, next } = match.next[i];
+        if (!type.isLeaf && !type.hasRequiredAttrs() && !(type.name in seen) && (!current.type || next.validEnd)) {
+          active.push({ match: type.contentMatch, type, via: current });
+          seen[type.name] = true;
+        }
+      }
+    }
+    return null;
+  }
+  /**
+  The number of outgoing edges this node has in the finite
+  automaton that describes the content expression.
+  */
+  get edgeCount() {
+    return this.next.length;
+  }
+  /**
+  Get the _n_​th outgoing edge from this node in the finite
+  automaton that describes the content expression.
+  */
+  edge(n) {
+    if (n >= this.next.length)
+      throw new RangeError(`There's no ${n}th edge in this content match`);
+    return this.next[n];
+  }
+  /**
+  @internal
+  */
+  toString() {
+    let seen = [];
+    function scan(m) {
+      seen.push(m);
+      for (let i = 0; i < m.next.length; i++)
+        if (seen.indexOf(m.next[i].next) == -1)
+          scan(m.next[i].next);
+    }
+    scan(this);
+    return seen.map((m, i) => {
+      let out = i + (m.validEnd ? "*" : " ") + " ";
+      for (let i2 = 0; i2 < m.next.length; i2++)
+        out += (i2 ? ", " : "") + m.next[i2].type.name + "->" + seen.indexOf(m.next[i2].next);
+      return out;
+    }).join("\n");
+  }
+}
+ContentMatch.empty = new ContentMatch(true);
+class TokenStream {
+  constructor(string, nodeTypes) {
+    this.string = string;
+    this.nodeTypes = nodeTypes;
+    this.inline = null;
+    this.pos = 0;
+    this.tokens = string.split(/\s*(?=\b|\W|$)/);
+    if (this.tokens[this.tokens.length - 1] == "")
+      this.tokens.pop();
+    if (this.tokens[0] == "")
+      this.tokens.shift();
+  }
+  get next() {
+    return this.tokens[this.pos];
+  }
+  eat(tok) {
+    return this.next == tok && (this.pos++ || true);
+  }
+  err(str) {
+    throw new SyntaxError(str + " (in content expression '" + this.string + "')");
+  }
+}
+function parseExpr(stream) {
+  let exprs = [];
+  do {
+    exprs.push(parseExprSeq(stream));
+  } while (stream.eat("|"));
+  return exprs.length == 1 ? exprs[0] : { type: "choice", exprs };
+}
+function parseExprSeq(stream) {
+  let exprs = [];
+  do {
+    exprs.push(parseExprSubscript(stream));
+  } while (stream.next && stream.next != ")" && stream.next != "|");
+  return exprs.length == 1 ? exprs[0] : { type: "seq", exprs };
+}
+function parseExprSubscript(stream) {
+  let expr = parseExprAtom(stream);
+  for (; ; ) {
+    if (stream.eat("+"))
+      expr = { type: "plus", expr };
+    else if (stream.eat("*"))
+      expr = { type: "star", expr };
+    else if (stream.eat("?"))
+      expr = { type: "opt", expr };
+    else if (stream.eat("{"))
+      expr = parseExprRange(stream, expr);
+    else
+      break;
+  }
+  return expr;
+}
+function parseNum(stream) {
+  if (/\D/.test(stream.next))
+    stream.err("Expected number, got '" + stream.next + "'");
+  let result = Number(stream.next);
+  stream.pos++;
+  return result;
+}
+function parseExprRange(stream, expr) {
+  let min = parseNum(stream), max = min;
+  if (stream.eat(",")) {
+    if (stream.next != "}")
+      max = parseNum(stream);
+    else
+      max = -1;
+  }
+  if (!stream.eat("}"))
+    stream.err("Unclosed braced range");
+  return { type: "range", min, max, expr };
+}
+function resolveName(stream, name) {
+  let types = stream.nodeTypes, type = types[name];
+  if (type)
+    return [type];
+  let result = [];
+  for (let typeName in types) {
+    let type2 = types[typeName];
+    if (type2.isInGroup(name))
+      result.push(type2);
+  }
+  if (result.length == 0)
+    stream.err("No node type or group '" + name + "' found");
+  return result;
+}
+function parseExprAtom(stream) {
+  if (stream.eat("(")) {
+    let expr = parseExpr(stream);
+    if (!stream.eat(")"))
+      stream.err("Missing closing paren");
+    return expr;
+  } else if (!/\W/.test(stream.next)) {
+    let exprs = resolveName(stream, stream.next).map((type) => {
+      if (stream.inline == null)
+        stream.inline = type.isInline;
+      else if (stream.inline != type.isInline)
+        stream.err("Mixing inline and block content");
+      return { type: "name", value: type };
+    });
+    stream.pos++;
+    return exprs.length == 1 ? exprs[0] : { type: "choice", exprs };
+  } else {
+    stream.err("Unexpected token '" + stream.next + "'");
+  }
+}
+function nfa(expr) {
+  let nfa2 = [[]];
+  connect(compile(expr, 0), node());
+  return nfa2;
+  function node() {
+    return nfa2.push([]) - 1;
+  }
+  function edge(from, to, term) {
+    let edge2 = { term, to };
+    nfa2[from].push(edge2);
+    return edge2;
+  }
+  function connect(edges, to) {
+    edges.forEach((edge2) => edge2.to = to);
+  }
+  function compile(expr2, from) {
+    if (expr2.type == "choice") {
+      return expr2.exprs.reduce((out, expr3) => out.concat(compile(expr3, from)), []);
+    } else if (expr2.type == "seq") {
+      for (let i = 0; ; i++) {
+        let next = compile(expr2.exprs[i], from);
+        if (i == expr2.exprs.length - 1)
+          return next;
+        connect(next, from = node());
+      }
+    } else if (expr2.type == "star") {
+      let loop = node();
+      edge(from, loop);
+      connect(compile(expr2.expr, loop), loop);
+      return [edge(loop)];
+    } else if (expr2.type == "plus") {
+      let loop = node();
+      connect(compile(expr2.expr, from), loop);
+      connect(compile(expr2.expr, loop), loop);
+      return [edge(loop)];
+    } else if (expr2.type == "opt") {
+      return [edge(from)].concat(compile(expr2.expr, from));
+    } else if (expr2.type == "range") {
+      let cur = from;
+      for (let i = 0; i < expr2.min; i++) {
+        let next = node();
+        connect(compile(expr2.expr, cur), next);
+        cur = next;
+      }
+      if (expr2.max == -1) {
+        connect(compile(expr2.expr, cur), cur);
+      } else {
+        for (let i = expr2.min; i < expr2.max; i++) {
+          let next = node();
+          edge(cur, next);
+          connect(compile(expr2.expr, cur), next);
+          cur = next;
+        }
+      }
+      return [edge(cur)];
+    } else if (expr2.type == "name") {
+      return [edge(from, void 0, expr2.value)];
+    } else {
+      throw new Error("Unknown expr type");
+    }
+  }
+}
+function cmp(a, b) {
+  return b - a;
+}
+function nullFrom(nfa2, node) {
+  let result = [];
+  scan(node);
+  return result.sort(cmp);
+  function scan(node2) {
+    let edges = nfa2[node2];
+    if (edges.length == 1 && !edges[0].term)
+      return scan(edges[0].to);
+    result.push(node2);
+    for (let i = 0; i < edges.length; i++) {
+      let { term, to } = edges[i];
+      if (!term && result.indexOf(to) == -1)
+        scan(to);
+    }
+  }
+}
+function dfa(nfa2) {
+  let labeled = /* @__PURE__ */ Object.create(null);
+  return explore(nullFrom(nfa2, 0));
+  function explore(states) {
+    let out = [];
+    states.forEach((node) => {
+      nfa2[node].forEach(({ term, to }) => {
+        if (!term)
+          return;
+        let set;
+        for (let i = 0; i < out.length; i++)
+          if (out[i][0] == term)
+            set = out[i][1];
+        nullFrom(nfa2, to).forEach((node2) => {
+          if (!set)
+            out.push([term, set = []]);
+          if (set.indexOf(node2) == -1)
+            set.push(node2);
+        });
+      });
+    });
+    let state = labeled[states.join(",")] = new ContentMatch(states.indexOf(nfa2.length - 1) > -1);
+    for (let i = 0; i < out.length; i++) {
+      let states2 = out[i][1].sort(cmp);
+      state.next.push({ type: out[i][0], next: labeled[states2.join(",")] || explore(states2) });
+    }
+    return state;
+  }
+}
+function checkForDeadEnds(match, stream) {
+  for (let i = 0, work = [match]; i < work.length; i++) {
+    let state = work[i], dead = !state.validEnd, nodes = [];
+    for (let j = 0; j < state.next.length; j++) {
+      let { type, next } = state.next[j];
+      nodes.push(type.name);
+      if (dead && !(type.isText || type.hasRequiredAttrs()))
+        dead = false;
+      if (work.indexOf(next) == -1)
+        work.push(next);
+    }
+    if (dead)
+      stream.err("Only non-generatable nodes (" + nodes.join(", ") + ") in a required position (see https://prosemirror.net/docs/guide/#generatable)");
+  }
+}
+function defaultAttrs(attrs) {
+  let defaults = /* @__PURE__ */ Object.create(null);
+  for (let attrName in attrs) {
+    let attr = attrs[attrName];
+    if (!attr.hasDefault)
+      return null;
+    defaults[attrName] = attr.default;
+  }
+  return defaults;
+}
+function computeAttrs(attrs, value) {
+  let built = /* @__PURE__ */ Object.create(null);
+  for (let name in attrs) {
+    let given = value && value[name];
+    if (given === void 0) {
+      let attr = attrs[name];
+      if (attr.hasDefault)
+        given = attr.default;
+      else
+        throw new RangeError("No value supplied for attribute " + name);
+    }
+    built[name] = given;
+  }
+  return built;
+}
+function checkAttrs(attrs, values, type, name) {
+  for (let attr in values)
+    if (!(attr in attrs))
+      throw new RangeError(`Unsupported attribute ${attr} for ${type} of type ${name}`);
+  for (let attr in attrs) {
+    if (attrs[attr].validate)
+      attrs[attr].validate(values[attr]);
+  }
+}
+function initAttrs(typeName, attrs) {
+  let result = /* @__PURE__ */ Object.create(null);
+  if (attrs)
+    for (let name in attrs)
+      result[name] = new Attribute(typeName, name, attrs[name]);
+  return result;
+}
+class NodeType {
+  /**
+  @internal
+  */
+  constructor(name, schema, spec) {
+    this.name = name;
+    this.schema = schema;
+    this.spec = spec;
+    this.markSet = null;
+    this.groups = spec.group ? spec.group.split(" ") : [];
+    this.attrs = initAttrs(name, spec.attrs);
+    this.defaultAttrs = defaultAttrs(this.attrs);
+    this.contentMatch = null;
+    this.inlineContent = null;
+    this.isBlock = !(spec.inline || name == "text");
+    this.isText = name == "text";
+  }
+  /**
+  True if this is an inline type.
+  */
+  get isInline() {
+    return !this.isBlock;
+  }
+  /**
+  True if this is a textblock type, a block that contains inline
+  content.
+  */
+  get isTextblock() {
+    return this.isBlock && this.inlineContent;
+  }
+  /**
+  True for node types that allow no content.
+  */
+  get isLeaf() {
+    return this.contentMatch == ContentMatch.empty;
+  }
+  /**
+  True when this node is an atom, i.e. when it does not have
+  directly editable content.
+  */
+  get isAtom() {
+    return this.isLeaf || !!this.spec.atom;
+  }
+  /**
+  Return true when this node type is part of the given
+  [group](https://prosemirror.net/docs/ref/#model.NodeSpec.group).
+  */
+  isInGroup(group) {
+    return this.groups.indexOf(group) > -1;
+  }
+  /**
+  The node type's [whitespace](https://prosemirror.net/docs/ref/#model.NodeSpec.whitespace) option.
+  */
+  get whitespace() {
+    return this.spec.whitespace || (this.spec.code ? "pre" : "normal");
+  }
+  /**
+  Tells you whether this node type has any required attributes.
+  */
+  hasRequiredAttrs() {
+    for (let n in this.attrs)
+      if (this.attrs[n].isRequired)
+        return true;
+    return false;
+  }
+  /**
+  Indicates whether this node allows some of the same content as
+  the given node type.
+  */
+  compatibleContent(other) {
+    return this == other || this.contentMatch.compatible(other.contentMatch);
+  }
+  /**
+  @internal
+  */
+  computeAttrs(attrs) {
+    if (!attrs && this.defaultAttrs)
+      return this.defaultAttrs;
+    else
+      return computeAttrs(this.attrs, attrs);
+  }
+  /**
+  Create a `Node` of this type. The given attributes are
+  checked and defaulted (you can pass `null` to use the type's
+  defaults entirely, if no required attributes exist). `content`
+  may be a `Fragment`, a node, an array of nodes, or
+  `null`. Similarly `marks` may be `null` to default to the empty
+  set of marks.
+  */
+  create(attrs = null, content, marks) {
+    if (this.isText)
+      throw new Error("NodeType.create can't construct text nodes");
+    return new Node(this, this.computeAttrs(attrs), Fragment.from(content), Mark$1.setFrom(marks));
+  }
+  /**
+  Like [`create`](https://prosemirror.net/docs/ref/#model.NodeType.create), but check the given content
+  against the node type's content restrictions, and throw an error
+  if it doesn't match.
+  */
+  createChecked(attrs = null, content, marks) {
+    content = Fragment.from(content);
+    this.checkContent(content);
+    return new Node(this, this.computeAttrs(attrs), content, Mark$1.setFrom(marks));
+  }
+  /**
+  Like [`create`](https://prosemirror.net/docs/ref/#model.NodeType.create), but see if it is
+  necessary to add nodes to the start or end of the given fragment
+  to make it fit the node. If no fitting wrapping can be found,
+  return null. Note that, due to the fact that required nodes can
+  always be created, this will always succeed if you pass null or
+  `Fragment.empty` as content.
+  */
+  createAndFill(attrs = null, content, marks) {
+    attrs = this.computeAttrs(attrs);
+    content = Fragment.from(content);
+    if (content.size) {
+      let before = this.contentMatch.fillBefore(content);
+      if (!before)
+        return null;
+      content = before.append(content);
+    }
+    let matched = this.contentMatch.matchFragment(content);
+    let after = matched && matched.fillBefore(Fragment.empty, true);
+    if (!after)
+      return null;
+    return new Node(this, attrs, content.append(after), Mark$1.setFrom(marks));
+  }
+  /**
+  Returns true if the given fragment is valid content for this node
+  type.
+  */
+  validContent(content) {
+    let result = this.contentMatch.matchFragment(content);
+    if (!result || !result.validEnd)
+      return false;
+    for (let i = 0; i < content.childCount; i++)
+      if (!this.allowsMarks(content.child(i).marks))
+        return false;
+    return true;
+  }
+  /**
+  Throws a RangeError if the given fragment is not valid content for this
+  node type.
+  @internal
+  */
+  checkContent(content) {
+    if (!this.validContent(content))
+      throw new RangeError(`Invalid content for node ${this.name}: ${content.toString().slice(0, 50)}`);
+  }
+  /**
+  @internal
+  */
+  checkAttrs(attrs) {
+    checkAttrs(this.attrs, attrs, "node", this.name);
+  }
+  /**
+  Check whether the given mark type is allowed in this node.
+  */
+  allowsMarkType(markType) {
+    return this.markSet == null || this.markSet.indexOf(markType) > -1;
+  }
+  /**
+  Test whether the given set of marks are allowed in this node.
+  */
+  allowsMarks(marks) {
+    if (this.markSet == null)
+      return true;
+    for (let i = 0; i < marks.length; i++)
+      if (!this.allowsMarkType(marks[i].type))
+        return false;
+    return true;
+  }
+  /**
+  Removes the marks that are not allowed in this node from the given set.
+  */
+  allowedMarks(marks) {
+    if (this.markSet == null)
+      return marks;
+    let copy2;
+    for (let i = 0; i < marks.length; i++) {
+      if (!this.allowsMarkType(marks[i].type)) {
+        if (!copy2)
+          copy2 = marks.slice(0, i);
+      } else if (copy2) {
+        copy2.push(marks[i]);
+      }
+    }
+    return !copy2 ? marks : copy2.length ? copy2 : Mark$1.none;
+  }
+  /**
+  @internal
+  */
+  static compile(nodes, schema) {
+    let result = /* @__PURE__ */ Object.create(null);
+    nodes.forEach((name, spec) => result[name] = new NodeType(name, schema, spec));
+    let topType = schema.spec.topNode || "doc";
+    if (!result[topType])
+      throw new RangeError("Schema is missing its top node type ('" + topType + "')");
+    if (!result.text)
+      throw new RangeError("Every schema needs a 'text' type");
+    for (let _ in result.text.attrs)
+      throw new RangeError("The text node type should not have attributes");
+    return result;
+  }
+}
+function validateType(typeName, attrName, type) {
+  let types = type.split("|");
+  return (value) => {
+    let name = value === null ? "null" : typeof value;
+    if (types.indexOf(name) < 0)
+      throw new RangeError(`Expected value of type ${types} for attribute ${attrName} on type ${typeName}, got ${name}`);
+  };
+}
+class Attribute {
+  constructor(typeName, attrName, options) {
+    this.hasDefault = Object.prototype.hasOwnProperty.call(options, "default");
+    this.default = options.default;
+    this.validate = typeof options.validate == "string" ? validateType(typeName, attrName, options.validate) : options.validate;
+  }
+  get isRequired() {
+    return !this.hasDefault;
+  }
+}
+class MarkType {
+  /**
+  @internal
+  */
+  constructor(name, rank, schema, spec) {
+    this.name = name;
+    this.rank = rank;
+    this.schema = schema;
+    this.spec = spec;
+    this.attrs = initAttrs(name, spec.attrs);
+    this.excluded = null;
+    let defaults = defaultAttrs(this.attrs);
+    this.instance = defaults ? new Mark$1(this, defaults) : null;
+  }
+  /**
+  Create a mark of this type. `attrs` may be `null` or an object
+  containing only some of the mark's attributes. The others, if
+  they have defaults, will be added.
+  */
+  create(attrs = null) {
+    if (!attrs && this.instance)
+      return this.instance;
+    return new Mark$1(this, computeAttrs(this.attrs, attrs));
+  }
+  /**
+  @internal
+  */
+  static compile(marks, schema) {
+    let result = /* @__PURE__ */ Object.create(null), rank = 0;
+    marks.forEach((name, spec) => result[name] = new MarkType(name, rank++, schema, spec));
+    return result;
+  }
+  /**
+  When there is a mark of this type in the given set, a new set
+  without it is returned. Otherwise, the input set is returned.
+  */
+  removeFromSet(set) {
+    for (var i = 0; i < set.length; i++)
+      if (set[i].type == this) {
+        set = set.slice(0, i).concat(set.slice(i + 1));
+        i--;
+      }
+    return set;
+  }
+  /**
+  Tests whether there is a mark of this type in the given set.
+  */
+  isInSet(set) {
+    for (let i = 0; i < set.length; i++)
+      if (set[i].type == this)
+        return set[i];
+  }
+  /**
+  @internal
+  */
+  checkAttrs(attrs) {
+    checkAttrs(this.attrs, attrs, "mark", this.name);
+  }
+  /**
+  Queries whether a given mark type is
+  [excluded](https://prosemirror.net/docs/ref/#model.MarkSpec.excludes) by this one.
+  */
+  excludes(other) {
+    return this.excluded.indexOf(other) > -1;
+  }
+}
+class Schema {
+  /**
+  Construct a schema from a schema [specification](https://prosemirror.net/docs/ref/#model.SchemaSpec).
+  */
+  constructor(spec) {
+    this.linebreakReplacement = null;
+    this.cached = /* @__PURE__ */ Object.create(null);
+    let instanceSpec = this.spec = {};
+    for (let prop in spec)
+      instanceSpec[prop] = spec[prop];
+    instanceSpec.nodes = OrderedMap.from(spec.nodes), instanceSpec.marks = OrderedMap.from(spec.marks || {}), this.nodes = NodeType.compile(this.spec.nodes, this);
+    this.marks = MarkType.compile(this.spec.marks, this);
+    let contentExprCache = /* @__PURE__ */ Object.create(null);
+    for (let prop in this.nodes) {
+      if (prop in this.marks)
+        throw new RangeError(prop + " can not be both a node and a mark");
+      let type = this.nodes[prop], contentExpr = type.spec.content || "", markExpr = type.spec.marks;
+      type.contentMatch = contentExprCache[contentExpr] || (contentExprCache[contentExpr] = ContentMatch.parse(contentExpr, this.nodes));
+      type.inlineContent = type.contentMatch.inlineContent;
+      if (type.spec.linebreakReplacement) {
+        if (this.linebreakReplacement)
+          throw new RangeError("Multiple linebreak nodes defined");
+        if (!type.isInline || !type.isLeaf)
+          throw new RangeError("Linebreak replacement nodes must be inline leaf nodes");
+        this.linebreakReplacement = type;
+      }
+      type.markSet = markExpr == "_" ? null : markExpr ? gatherMarks(this, markExpr.split(" ")) : markExpr == "" || !type.inlineContent ? [] : null;
+    }
+    for (let prop in this.marks) {
+      let type = this.marks[prop], excl = type.spec.excludes;
+      type.excluded = excl == null ? [type] : excl == "" ? [] : gatherMarks(this, excl.split(" "));
+    }
+    this.nodeFromJSON = (json) => Node.fromJSON(this, json);
+    this.markFromJSON = (json) => Mark$1.fromJSON(this, json);
+    this.topNodeType = this.nodes[this.spec.topNode || "doc"];
+    this.cached.wrappings = /* @__PURE__ */ Object.create(null);
+  }
+  /**
+  Create a node in this schema. The `type` may be a string or a
+  `NodeType` instance. Attributes will be extended with defaults,
+  `content` may be a `Fragment`, `null`, a `Node`, or an array of
+  nodes.
+  */
+  node(type, attrs = null, content, marks) {
+    if (typeof type == "string")
+      type = this.nodeType(type);
+    else if (!(type instanceof NodeType))
+      throw new RangeError("Invalid node type: " + type);
+    else if (type.schema != this)
+      throw new RangeError("Node type from different schema used (" + type.name + ")");
+    return type.createChecked(attrs, content, marks);
+  }
+  /**
+  Create a text node in the schema. Empty text nodes are not
+  allowed.
+  */
+  text(text, marks) {
+    let type = this.nodes.text;
+    return new TextNode(type, type.defaultAttrs, text, Mark$1.setFrom(marks));
+  }
+  /**
+  Create a mark with the given type and attributes.
+  */
+  mark(type, attrs) {
+    if (typeof type == "string")
+      type = this.marks[type];
+    return type.create(attrs);
+  }
+  /**
+  @internal
+  */
+  nodeType(name) {
+    let found2 = this.nodes[name];
+    if (!found2)
+      throw new RangeError("Unknown node type: " + name);
+    return found2;
+  }
+}
+function gatherMarks(schema, marks) {
+  let found2 = [];
+  for (let i = 0; i < marks.length; i++) {
+    let name = marks[i], mark = schema.marks[name], ok = mark;
+    if (mark) {
+      found2.push(mark);
+    } else {
+      for (let prop in schema.marks) {
+        let mark2 = schema.marks[prop];
+        if (name == "_" || mark2.spec.group && mark2.spec.group.split(" ").indexOf(name) > -1)
+          found2.push(ok = mark2);
+      }
+    }
+    if (!ok)
+      throw new SyntaxError("Unknown mark type: '" + marks[i] + "'");
+  }
+  return found2;
+}
+function isTagRule(rule) {
+  return rule.tag != null;
+}
+function isStyleRule(rule) {
+  return rule.style != null;
+}
+class DOMParser {
+  /**
+  Create a parser that targets the given schema, using the given
+  parsing rules.
+  */
+  constructor(schema, rules) {
+    this.schema = schema;
+    this.rules = rules;
+    this.tags = [];
+    this.styles = [];
+    let matchedStyles = this.matchedStyles = [];
+    rules.forEach((rule) => {
+      if (isTagRule(rule)) {
+        this.tags.push(rule);
+      } else if (isStyleRule(rule)) {
+        let prop = /[^=]*/.exec(rule.style)[0];
+        if (matchedStyles.indexOf(prop) < 0)
+          matchedStyles.push(prop);
+        this.styles.push(rule);
+      }
+    });
+    this.normalizeLists = !this.tags.some((r) => {
+      if (!/^(ul|ol)\b/.test(r.tag) || !r.node)
+        return false;
+      let node = schema.nodes[r.node];
+      return node.contentMatch.matchType(node);
+    });
+  }
+  /**
+  Parse a document from the content of a DOM node.
+  */
+  parse(dom, options = {}) {
+    let context = new ParseContext(this, options, false);
+    context.addAll(dom, Mark$1.none, options.from, options.to);
+    return context.finish();
+  }
+  /**
+  Parses the content of the given DOM node, like
+  [`parse`](https://prosemirror.net/docs/ref/#model.DOMParser.parse), and takes the same set of
+  options. But unlike that method, which produces a whole node,
+  this one returns a slice that is open at the sides, meaning that
+  the schema constraints aren't applied to the start of nodes to
+  the left of the input and the end of nodes at the end.
+  */
+  parseSlice(dom, options = {}) {
+    let context = new ParseContext(this, options, true);
+    context.addAll(dom, Mark$1.none, options.from, options.to);
+    return Slice.maxOpen(context.finish());
+  }
+  /**
+  @internal
+  */
+  matchTag(dom, context, after) {
+    for (let i = after ? this.tags.indexOf(after) + 1 : 0; i < this.tags.length; i++) {
+      let rule = this.tags[i];
+      if (matches(dom, rule.tag) && (rule.namespace === void 0 || dom.namespaceURI == rule.namespace) && (!rule.context || context.matchesContext(rule.context))) {
+        if (rule.getAttrs) {
+          let result = rule.getAttrs(dom);
+          if (result === false)
+            continue;
+          rule.attrs = result || void 0;
+        }
+        return rule;
+      }
+    }
+  }
+  /**
+  @internal
+  */
+  matchStyle(prop, value, context, after) {
+    for (let i = after ? this.styles.indexOf(after) + 1 : 0; i < this.styles.length; i++) {
+      let rule = this.styles[i], style = rule.style;
+      if (style.indexOf(prop) != 0 || rule.context && !context.matchesContext(rule.context) || // Test that the style string either precisely matches the prop,
+      // or has an '=' sign after the prop, followed by the given
+      // value.
+      style.length > prop.length && (style.charCodeAt(prop.length) != 61 || style.slice(prop.length + 1) != value))
+        continue;
+      if (rule.getAttrs) {
+        let result = rule.getAttrs(value);
+        if (result === false)
+          continue;
+        rule.attrs = result || void 0;
+      }
+      return rule;
+    }
+  }
+  /**
+  @internal
+  */
+  static schemaRules(schema) {
+    let result = [];
+    function insert(rule) {
+      let priority = rule.priority == null ? 50 : rule.priority, i = 0;
+      for (; i < result.length; i++) {
+        let next = result[i], nextPriority = next.priority == null ? 50 : next.priority;
+        if (nextPriority < priority)
+          break;
+      }
+      result.splice(i, 0, rule);
+    }
+    for (let name in schema.marks) {
+      let rules = schema.marks[name].spec.parseDOM;
+      if (rules)
+        rules.forEach((rule) => {
+          insert(rule = copy(rule));
+          if (!(rule.mark || rule.ignore || rule.clearMark))
+            rule.mark = name;
+        });
+    }
+    for (let name in schema.nodes) {
+      let rules = schema.nodes[name].spec.parseDOM;
+      if (rules)
+        rules.forEach((rule) => {
+          insert(rule = copy(rule));
+          if (!(rule.node || rule.ignore || rule.mark))
+            rule.node = name;
+        });
+    }
+    return result;
+  }
+  /**
+  Construct a DOM parser using the parsing rules listed in a
+  schema's [node specs](https://prosemirror.net/docs/ref/#model.NodeSpec.parseDOM), reordered by
+  [priority](https://prosemirror.net/docs/ref/#model.GenericParseRule.priority).
+  */
+  static fromSchema(schema) {
+    return schema.cached.domParser || (schema.cached.domParser = new DOMParser(schema, DOMParser.schemaRules(schema)));
+  }
+}
+const blockTags = {
+  address: true,
+  article: true,
+  aside: true,
+  blockquote: true,
+  body: true,
+  canvas: true,
+  dd: true,
+  div: true,
+  dl: true,
+  fieldset: true,
+  figcaption: true,
+  figure: true,
+  footer: true,
+  form: true,
+  h1: true,
+  h2: true,
+  h3: true,
+  h4: true,
+  h5: true,
+  h6: true,
+  header: true,
+  hgroup: true,
+  hr: true,
+  li: true,
+  noscript: true,
+  ol: true,
+  output: true,
+  p: true,
+  pre: true,
+  section: true,
+  table: true,
+  tfoot: true,
+  ul: true
+};
+const ignoreTags = {
+  head: true,
+  noscript: true,
+  object: true,
+  script: true,
+  style: true,
+  title: true
+};
+const listTags = { ol: true, ul: true };
+const OPT_PRESERVE_WS = 1, OPT_PRESERVE_WS_FULL = 2, OPT_OPEN_LEFT = 4;
+function wsOptionsFor(type, preserveWhitespace, base) {
+  if (preserveWhitespace != null)
+    return (preserveWhitespace ? OPT_PRESERVE_WS : 0) | (preserveWhitespace === "full" ? OPT_PRESERVE_WS_FULL : 0);
+  return type && type.whitespace == "pre" ? OPT_PRESERVE_WS | OPT_PRESERVE_WS_FULL : base & ~OPT_OPEN_LEFT;
+}
+class NodeContext {
+  constructor(type, attrs, marks, solid, match, options) {
+    this.type = type;
+    this.attrs = attrs;
+    this.marks = marks;
+    this.solid = solid;
+    this.options = options;
+    this.content = [];
+    this.activeMarks = Mark$1.none;
+    this.match = match || (options & OPT_OPEN_LEFT ? null : type.contentMatch);
+  }
+  findWrapping(node) {
+    if (!this.match) {
+      if (!this.type)
+        return [];
+      let fill = this.type.contentMatch.fillBefore(Fragment.from(node));
+      if (fill) {
+        this.match = this.type.contentMatch.matchFragment(fill);
+      } else {
+        let start = this.type.contentMatch, wrap2;
+        if (wrap2 = start.findWrapping(node.type)) {
+          this.match = start;
+          return wrap2;
+        } else {
+          return null;
+        }
+      }
+    }
+    return this.match.findWrapping(node.type);
+  }
+  finish(openEnd) {
+    if (!(this.options & OPT_PRESERVE_WS)) {
+      let last = this.content[this.content.length - 1], m;
+      if (last && last.isText && (m = /[ \t\r\n\u000c]+$/.exec(last.text))) {
+        let text = last;
+        if (last.text.length == m[0].length)
+          this.content.pop();
+        else
+          this.content[this.content.length - 1] = text.withText(text.text.slice(0, text.text.length - m[0].length));
+      }
+    }
+    let content = Fragment.from(this.content);
+    if (!openEnd && this.match)
+      content = content.append(this.match.fillBefore(Fragment.empty, true));
+    return this.type ? this.type.create(this.attrs, content, this.marks) : content;
+  }
+  inlineContext(node) {
+    if (this.type)
+      return this.type.inlineContent;
+    if (this.content.length)
+      return this.content[0].isInline;
+    return node.parentNode && !blockTags.hasOwnProperty(node.parentNode.nodeName.toLowerCase());
+  }
+}
+class ParseContext {
+  constructor(parser, options, isOpen) {
+    this.parser = parser;
+    this.options = options;
+    this.isOpen = isOpen;
+    this.open = 0;
+    this.localPreserveWS = false;
+    let topNode = options.topNode, topContext;
+    let topOptions = wsOptionsFor(null, options.preserveWhitespace, 0) | (isOpen ? OPT_OPEN_LEFT : 0);
+    if (topNode)
+      topContext = new NodeContext(topNode.type, topNode.attrs, Mark$1.none, true, options.topMatch || topNode.type.contentMatch, topOptions);
+    else if (isOpen)
+      topContext = new NodeContext(null, null, Mark$1.none, true, null, topOptions);
+    else
+      topContext = new NodeContext(parser.schema.topNodeType, null, Mark$1.none, true, null, topOptions);
+    this.nodes = [topContext];
+    this.find = options.findPositions;
+    this.needsBlock = false;
+  }
+  get top() {
+    return this.nodes[this.open];
+  }
+  // Add a DOM node to the content. Text is inserted as text node,
+  // otherwise, the node is passed to `addElement` or, if it has a
+  // `style` attribute, `addElementWithStyles`.
+  addDOM(dom, marks) {
+    if (dom.nodeType == 3)
+      this.addTextNode(dom, marks);
+    else if (dom.nodeType == 1)
+      this.addElement(dom, marks);
+  }
+  addTextNode(dom, marks) {
+    let value = dom.nodeValue;
+    let top = this.top, preserveWS = top.options & OPT_PRESERVE_WS_FULL ? "full" : this.localPreserveWS || (top.options & OPT_PRESERVE_WS) > 0;
+    let { schema } = this.parser;
+    if (preserveWS === "full" || top.inlineContext(dom) || /[^ \t\r\n\u000c]/.test(value)) {
+      if (!preserveWS) {
+        value = value.replace(/[ \t\r\n\u000c]+/g, " ");
+        if (/^[ \t\r\n\u000c]/.test(value) && this.open == this.nodes.length - 1) {
+          let nodeBefore = top.content[top.content.length - 1];
+          let domNodeBefore = dom.previousSibling;
+          if (!nodeBefore || domNodeBefore && domNodeBefore.nodeName == "BR" || nodeBefore.isText && /[ \t\r\n\u000c]$/.test(nodeBefore.text))
+            value = value.slice(1);
+        }
+      } else if (preserveWS === "full") {
+        value = value.replace(/\r\n?/g, "\n");
+      } else if (schema.linebreakReplacement && /[\r\n]/.test(value) && this.top.findWrapping(schema.linebreakReplacement.create())) {
+        let lines = value.split(/\r?\n|\r/);
+        for (let i = 0; i < lines.length; i++) {
+          if (i)
+            this.insertNode(schema.linebreakReplacement.create(), marks, true);
+          if (lines[i])
+            this.insertNode(schema.text(lines[i]), marks, !/\S/.test(lines[i]));
+        }
+        value = "";
+      } else {
+        value = value.replace(/\r?\n|\r/g, " ");
+      }
+      if (value)
+        this.insertNode(schema.text(value), marks, !/\S/.test(value));
+      this.findInText(dom);
+    } else {
+      this.findInside(dom);
+    }
+  }
+  // Try to find a handler for the given tag and use that to parse. If
+  // none is found, the element's content nodes are added directly.
+  addElement(dom, marks, matchAfter) {
+    let outerWS = this.localPreserveWS, top = this.top;
+    if (dom.tagName == "PRE" || /pre/.test(dom.style && dom.style.whiteSpace))
+      this.localPreserveWS = true;
+    let name = dom.nodeName.toLowerCase(), ruleID;
+    if (listTags.hasOwnProperty(name) && this.parser.normalizeLists)
+      normalizeList(dom);
+    let rule = this.options.ruleFromNode && this.options.ruleFromNode(dom) || (ruleID = this.parser.matchTag(dom, this, matchAfter));
+    out: if (rule ? rule.ignore : ignoreTags.hasOwnProperty(name)) {
+      this.findInside(dom);
+      this.ignoreFallback(dom, marks);
+    } else if (!rule || rule.skip || rule.closeParent) {
+      if (rule && rule.closeParent)
+        this.open = Math.max(0, this.open - 1);
+      else if (rule && rule.skip.nodeType)
+        dom = rule.skip;
+      let sync, oldNeedsBlock = this.needsBlock;
+      if (blockTags.hasOwnProperty(name)) {
+        if (top.content.length && top.content[0].isInline && this.open) {
+          this.open--;
+          top = this.top;
+        }
+        sync = true;
+        if (!top.type)
+          this.needsBlock = true;
+      } else if (!dom.firstChild) {
+        this.leafFallback(dom, marks);
+        break out;
+      }
+      let innerMarks = rule && rule.skip ? marks : this.readStyles(dom, marks);
+      if (innerMarks)
+        this.addAll(dom, innerMarks);
+      if (sync)
+        this.sync(top);
+      this.needsBlock = oldNeedsBlock;
+    } else {
+      let innerMarks = this.readStyles(dom, marks);
+      if (innerMarks)
+        this.addElementByRule(dom, rule, innerMarks, rule.consuming === false ? ruleID : void 0);
+    }
+    this.localPreserveWS = outerWS;
+  }
+  // Called for leaf DOM nodes that would otherwise be ignored
+  leafFallback(dom, marks) {
+    if (dom.nodeName == "BR" && this.top.type && this.top.type.inlineContent)
+      this.addTextNode(dom.ownerDocument.createTextNode("\n"), marks);
+  }
+  // Called for ignored nodes
+  ignoreFallback(dom, marks) {
+    if (dom.nodeName == "BR" && (!this.top.type || !this.top.type.inlineContent))
+      this.findPlace(this.parser.schema.text("-"), marks, true);
+  }
+  // Run any style parser associated with the node's styles. Either
+  // return an updated array of marks, or null to indicate some of the
+  // styles had a rule with `ignore` set.
+  readStyles(dom, marks) {
+    let styles = dom.style;
+    if (styles && styles.length)
+      for (let i = 0; i < this.parser.matchedStyles.length; i++) {
+        let name = this.parser.matchedStyles[i], value = styles.getPropertyValue(name);
+        if (value)
+          for (let after = void 0; ; ) {
+            let rule = this.parser.matchStyle(name, value, this, after);
+            if (!rule)
+              break;
+            if (rule.ignore)
+              return null;
+            if (rule.clearMark)
+              marks = marks.filter((m) => !rule.clearMark(m));
+            else
+              marks = marks.concat(this.parser.schema.marks[rule.mark].create(rule.attrs));
+            if (rule.consuming === false)
+              after = rule;
+            else
+              break;
+          }
+      }
+    return marks;
+  }
+  // Look up a handler for the given node. If none are found, return
+  // false. Otherwise, apply it, use its return value to drive the way
+  // the node's content is wrapped, and return true.
+  addElementByRule(dom, rule, marks, continueAfter) {
+    let sync, nodeType;
+    if (rule.node) {
+      nodeType = this.parser.schema.nodes[rule.node];
+      if (!nodeType.isLeaf) {
+        let inner = this.enter(nodeType, rule.attrs || null, marks, rule.preserveWhitespace);
+        if (inner) {
+          sync = true;
+          marks = inner;
+        }
+      } else if (!this.insertNode(nodeType.create(rule.attrs), marks, dom.nodeName == "BR")) {
+        this.leafFallback(dom, marks);
+      }
+    } else {
+      let markType = this.parser.schema.marks[rule.mark];
+      marks = marks.concat(markType.create(rule.attrs));
+    }
+    let startIn = this.top;
+    if (nodeType && nodeType.isLeaf) {
+      this.findInside(dom);
+    } else if (continueAfter) {
+      this.addElement(dom, marks, continueAfter);
+    } else if (rule.getContent) {
+      this.findInside(dom);
+      rule.getContent(dom, this.parser.schema).forEach((node) => this.insertNode(node, marks, false));
+    } else {
+      let contentDOM = dom;
+      if (typeof rule.contentElement == "string")
+        contentDOM = dom.querySelector(rule.contentElement);
+      else if (typeof rule.contentElement == "function")
+        contentDOM = rule.contentElement(dom);
+      else if (rule.contentElement)
+        contentDOM = rule.contentElement;
+      this.findAround(dom, contentDOM, true);
+      this.addAll(contentDOM, marks);
+      this.findAround(dom, contentDOM, false);
+    }
+    if (sync && this.sync(startIn))
+      this.open--;
+  }
+  // Add all child nodes between `startIndex` and `endIndex` (or the
+  // whole node, if not given). If `sync` is passed, use it to
+  // synchronize after every block element.
+  addAll(parent, marks, startIndex, endIndex) {
+    let index = startIndex || 0;
+    for (let dom = startIndex ? parent.childNodes[startIndex] : parent.firstChild, end = endIndex == null ? null : parent.childNodes[endIndex]; dom != end; dom = dom.nextSibling, ++index) {
+      this.findAtPoint(parent, index);
+      this.addDOM(dom, marks);
+    }
+    this.findAtPoint(parent, index);
+  }
+  // Try to find a way to fit the given node type into the current
+  // context. May add intermediate wrappers and/or leave non-solid
+  // nodes that we're in.
+  findPlace(node, marks, cautious) {
+    let route, sync;
+    for (let depth = this.open, penalty = 0; depth >= 0; depth--) {
+      let cx = this.nodes[depth];
+      let found2 = cx.findWrapping(node);
+      if (found2 && (!route || route.length > found2.length + penalty)) {
+        route = found2;
+        sync = cx;
+        if (!found2.length)
+          break;
+      }
+      if (cx.solid) {
+        if (cautious)
+          break;
+        penalty += 2;
+      }
+    }
+    if (!route)
+      return null;
+    this.sync(sync);
+    for (let i = 0; i < route.length; i++)
+      marks = this.enterInner(route[i], null, marks, false);
+    return marks;
+  }
+  // Try to insert the given node, adjusting the context when needed.
+  insertNode(node, marks, cautious) {
+    if (node.isInline && this.needsBlock && !this.top.type) {
+      let block = this.textblockFromContext();
+      if (block)
+        marks = this.enterInner(block, null, marks);
+    }
+    let innerMarks = this.findPlace(node, marks, cautious);
+    if (innerMarks) {
+      this.closeExtra();
+      let top = this.top;
+      if (top.match)
+        top.match = top.match.matchType(node.type);
+      let nodeMarks = Mark$1.none;
+      for (let m of innerMarks.concat(node.marks))
+        if (top.type ? top.type.allowsMarkType(m.type) : markMayApply(m.type, node.type))
+          nodeMarks = m.addToSet(nodeMarks);
+      top.content.push(node.mark(nodeMarks));
+      return true;
+    }
+    return false;
+  }
+  // Try to start a node of the given type, adjusting the context when
+  // necessary.
+  enter(type, attrs, marks, preserveWS) {
+    let innerMarks = this.findPlace(type.create(attrs), marks, false);
+    if (innerMarks)
+      innerMarks = this.enterInner(type, attrs, marks, true, preserveWS);
+    return innerMarks;
+  }
+  // Open a node of the given type
+  enterInner(type, attrs, marks, solid = false, preserveWS) {
+    this.closeExtra();
+    let top = this.top;
+    top.match = top.match && top.match.matchType(type);
+    let options = wsOptionsFor(type, preserveWS, top.options);
+    if (top.options & OPT_OPEN_LEFT && top.content.length == 0)
+      options |= OPT_OPEN_LEFT;
+    let applyMarks = Mark$1.none;
+    marks = marks.filter((m) => {
+      if (top.type ? top.type.allowsMarkType(m.type) : markMayApply(m.type, type)) {
+        applyMarks = m.addToSet(applyMarks);
+        return false;
+      }
+      return true;
+    });
+    this.nodes.push(new NodeContext(type, attrs, applyMarks, solid, null, options));
+    this.open++;
+    return marks;
+  }
+  // Make sure all nodes above this.open are finished and added to
+  // their parents
+  closeExtra(openEnd = false) {
+    let i = this.nodes.length - 1;
+    if (i > this.open) {
+      for (; i > this.open; i--)
+        this.nodes[i - 1].content.push(this.nodes[i].finish(openEnd));
+      this.nodes.length = this.open + 1;
+    }
+  }
+  finish() {
+    this.open = 0;
+    this.closeExtra(this.isOpen);
+    return this.nodes[0].finish(!!(this.isOpen || this.options.topOpen));
+  }
+  sync(to) {
+    for (let i = this.open; i >= 0; i--) {
+      if (this.nodes[i] == to) {
+        this.open = i;
+        return true;
+      } else if (this.localPreserveWS) {
+        this.nodes[i].options |= OPT_PRESERVE_WS;
+      }
+    }
+    return false;
+  }
+  get currentPos() {
+    this.closeExtra();
+    let pos = 0;
+    for (let i = this.open; i >= 0; i--) {
+      let content = this.nodes[i].content;
+      for (let j = content.length - 1; j >= 0; j--)
+        pos += content[j].nodeSize;
+      if (i)
+        pos++;
+    }
+    return pos;
+  }
+  findAtPoint(parent, offset) {
+    if (this.find)
+      for (let i = 0; i < this.find.length; i++) {
+        if (this.find[i].node == parent && this.find[i].offset == offset)
+          this.find[i].pos = this.currentPos;
+      }
+  }
+  findInside(parent) {
+    if (this.find)
+      for (let i = 0; i < this.find.length; i++) {
+        if (this.find[i].pos == null && parent.nodeType == 1 && parent.contains(this.find[i].node))
+          this.find[i].pos = this.currentPos;
+      }
+  }
+  findAround(parent, content, before) {
+    if (parent != content && this.find)
+      for (let i = 0; i < this.find.length; i++) {
+        if (this.find[i].pos == null && parent.nodeType == 1 && parent.contains(this.find[i].node)) {
+          let pos = content.compareDocumentPosition(this.find[i].node);
+          if (pos & (before ? 2 : 4))
+            this.find[i].pos = this.currentPos;
+        }
+      }
+  }
+  findInText(textNode) {
+    if (this.find)
+      for (let i = 0; i < this.find.length; i++) {
+        if (this.find[i].node == textNode)
+          this.find[i].pos = this.currentPos - (textNode.nodeValue.length - this.find[i].offset);
+      }
+  }
+  // Determines whether the given context string matches this context.
+  matchesContext(context) {
+    if (context.indexOf("|") > -1)
+      return context.split(/\s*\|\s*/).some(this.matchesContext, this);
+    let parts = context.split("/");
+    let option = this.options.context;
+    let useRoot = !this.isOpen && (!option || option.parent.type == this.nodes[0].type);
+    let minDepth = -(option ? option.depth + 1 : 0) + (useRoot ? 0 : 1);
+    let match = (i, depth) => {
+      for (; i >= 0; i--) {
+        let part = parts[i];
+        if (part == "") {
+          if (i == parts.length - 1 || i == 0)
+            continue;
+          for (; depth >= minDepth; depth--)
+            if (match(i - 1, depth))
+              return true;
+          return false;
+        } else {
+          let next = depth > 0 || depth == 0 && useRoot ? this.nodes[depth].type : option && depth >= minDepth ? option.node(depth - minDepth).type : null;
+          if (!next || next.name != part && !next.isInGroup(part))
+            return false;
+          depth--;
+        }
+      }
+      return true;
+    };
+    return match(parts.length - 1, this.open);
+  }
+  textblockFromContext() {
+    let $context = this.options.context;
+    if ($context)
+      for (let d = $context.depth; d >= 0; d--) {
+        let deflt = $context.node(d).contentMatchAt($context.indexAfter(d)).defaultType;
+        if (deflt && deflt.isTextblock && deflt.defaultAttrs)
+          return deflt;
+      }
+    for (let name in this.parser.schema.nodes) {
+      let type = this.parser.schema.nodes[name];
+      if (type.isTextblock && type.defaultAttrs)
+        return type;
+    }
+  }
+}
+function normalizeList(dom) {
+  for (let child = dom.firstChild, prevItem = null; child; child = child.nextSibling) {
+    let name = child.nodeType == 1 ? child.nodeName.toLowerCase() : null;
+    if (name && listTags.hasOwnProperty(name) && prevItem) {
+      prevItem.appendChild(child);
+      child = prevItem;
+    } else if (name == "li") {
+      prevItem = child;
+    } else if (name) {
+      prevItem = null;
+    }
+  }
+}
+function matches(dom, selector) {
+  return (dom.matches || dom.msMatchesSelector || dom.webkitMatchesSelector || dom.mozMatchesSelector).call(dom, selector);
+}
+function copy(obj) {
+  let copy2 = {};
+  for (let prop in obj)
+    copy2[prop] = obj[prop];
+  return copy2;
+}
+function markMayApply(markType, nodeType) {
+  let nodes = nodeType.schema.nodes;
+  for (let name in nodes) {
+    let parent = nodes[name];
+    if (!parent.allowsMarkType(markType))
+      continue;
+    let seen = [], scan = (match) => {
+      seen.push(match);
+      for (let i = 0; i < match.edgeCount; i++) {
+        let { type, next } = match.edge(i);
+        if (type == nodeType)
+          return true;
+        if (seen.indexOf(next) < 0 && scan(next))
+          return true;
+      }
+    };
+    if (scan(parent.contentMatch))
+      return true;
+  }
+}
+const lower16 = 65535;
+const factor16 = Math.pow(2, 16);
+function makeRecover(index, offset) {
+  return index + offset * factor16;
+}
+function recoverIndex(value) {
+  return value & lower16;
+}
+function recoverOffset(value) {
+  return (value - (value & lower16)) / factor16;
+}
+const DEL_BEFORE = 1, DEL_AFTER = 2, DEL_ACROSS = 4, DEL_SIDE = 8;
+class MapResult {
+  /**
+  @internal
+  */
+  constructor(pos, delInfo, recover) {
+    this.pos = pos;
+    this.delInfo = delInfo;
+    this.recover = recover;
+  }
+  /**
+  Tells you whether the position was deleted, that is, whether the
+  step removed the token on the side queried (via the `assoc`)
+  argument from the document.
+  */
+  get deleted() {
+    return (this.delInfo & DEL_SIDE) > 0;
+  }
+  /**
+  Tells you whether the token before the mapped position was deleted.
+  */
+  get deletedBefore() {
+    return (this.delInfo & (DEL_BEFORE | DEL_ACROSS)) > 0;
+  }
+  /**
+  True when the token after the mapped position was deleted.
+  */
+  get deletedAfter() {
+    return (this.delInfo & (DEL_AFTER | DEL_ACROSS)) > 0;
+  }
+  /**
+  Tells whether any of the steps mapped through deletes across the
+  position (including both the token before and after the
+  position).
+  */
+  get deletedAcross() {
+    return (this.delInfo & DEL_ACROSS) > 0;
+  }
+}
+class StepMap {
+  /**
+  Create a position map. The modifications to the document are
+  represented as an array of numbers, in which each group of three
+  represents a modified chunk as `[start, oldSize, newSize]`.
+  */
+  constructor(ranges, inverted = false) {
+    this.ranges = ranges;
+    this.inverted = inverted;
+    if (!ranges.length && StepMap.empty)
+      return StepMap.empty;
+  }
+  /**
+  @internal
+  */
+  recover(value) {
+    let diff = 0, index = recoverIndex(value);
+    if (!this.inverted)
+      for (let i = 0; i < index; i++)
+        diff += this.ranges[i * 3 + 2] - this.ranges[i * 3 + 1];
+    return this.ranges[index * 3] + diff + recoverOffset(value);
+  }
+  mapResult(pos, assoc = 1) {
+    return this._map(pos, assoc, false);
+  }
+  map(pos, assoc = 1) {
+    return this._map(pos, assoc, true);
+  }
+  /**
+  @internal
+  */
+  _map(pos, assoc, simple) {
+    let diff = 0, oldIndex = this.inverted ? 2 : 1, newIndex = this.inverted ? 1 : 2;
+    for (let i = 0; i < this.ranges.length; i += 3) {
+      let start = this.ranges[i] - (this.inverted ? diff : 0);
+      if (start > pos)
+        break;
+      let oldSize = this.ranges[i + oldIndex], newSize = this.ranges[i + newIndex], end = start + oldSize;
+      if (pos <= end) {
+        let side = !oldSize ? assoc : pos == start ? -1 : pos == end ? 1 : assoc;
+        let result = start + diff + (side < 0 ? 0 : newSize);
+        if (simple)
+          return result;
+        let recover = pos == (assoc < 0 ? start : end) ? null : makeRecover(i / 3, pos - start);
+        let del = pos == start ? DEL_AFTER : pos == end ? DEL_BEFORE : DEL_ACROSS;
+        if (assoc < 0 ? pos != start : pos != end)
+          del |= DEL_SIDE;
+        return new MapResult(result, del, recover);
+      }
+      diff += newSize - oldSize;
+    }
+    return simple ? pos + diff : new MapResult(pos + diff, 0, null);
+  }
+  /**
+  @internal
+  */
+  touches(pos, recover) {
+    let diff = 0, index = recoverIndex(recover);
+    let oldIndex = this.inverted ? 2 : 1, newIndex = this.inverted ? 1 : 2;
+    for (let i = 0; i < this.ranges.length; i += 3) {
+      let start = this.ranges[i] - (this.inverted ? diff : 0);
+      if (start > pos)
+        break;
+      let oldSize = this.ranges[i + oldIndex], end = start + oldSize;
+      if (pos <= end && i == index * 3)
+        return true;
+      diff += this.ranges[i + newIndex] - oldSize;
+    }
+    return false;
+  }
+  /**
+  Calls the given function on each of the changed ranges included in
+  this map.
+  */
+  forEach(f) {
+    let oldIndex = this.inverted ? 2 : 1, newIndex = this.inverted ? 1 : 2;
+    for (let i = 0, diff = 0; i < this.ranges.length; i += 3) {
+      let start = this.ranges[i], oldStart = start - (this.inverted ? diff : 0), newStart = start + (this.inverted ? 0 : diff);
+      let oldSize = this.ranges[i + oldIndex], newSize = this.ranges[i + newIndex];
+      f(oldStart, oldStart + oldSize, newStart, newStart + newSize);
+      diff += newSize - oldSize;
+    }
+  }
+  /**
+  Create an inverted version of this map. The result can be used to
+  map positions in the post-step document to the pre-step document.
+  */
+  invert() {
+    return new StepMap(this.ranges, !this.inverted);
+  }
+  /**
+  @internal
+  */
+  toString() {
+    return (this.inverted ? "-" : "") + JSON.stringify(this.ranges);
+  }
+  /**
+  Create a map that moves all positions by offset `n` (which may be
+  negative). This can be useful when applying steps meant for a
+  sub-document to a larger document, or vice-versa.
+  */
+  static offset(n) {
+    return n == 0 ? StepMap.empty : new StepMap(n < 0 ? [0, -n, 0] : [0, 0, n]);
+  }
+}
+StepMap.empty = new StepMap([]);
+class Mapping {
+  /**
+  Create a new mapping with the given position maps.
+  */
+  constructor(maps, mirror, from = 0, to = maps ? maps.length : 0) {
+    this.mirror = mirror;
+    this.from = from;
+    this.to = to;
+    this._maps = maps || [];
+    this.ownData = !(maps || mirror);
+  }
+  /**
+  The step maps in this mapping.
+  */
+  get maps() {
+    return this._maps;
+  }
+  /**
+  Create a mapping that maps only through a part of this one.
+  */
+  slice(from = 0, to = this.maps.length) {
+    return new Mapping(this._maps, this.mirror, from, to);
+  }
+  /**
+  Add a step map to the end of this mapping. If `mirrors` is
+  given, it should be the index of the step map that is the mirror
+  image of this one.
+  */
+  appendMap(map, mirrors) {
+    if (!this.ownData) {
+      this._maps = this._maps.slice();
+      this.mirror = this.mirror && this.mirror.slice();
+      this.ownData = true;
+    }
+    this.to = this._maps.push(map);
+    if (mirrors != null)
+      this.setMirror(this._maps.length - 1, mirrors);
+  }
+  /**
+  Add all the step maps in a given mapping to this one (preserving
+  mirroring information).
+  */
+  appendMapping(mapping) {
+    for (let i = 0, startSize = this._maps.length; i < mapping._maps.length; i++) {
+      let mirr = mapping.getMirror(i);
+      this.appendMap(mapping._maps[i], mirr != null && mirr < i ? startSize + mirr : void 0);
+    }
+  }
+  /**
+  Finds the offset of the step map that mirrors the map at the
+  given offset, in this mapping (as per the second argument to
+  `appendMap`).
+  */
+  getMirror(n) {
+    if (this.mirror) {
+      for (let i = 0; i < this.mirror.length; i++)
+        if (this.mirror[i] == n)
+          return this.mirror[i + (i % 2 ? -1 : 1)];
+    }
+  }
+  /**
+  @internal
+  */
+  setMirror(n, m) {
+    if (!this.mirror)
+      this.mirror = [];
+    this.mirror.push(n, m);
+  }
+  /**
+  Append the inverse of the given mapping to this one.
+  */
+  appendMappingInverted(mapping) {
+    for (let i = mapping.maps.length - 1, totalSize = this._maps.length + mapping._maps.length; i >= 0; i--) {
+      let mirr = mapping.getMirror(i);
+      this.appendMap(mapping._maps[i].invert(), mirr != null && mirr > i ? totalSize - mirr - 1 : void 0);
+    }
+  }
+  /**
+  Create an inverted version of this mapping.
+  */
+  invert() {
+    let inverse = new Mapping();
+    inverse.appendMappingInverted(this);
+    return inverse;
+  }
+  /**
+  Map a position through this mapping.
+  */
+  map(pos, assoc = 1) {
+    if (this.mirror)
+      return this._map(pos, assoc, true);
+    for (let i = this.from; i < this.to; i++)
+      pos = this._maps[i].map(pos, assoc);
+    return pos;
+  }
+  /**
+  Map a position through this mapping, returning a mapping
+  result.
+  */
+  mapResult(pos, assoc = 1) {
+    return this._map(pos, assoc, false);
+  }
+  /**
+  @internal
+  */
+  _map(pos, assoc, simple) {
+    let delInfo = 0;
+    for (let i = this.from; i < this.to; i++) {
+      let map = this._maps[i], result = map.mapResult(pos, assoc);
+      if (result.recover != null) {
+        let corr = this.getMirror(i);
+        if (corr != null && corr > i && corr < this.to) {
+          i = corr;
+          pos = this._maps[corr].recover(result.recover);
+          continue;
+        }
+      }
+      delInfo |= result.delInfo;
+      pos = result.pos;
+    }
+    return simple ? pos : new MapResult(pos, delInfo, null);
+  }
+}
+const stepsByID = /* @__PURE__ */ Object.create(null);
+class Step {
+  /**
+  Get the step map that represents the changes made by this step,
+  and which can be used to transform between positions in the old
+  and the new document.
+  */
+  getMap() {
+    return StepMap.empty;
+  }
+  /**
+  Try to merge this step with another one, to be applied directly
+  after it. Returns the merged step when possible, null if the
+  steps can't be merged.
+  */
+  merge(other) {
+    return null;
+  }
+  /**
+  Deserialize a step from its JSON representation. Will call
+  through to the step class' own implementation of this method.
+  */
+  static fromJSON(schema, json) {
+    if (!json || !json.stepType)
+      throw new RangeError("Invalid input for Step.fromJSON");
+    let type = stepsByID[json.stepType];
+    if (!type)
+      throw new RangeError(`No step type ${json.stepType} defined`);
+    return type.fromJSON(schema, json);
+  }
+  /**
+  To be able to serialize steps to JSON, each step needs a string
+  ID to attach to its JSON representation. Use this method to
+  register an ID for your step classes. Try to pick something
+  that's unlikely to clash with steps from other modules.
+  */
+  static jsonID(id, stepClass) {
+    if (id in stepsByID)
+      throw new RangeError("Duplicate use of step JSON ID " + id);
+    stepsByID[id] = stepClass;
+    stepClass.prototype.jsonID = id;
+    return stepClass;
+  }
+}
+class StepResult {
+  /**
+  @internal
+  */
+  constructor(doc, failed) {
+    this.doc = doc;
+    this.failed = failed;
+  }
+  /**
+  Create a successful step result.
+  */
+  static ok(doc) {
+    return new StepResult(doc, null);
+  }
+  /**
+  Create a failed step result.
+  */
+  static fail(message) {
+    return new StepResult(null, message);
+  }
+  /**
+  Call [`Node.replace`](https://prosemirror.net/docs/ref/#model.Node.replace) with the given
+  arguments. Create a successful result if it succeeds, and a
+  failed one if it throws a `ReplaceError`.
+  */
+  static fromReplace(doc, from, to, slice) {
+    try {
+      return StepResult.ok(doc.replace(from, to, slice));
+    } catch (e) {
+      if (e instanceof ReplaceError)
+        return StepResult.fail(e.message);
+      throw e;
+    }
+  }
+}
+function mapFragment(fragment, f, parent) {
+  let mapped = [];
+  for (let i = 0; i < fragment.childCount; i++) {
+    let child = fragment.child(i);
+    if (child.content.size)
+      child = child.copy(mapFragment(child.content, f, child));
+    if (child.isInline)
+      child = f(child, parent, i);
+    mapped.push(child);
+  }
+  return Fragment.fromArray(mapped);
+}
+class AddMarkStep extends Step {
+  /**
+  Create a mark step.
+  */
+  constructor(from, to, mark) {
+    super();
+    this.from = from;
+    this.to = to;
+    this.mark = mark;
+  }
+  apply(doc) {
+    let oldSlice = doc.slice(this.from, this.to), $from = doc.resolve(this.from);
+    let parent = $from.node($from.sharedDepth(this.to));
+    let slice = new Slice(mapFragment(oldSlice.content, (node, parent2) => {
+      if (!node.isAtom || !parent2.type.allowsMarkType(this.mark.type))
+        return node;
+      return node.mark(this.mark.addToSet(node.marks));
+    }, parent), oldSlice.openStart, oldSlice.openEnd);
+    return StepResult.fromReplace(doc, this.from, this.to, slice);
+  }
+  invert() {
+    return new RemoveMarkStep(this.from, this.to, this.mark);
+  }
+  map(mapping) {
+    let from = mapping.mapResult(this.from, 1), to = mapping.mapResult(this.to, -1);
+    if (from.deleted && to.deleted || from.pos >= to.pos)
+      return null;
+    return new AddMarkStep(from.pos, to.pos, this.mark);
+  }
+  merge(other) {
+    if (other instanceof AddMarkStep && other.mark.eq(this.mark) && this.from <= other.to && this.to >= other.from)
+      return new AddMarkStep(Math.min(this.from, other.from), Math.max(this.to, other.to), this.mark);
+    return null;
+  }
+  toJSON() {
+    return {
+      stepType: "addMark",
+      mark: this.mark.toJSON(),
+      from: this.from,
+      to: this.to
+    };
+  }
+  /**
+  @internal
+  */
+  static fromJSON(schema, json) {
+    if (typeof json.from != "number" || typeof json.to != "number")
+      throw new RangeError("Invalid input for AddMarkStep.fromJSON");
+    return new AddMarkStep(json.from, json.to, schema.markFromJSON(json.mark));
+  }
+}
+Step.jsonID("addMark", AddMarkStep);
+class RemoveMarkStep extends Step {
+  /**
+  Create a mark-removing step.
+  */
+  constructor(from, to, mark) {
+    super();
+    this.from = from;
+    this.to = to;
+    this.mark = mark;
+  }
+  apply(doc) {
+    let oldSlice = doc.slice(this.from, this.to);
+    let slice = new Slice(mapFragment(oldSlice.content, (node) => {
+      return node.mark(this.mark.removeFromSet(node.marks));
+    }, doc), oldSlice.openStart, oldSlice.openEnd);
+    return StepResult.fromReplace(doc, this.from, this.to, slice);
+  }
+  invert() {
+    return new AddMarkStep(this.from, this.to, this.mark);
+  }
+  map(mapping) {
+    let from = mapping.mapResult(this.from, 1), to = mapping.mapResult(this.to, -1);
+    if (from.deleted && to.deleted || from.pos >= to.pos)
+      return null;
+    return new RemoveMarkStep(from.pos, to.pos, this.mark);
+  }
+  merge(other) {
+    if (other instanceof RemoveMarkStep && other.mark.eq(this.mark) && this.from <= other.to && this.to >= other.from)
+      return new RemoveMarkStep(Math.min(this.from, other.from), Math.max(this.to, other.to), this.mark);
+    return null;
+  }
+  toJSON() {
+    return {
+      stepType: "removeMark",
+      mark: this.mark.toJSON(),
+      from: this.from,
+      to: this.to
+    };
+  }
+  /**
+  @internal
+  */
+  static fromJSON(schema, json) {
+    if (typeof json.from != "number" || typeof json.to != "number")
+      throw new RangeError("Invalid input for RemoveMarkStep.fromJSON");
+    return new RemoveMarkStep(json.from, json.to, schema.markFromJSON(json.mark));
+  }
+}
+Step.jsonID("removeMark", RemoveMarkStep);
+class AddNodeMarkStep extends Step {
+  /**
+  Create a node mark step.
+  */
+  constructor(pos, mark) {
+    super();
+    this.pos = pos;
+    this.mark = mark;
+  }
+  apply(doc) {
+    let node = doc.nodeAt(this.pos);
+    if (!node)
+      return StepResult.fail("No node at mark step's position");
+    let updated = node.type.create(node.attrs, null, this.mark.addToSet(node.marks));
+    return StepResult.fromReplace(doc, this.pos, this.pos + 1, new Slice(Fragment.from(updated), 0, node.isLeaf ? 0 : 1));
+  }
+  invert(doc) {
+    let node = doc.nodeAt(this.pos);
+    if (node) {
+      let newSet = this.mark.addToSet(node.marks);
+      if (newSet.length == node.marks.length) {
+        for (let i = 0; i < node.marks.length; i++)
+          if (!node.marks[i].isInSet(newSet))
+            return new AddNodeMarkStep(this.pos, node.marks[i]);
+        return new AddNodeMarkStep(this.pos, this.mark);
+      }
+    }
+    return new RemoveNodeMarkStep(this.pos, this.mark);
+  }
+  map(mapping) {
+    let pos = mapping.mapResult(this.pos, 1);
+    return pos.deletedAfter ? null : new AddNodeMarkStep(pos.pos, this.mark);
+  }
+  toJSON() {
+    return { stepType: "addNodeMark", pos: this.pos, mark: this.mark.toJSON() };
+  }
+  /**
+  @internal
+  */
+  static fromJSON(schema, json) {
+    if (typeof json.pos != "number")
+      throw new RangeError("Invalid input for AddNodeMarkStep.fromJSON");
+    return new AddNodeMarkStep(json.pos, schema.markFromJSON(json.mark));
+  }
+}
+Step.jsonID("addNodeMark", AddNodeMarkStep);
+class RemoveNodeMarkStep extends Step {
+  /**
+  Create a mark-removing step.
+  */
+  constructor(pos, mark) {
+    super();
+    this.pos = pos;
+    this.mark = mark;
+  }
+  apply(doc) {
+    let node = doc.nodeAt(this.pos);
+    if (!node)
+      return StepResult.fail("No node at mark step's position");
+    let updated = node.type.create(node.attrs, null, this.mark.removeFromSet(node.marks));
+    return StepResult.fromReplace(doc, this.pos, this.pos + 1, new Slice(Fragment.from(updated), 0, node.isLeaf ? 0 : 1));
+  }
+  invert(doc) {
+    let node = doc.nodeAt(this.pos);
+    if (!node || !this.mark.isInSet(node.marks))
+      return this;
+    return new AddNodeMarkStep(this.pos, this.mark);
+  }
+  map(mapping) {
+    let pos = mapping.mapResult(this.pos, 1);
+    return pos.deletedAfter ? null : new RemoveNodeMarkStep(pos.pos, this.mark);
+  }
+  toJSON() {
+    return { stepType: "removeNodeMark", pos: this.pos, mark: this.mark.toJSON() };
+  }
+  /**
+  @internal
+  */
+  static fromJSON(schema, json) {
+    if (typeof json.pos != "number")
+      throw new RangeError("Invalid input for RemoveNodeMarkStep.fromJSON");
+    return new RemoveNodeMarkStep(json.pos, schema.markFromJSON(json.mark));
+  }
+}
+Step.jsonID("removeNodeMark", RemoveNodeMarkStep);
+class ReplaceStep extends Step {
+  /**
+  The given `slice` should fit the 'gap' between `from` and
+  `to`—the depths must line up, and the surrounding nodes must be
+  able to be joined with the open sides of the slice. When
+  `structure` is true, the step will fail if the content between
+  from and to is not just a sequence of closing and then opening
+  tokens (this is to guard against rebased replace steps
+  overwriting something they weren't supposed to).
+  */
+  constructor(from, to, slice, structure = false) {
+    super();
+    this.from = from;
+    this.to = to;
+    this.slice = slice;
+    this.structure = structure;
+  }
+  apply(doc) {
+    if (this.structure && contentBetween(doc, this.from, this.to))
+      return StepResult.fail("Structure replace would overwrite content");
+    return StepResult.fromReplace(doc, this.from, this.to, this.slice);
+  }
+  getMap() {
+    return new StepMap([this.from, this.to - this.from, this.slice.size]);
+  }
+  invert(doc) {
+    return new ReplaceStep(this.from, this.from + this.slice.size, doc.slice(this.from, this.to));
+  }
+  map(mapping) {
+    let to = mapping.mapResult(this.to, -1);
+    let from = this.from == this.to && ReplaceStep.MAP_BIAS < 0 ? to : mapping.mapResult(this.from, 1);
+    if (from.deletedAcross && to.deletedAcross)
+      return null;
+    return new ReplaceStep(from.pos, Math.max(from.pos, to.pos), this.slice, this.structure);
+  }
+  merge(other) {
+    if (!(other instanceof ReplaceStep) || other.structure || this.structure)
+      return null;
+    if (this.from + this.slice.size == other.from && !this.slice.openEnd && !other.slice.openStart) {
+      let slice = this.slice.size + other.slice.size == 0 ? Slice.empty : new Slice(this.slice.content.append(other.slice.content), this.slice.openStart, other.slice.openEnd);
+      return new ReplaceStep(this.from, this.to + (other.to - other.from), slice, this.structure);
+    } else if (other.to == this.from && !this.slice.openStart && !other.slice.openEnd) {
+      let slice = this.slice.size + other.slice.size == 0 ? Slice.empty : new Slice(other.slice.content.append(this.slice.content), other.slice.openStart, this.slice.openEnd);
+      return new ReplaceStep(other.from, this.to, slice, this.structure);
+    } else {
+      return null;
+    }
+  }
+  toJSON() {
+    let json = { stepType: "replace", from: this.from, to: this.to };
+    if (this.slice.size)
+      json.slice = this.slice.toJSON();
+    if (this.structure)
+      json.structure = true;
+    return json;
+  }
+  /**
+  @internal
+  */
+  static fromJSON(schema, json) {
+    if (typeof json.from != "number" || typeof json.to != "number")
+      throw new RangeError("Invalid input for ReplaceStep.fromJSON");
+    return new ReplaceStep(json.from, json.to, Slice.fromJSON(schema, json.slice), !!json.structure);
+  }
+}
+ReplaceStep.MAP_BIAS = 1;
+Step.jsonID("replace", ReplaceStep);
+class ReplaceAroundStep extends Step {
+  /**
+  Create a replace-around step with the given range and gap.
+  `insert` should be the point in the slice into which the content
+  of the gap should be moved. `structure` has the same meaning as
+  it has in the [`ReplaceStep`](https://prosemirror.net/docs/ref/#transform.ReplaceStep) class.
+  */
+  constructor(from, to, gapFrom, gapTo, slice, insert, structure = false) {
+    super();
+    this.from = from;
+    this.to = to;
+    this.gapFrom = gapFrom;
+    this.gapTo = gapTo;
+    this.slice = slice;
+    this.insert = insert;
+    this.structure = structure;
+  }
+  apply(doc) {
+    if (this.structure && (contentBetween(doc, this.from, this.gapFrom) || contentBetween(doc, this.gapTo, this.to)))
+      return StepResult.fail("Structure gap-replace would overwrite content");
+    let gap = doc.slice(this.gapFrom, this.gapTo);
+    if (gap.openStart || gap.openEnd)
+      return StepResult.fail("Gap is not a flat range");
+    let inserted = this.slice.insertAt(this.insert, gap.content);
+    if (!inserted)
+      return StepResult.fail("Content does not fit in gap");
+    return StepResult.fromReplace(doc, this.from, this.to, inserted);
+  }
+  getMap() {
+    return new StepMap([
+      this.from,
+      this.gapFrom - this.from,
+      this.insert,
+      this.gapTo,
+      this.to - this.gapTo,
+      this.slice.size - this.insert
+    ]);
+  }
+  invert(doc) {
+    let gap = this.gapTo - this.gapFrom;
+    return new ReplaceAroundStep(this.from, this.from + this.slice.size + gap, this.from + this.insert, this.from + this.insert + gap, doc.slice(this.from, this.to).removeBetween(this.gapFrom - this.from, this.gapTo - this.from), this.gapFrom - this.from, this.structure);
+  }
+  map(mapping) {
+    let from = mapping.mapResult(this.from, 1), to = mapping.mapResult(this.to, -1);
+    let gapFrom = this.from == this.gapFrom ? from.pos : mapping.map(this.gapFrom, -1);
+    let gapTo = this.to == this.gapTo ? to.pos : mapping.map(this.gapTo, 1);
+    if (from.deletedAcross && to.deletedAcross || gapFrom < from.pos || gapTo > to.pos)
+      return null;
+    return new ReplaceAroundStep(from.pos, to.pos, gapFrom, gapTo, this.slice, this.insert, this.structure);
+  }
+  toJSON() {
+    let json = {
+      stepType: "replaceAround",
+      from: this.from,
+      to: this.to,
+      gapFrom: this.gapFrom,
+      gapTo: this.gapTo,
+      insert: this.insert
+    };
+    if (this.slice.size)
+      json.slice = this.slice.toJSON();
+    if (this.structure)
+      json.structure = true;
+    return json;
+  }
+  /**
+  @internal
+  */
+  static fromJSON(schema, json) {
+    if (typeof json.from != "number" || typeof json.to != "number" || typeof json.gapFrom != "number" || typeof json.gapTo != "number" || typeof json.insert != "number")
+      throw new RangeError("Invalid input for ReplaceAroundStep.fromJSON");
+    return new ReplaceAroundStep(json.from, json.to, json.gapFrom, json.gapTo, Slice.fromJSON(schema, json.slice), json.insert, !!json.structure);
+  }
+}
+Step.jsonID("replaceAround", ReplaceAroundStep);
+function contentBetween(doc, from, to) {
+  let $from = doc.resolve(from), dist = to - from, depth = $from.depth;
+  while (dist > 0 && depth > 0 && $from.indexAfter(depth) == $from.node(depth).childCount) {
+    depth--;
+    dist--;
+  }
+  if (dist > 0) {
+    let next = $from.node(depth).maybeChild($from.indexAfter(depth));
+    while (dist > 0) {
+      if (!next || next.isLeaf)
+        return true;
+      next = next.firstChild;
+      dist--;
+    }
+  }
+  return false;
+}
+function addMark(tr, from, to, mark) {
+  let removed = [], added = [];
+  let removing, adding;
+  tr.doc.nodesBetween(from, to, (node, pos, parent) => {
+    if (!node.isInline)
+      return;
+    let marks = node.marks;
+    if (!mark.isInSet(marks) && parent.type.allowsMarkType(mark.type)) {
+      let start = Math.max(pos, from), end = Math.min(pos + node.nodeSize, to);
+      let newSet = mark.addToSet(marks);
+      for (let i = 0; i < marks.length; i++) {
+        if (!marks[i].isInSet(newSet)) {
+          if (removing && removing.to == start && removing.mark.eq(marks[i]))
+            removing.to = end;
+          else
+            removed.push(removing = new RemoveMarkStep(start, end, marks[i]));
+        }
+      }
+      if (adding && adding.to == start)
+        adding.to = end;
+      else
+        added.push(adding = new AddMarkStep(start, end, mark));
+    }
+  });
+  removed.forEach((s) => tr.step(s));
+  added.forEach((s) => tr.step(s));
+}
+function removeMark(tr, from, to, mark) {
+  let matched = [], step = 0;
+  tr.doc.nodesBetween(from, to, (node, pos) => {
+    if (!node.isInline)
+      return;
+    step++;
+    let toRemove = null;
+    if (mark instanceof MarkType) {
+      let set = node.marks, found2;
+      while (found2 = mark.isInSet(set)) {
+        (toRemove || (toRemove = [])).push(found2);
+        set = found2.removeFromSet(set);
+      }
+    } else if (mark) {
+      if (mark.isInSet(node.marks))
+        toRemove = [mark];
+    } else {
+      toRemove = node.marks;
+    }
+    if (toRemove && toRemove.length) {
+      let end = Math.min(pos + node.nodeSize, to);
+      for (let i = 0; i < toRemove.length; i++) {
+        let style = toRemove[i], found2;
+        for (let j = 0; j < matched.length; j++) {
+          let m = matched[j];
+          if (m.step == step - 1 && style.eq(matched[j].style))
+            found2 = m;
+        }
+        if (found2) {
+          found2.to = end;
+          found2.step = step;
+        } else {
+          matched.push({ style, from: Math.max(pos, from), to: end, step });
+        }
+      }
+    }
+  });
+  matched.forEach((m) => tr.step(new RemoveMarkStep(m.from, m.to, m.style)));
+}
+function clearIncompatible(tr, pos, parentType, match = parentType.contentMatch, clearNewlines = true) {
+  let node = tr.doc.nodeAt(pos);
+  let replSteps = [], cur = pos + 1;
+  for (let i = 0; i < node.childCount; i++) {
+    let child = node.child(i), end = cur + child.nodeSize;
+    let allowed = match.matchType(child.type);
+    if (!allowed) {
+      replSteps.push(new ReplaceStep(cur, end, Slice.empty));
+    } else {
+      match = allowed;
+      for (let j = 0; j < child.marks.length; j++)
+        if (!parentType.allowsMarkType(child.marks[j].type))
+          tr.step(new RemoveMarkStep(cur, end, child.marks[j]));
+      if (clearNewlines && child.isText && parentType.whitespace != "pre") {
+        let m, newline = /\r?\n|\r/g, slice;
+        while (m = newline.exec(child.text)) {
+          if (!slice)
+            slice = new Slice(Fragment.from(parentType.schema.text(" ", parentType.allowedMarks(child.marks))), 0, 0);
+          replSteps.push(new ReplaceStep(cur + m.index, cur + m.index + m[0].length, slice));
+        }
+      }
+    }
+    cur = end;
+  }
+  if (!match.validEnd) {
+    let fill = match.fillBefore(Fragment.empty, true);
+    tr.replace(cur, cur, new Slice(fill, 0, 0));
+  }
+  for (let i = replSteps.length - 1; i >= 0; i--)
+    tr.step(replSteps[i]);
+}
+function canCut(node, start, end) {
+  return (start == 0 || node.canReplace(start, node.childCount)) && (end == node.childCount || node.canReplace(0, end));
+}
+function liftTarget(range) {
+  let parent = range.parent;
+  let content = parent.content.cutByIndex(range.startIndex, range.endIndex);
+  for (let depth = range.depth, contentBefore = 0, contentAfter = 0; ; --depth) {
+    let node = range.$from.node(depth);
+    let index = range.$from.index(depth) + contentBefore, endIndex = range.$to.indexAfter(depth) - contentAfter;
+    if (depth < range.depth && node.canReplace(index, endIndex, content))
+      return depth;
+    if (depth == 0 || node.type.spec.isolating || !canCut(node, index, endIndex))
+      break;
+    if (index)
+      contentBefore = 1;
+    if (endIndex < node.childCount)
+      contentAfter = 1;
+  }
+  return null;
+}
+function lift$2(tr, range, target) {
+  let { $from, $to, depth } = range;
+  let gapStart = $from.before(depth + 1), gapEnd = $to.after(depth + 1);
+  let start = gapStart, end = gapEnd;
+  let before = Fragment.empty, openStart = 0;
+  for (let d = depth, splitting = false; d > target; d--)
+    if (splitting || $from.index(d) > 0) {
+      splitting = true;
+      before = Fragment.from($from.node(d).copy(before));
+      openStart++;
+    } else {
+      start--;
+    }
+  let after = Fragment.empty, openEnd = 0;
+  for (let d = depth, splitting = false; d > target; d--)
+    if (splitting || $to.after(d + 1) < $to.end(d)) {
+      splitting = true;
+      after = Fragment.from($to.node(d).copy(after));
+      openEnd++;
+    } else {
+      end++;
+    }
+  tr.step(new ReplaceAroundStep(start, end, gapStart, gapEnd, new Slice(before.append(after), openStart, openEnd), before.size - openStart, true));
+}
+function findWrapping(range, nodeType, attrs = null, innerRange = range) {
+  let around = findWrappingOutside(range, nodeType);
+  let inner = around && findWrappingInside(innerRange, nodeType);
+  if (!inner)
+    return null;
+  return around.map(withAttrs).concat({ type: nodeType, attrs }).concat(inner.map(withAttrs));
+}
+function withAttrs(type) {
+  return { type, attrs: null };
+}
+function findWrappingOutside(range, type) {
+  let { parent, startIndex, endIndex } = range;
+  let around = parent.contentMatchAt(startIndex).findWrapping(type);
+  if (!around)
+    return null;
+  let outer = around.length ? around[0] : type;
+  return parent.canReplaceWith(startIndex, endIndex, outer) ? around : null;
+}
+function findWrappingInside(range, type) {
+  let { parent, startIndex, endIndex } = range;
+  let inner = parent.child(startIndex);
+  let inside = type.contentMatch.findWrapping(inner.type);
+  if (!inside)
+    return null;
+  let lastType = inside.length ? inside[inside.length - 1] : type;
+  let innerMatch = lastType.contentMatch;
+  for (let i = startIndex; innerMatch && i < endIndex; i++)
+    innerMatch = innerMatch.matchType(parent.child(i).type);
+  if (!innerMatch || !innerMatch.validEnd)
+    return null;
+  return inside;
+}
+function wrap(tr, range, wrappers) {
+  let content = Fragment.empty;
+  for (let i = wrappers.length - 1; i >= 0; i--) {
+    if (content.size) {
+      let match = wrappers[i].type.contentMatch.matchFragment(content);
+      if (!match || !match.validEnd)
+        throw new RangeError("Wrapper type given to Transform.wrap does not form valid content of its parent wrapper");
+    }
+    content = Fragment.from(wrappers[i].type.create(wrappers[i].attrs, content));
+  }
+  let start = range.start, end = range.end;
+  tr.step(new ReplaceAroundStep(start, end, start, end, new Slice(content, 0, 0), wrappers.length, true));
+}
+function setBlockType$1(tr, from, to, type, attrs) {
+  if (!type.isTextblock)
+    throw new RangeError("Type given to setBlockType should be a textblock");
+  let mapFrom = tr.steps.length;
+  tr.doc.nodesBetween(from, to, (node, pos) => {
+    let attrsHere = typeof attrs == "function" ? attrs(node) : attrs;
+    if (node.isTextblock && !node.hasMarkup(type, attrsHere) && canChangeType(tr.doc, tr.mapping.slice(mapFrom).map(pos), type)) {
+      let convertNewlines = null;
+      if (type.schema.linebreakReplacement) {
+        let pre = type.whitespace == "pre", supportLinebreak = !!type.contentMatch.matchType(type.schema.linebreakReplacement);
+        if (pre && !supportLinebreak)
+          convertNewlines = false;
+        else if (!pre && supportLinebreak)
+          convertNewlines = true;
+      }
+      if (convertNewlines === false)
+        replaceLinebreaks(tr, node, pos, mapFrom);
+      clearIncompatible(tr, tr.mapping.slice(mapFrom).map(pos, 1), type, void 0, convertNewlines === null);
+      let mapping = tr.mapping.slice(mapFrom);
+      let startM = mapping.map(pos, 1), endM = mapping.map(pos + node.nodeSize, 1);
+      tr.step(new ReplaceAroundStep(startM, endM, startM + 1, endM - 1, new Slice(Fragment.from(type.create(attrsHere, null, node.marks)), 0, 0), 1, true));
+      if (convertNewlines === true)
+        replaceNewlines(tr, node, pos, mapFrom);
+      return false;
+    }
+  });
+}
+function replaceNewlines(tr, node, pos, mapFrom) {
+  node.forEach((child, offset) => {
+    if (child.isText) {
+      let m, newline = /\r?\n|\r/g;
+      while (m = newline.exec(child.text)) {
+        let start = tr.mapping.slice(mapFrom).map(pos + 1 + offset + m.index);
+        tr.replaceWith(start, start + 1, node.type.schema.linebreakReplacement.create());
+      }
+    }
+  });
+}
+function replaceLinebreaks(tr, node, pos, mapFrom) {
+  node.forEach((child, offset) => {
+    if (child.type == child.type.schema.linebreakReplacement) {
+      let start = tr.mapping.slice(mapFrom).map(pos + 1 + offset);
+      tr.replaceWith(start, start + 1, node.type.schema.text("\n"));
+    }
+  });
+}
+function canChangeType(doc, pos, type) {
+  let $pos = doc.resolve(pos), index = $pos.index();
+  return $pos.parent.canReplaceWith(index, index + 1, type);
+}
+function setNodeMarkup(tr, pos, type, attrs, marks) {
+  let node = tr.doc.nodeAt(pos);
+  if (!node)
+    throw new RangeError("No node at given position");
+  if (!type)
+    type = node.type;
+  let newNode = type.create(attrs, null, marks || node.marks);
+  if (node.isLeaf)
+    return tr.replaceWith(pos, pos + node.nodeSize, newNode);
+  if (!type.validContent(node.content))
+    throw new RangeError("Invalid content for node type " + type.name);
+  tr.step(new ReplaceAroundStep(pos, pos + node.nodeSize, pos + 1, pos + node.nodeSize - 1, new Slice(Fragment.from(newNode), 0, 0), 1, true));
+}
+function canSplit(doc, pos, depth = 1, typesAfter) {
+  let $pos = doc.resolve(pos), base = $pos.depth - depth;
+  let innerType = typesAfter && typesAfter[typesAfter.length - 1] || $pos.parent;
+  if (base < 0 || $pos.parent.type.spec.isolating || !$pos.parent.canReplace($pos.index(), $pos.parent.childCount) || !innerType.type.validContent($pos.parent.content.cutByIndex($pos.index(), $pos.parent.childCount)))
+    return false;
+  for (let d = $pos.depth - 1, i = depth - 2; d > base; d--, i--) {
+    let node = $pos.node(d), index2 = $pos.index(d);
+    if (node.type.spec.isolating)
+      return false;
+    let rest = node.content.cutByIndex(index2, node.childCount);
+    let overrideChild = typesAfter && typesAfter[i + 1];
+    if (overrideChild)
+      rest = rest.replaceChild(0, overrideChild.type.create(overrideChild.attrs));
+    let after = typesAfter && typesAfter[i] || node;
+    if (!node.canReplace(index2 + 1, node.childCount) || !after.type.validContent(rest))
+      return false;
+  }
+  let index = $pos.indexAfter(base);
+  let baseType = typesAfter && typesAfter[0];
+  return $pos.node(base).canReplaceWith(index, index, baseType ? baseType.type : $pos.node(base + 1).type);
+}
+function split(tr, pos, depth = 1, typesAfter) {
+  let $pos = tr.doc.resolve(pos), before = Fragment.empty, after = Fragment.empty;
+  for (let d = $pos.depth, e = $pos.depth - depth, i = depth - 1; d > e; d--, i--) {
+    before = Fragment.from($pos.node(d).copy(before));
+    let typeAfter = typesAfter && typesAfter[i];
+    after = Fragment.from(typeAfter ? typeAfter.type.create(typeAfter.attrs, after) : $pos.node(d).copy(after));
+  }
+  tr.step(new ReplaceStep(pos, pos, new Slice(before.append(after), depth, depth), true));
+}
+function canJoin(doc, pos) {
+  let $pos = doc.resolve(pos), index = $pos.index();
+  return joinable($pos.nodeBefore, $pos.nodeAfter) && $pos.parent.canReplace(index, index + 1);
+}
+function canAppendWithSubstitutedLinebreaks(a, b) {
+  if (!b.content.size)
+    a.type.compatibleContent(b.type);
+  let match = a.contentMatchAt(a.childCount);
+  let { linebreakReplacement } = a.type.schema;
+  for (let i = 0; i < b.childCount; i++) {
+    let child = b.child(i);
+    let type = child.type == linebreakReplacement ? a.type.schema.nodes.text : child.type;
+    match = match.matchType(type);
+    if (!match)
+      return false;
+    if (!a.type.allowsMarks(child.marks))
+      return false;
+  }
+  return match.validEnd;
+}
+function joinable(a, b) {
+  return !!(a && b && !a.isLeaf && canAppendWithSubstitutedLinebreaks(a, b));
+}
+function joinPoint(doc, pos, dir = -1) {
+  let $pos = doc.resolve(pos);
+  for (let d = $pos.depth; ; d--) {
+    let before, after, index = $pos.index(d);
+    if (d == $pos.depth) {
+      before = $pos.nodeBefore;
+      after = $pos.nodeAfter;
+    } else if (dir > 0) {
+      before = $pos.node(d + 1);
+      index++;
+      after = $pos.node(d).maybeChild(index);
+    } else {
+      before = $pos.node(d).maybeChild(index - 1);
+      after = $pos.node(d + 1);
+    }
+    if (before && !before.isTextblock && joinable(before, after) && $pos.node(d).canReplace(index, index + 1))
+      return pos;
+    if (d == 0)
+      break;
+    pos = dir < 0 ? $pos.before(d) : $pos.after(d);
+  }
+}
+function join(tr, pos, depth) {
+  let convertNewlines = null;
+  let { linebreakReplacement } = tr.doc.type.schema;
+  let $before = tr.doc.resolve(pos - depth), beforeType = $before.node().type;
+  if (linebreakReplacement && beforeType.inlineContent) {
+    let pre = beforeType.whitespace == "pre";
+    let supportLinebreak = !!beforeType.contentMatch.matchType(linebreakReplacement);
+    if (pre && !supportLinebreak)
+      convertNewlines = false;
+    else if (!pre && supportLinebreak)
+      convertNewlines = true;
+  }
+  let mapFrom = tr.steps.length;
+  if (convertNewlines === false) {
+    let $after = tr.doc.resolve(pos + depth);
+    replaceLinebreaks(tr, $after.node(), $after.before(), mapFrom);
+  }
+  if (beforeType.inlineContent)
+    clearIncompatible(tr, pos + depth - 1, beforeType, $before.node().contentMatchAt($before.index()), convertNewlines == null);
+  let mapping = tr.mapping.slice(mapFrom), start = mapping.map(pos - depth);
+  tr.step(new ReplaceStep(start, mapping.map(pos + depth, -1), Slice.empty, true));
+  if (convertNewlines === true) {
+    let $full = tr.doc.resolve(start);
+    replaceNewlines(tr, $full.node(), $full.before(), tr.steps.length);
+  }
+  return tr;
+}
+function insertPoint(doc, pos, nodeType) {
+  let $pos = doc.resolve(pos);
+  if ($pos.parent.canReplaceWith($pos.index(), $pos.index(), nodeType))
+    return pos;
+  if ($pos.parentOffset == 0)
+    for (let d = $pos.depth - 1; d >= 0; d--) {
+      let index = $pos.index(d);
+      if ($pos.node(d).canReplaceWith(index, index, nodeType))
+        return $pos.before(d + 1);
+      if (index > 0)
+        return null;
+    }
+  if ($pos.parentOffset == $pos.parent.content.size)
+    for (let d = $pos.depth - 1; d >= 0; d--) {
+      let index = $pos.indexAfter(d);
+      if ($pos.node(d).canReplaceWith(index, index, nodeType))
+        return $pos.after(d + 1);
+      if (index < $pos.node(d).childCount)
+        return null;
+    }
+  return null;
+}
+function replaceStep(doc, from, to = from, slice = Slice.empty) {
+  if (from == to && !slice.size)
+    return null;
+  let $from = doc.resolve(from), $to = doc.resolve(to);
+  if (fitsTrivially($from, $to, slice))
+    return new ReplaceStep(from, to, slice);
+  return new Fitter($from, $to, slice).fit();
+}
+function fitsTrivially($from, $to, slice) {
+  return !slice.openStart && !slice.openEnd && $from.start() == $to.start() && $from.parent.canReplace($from.index(), $to.index(), slice.content);
+}
+class Fitter {
+  constructor($from, $to, unplaced) {
+    this.$from = $from;
+    this.$to = $to;
+    this.unplaced = unplaced;
+    this.frontier = [];
+    this.placed = Fragment.empty;
+    for (let i = 0; i <= $from.depth; i++) {
+      let node = $from.node(i);
+      this.frontier.push({
+        type: node.type,
+        match: node.contentMatchAt($from.indexAfter(i))
+      });
+    }
+    for (let i = $from.depth; i > 0; i--)
+      this.placed = Fragment.from($from.node(i).copy(this.placed));
+  }
+  get depth() {
+    return this.frontier.length - 1;
+  }
+  fit() {
+    while (this.unplaced.size) {
+      let fit = this.findFittable();
+      if (fit)
+        this.placeNodes(fit);
+      else
+        this.openMore() || this.dropNode();
+    }
+    let moveInline = this.mustMoveInline(), placedSize = this.placed.size - this.depth - this.$from.depth;
+    let $from = this.$from, $to = this.close(moveInline < 0 ? this.$to : $from.doc.resolve(moveInline));
+    if (!$to)
+      return null;
+    let content = this.placed, openStart = $from.depth, openEnd = $to.depth;
+    while (openStart && openEnd && content.childCount == 1) {
+      content = content.firstChild.content;
+      openStart--;
+      openEnd--;
+    }
+    let slice = new Slice(content, openStart, openEnd);
+    if (moveInline > -1)
+      return new ReplaceAroundStep($from.pos, moveInline, this.$to.pos, this.$to.end(), slice, placedSize);
+    if (slice.size || $from.pos != this.$to.pos)
+      return new ReplaceStep($from.pos, $to.pos, slice);
+    return null;
+  }
+  // Find a position on the start spine of `this.unplaced` that has
+  // content that can be moved somewhere on the frontier. Returns two
+  // depths, one for the slice and one for the frontier.
+  findFittable() {
+    let startDepth = this.unplaced.openStart;
+    for (let cur = this.unplaced.content, d = 0, openEnd = this.unplaced.openEnd; d < startDepth; d++) {
+      let node = cur.firstChild;
+      if (cur.childCount > 1)
+        openEnd = 0;
+      if (node.type.spec.isolating && openEnd <= d) {
+        startDepth = d;
+        break;
+      }
+      cur = node.content;
+    }
+    for (let pass = 1; pass <= 2; pass++) {
+      for (let sliceDepth = pass == 1 ? startDepth : this.unplaced.openStart; sliceDepth >= 0; sliceDepth--) {
+        let fragment, parent = null;
+        if (sliceDepth) {
+          parent = contentAt(this.unplaced.content, sliceDepth - 1).firstChild;
+          fragment = parent.content;
+        } else {
+          fragment = this.unplaced.content;
+        }
+        let first2 = fragment.firstChild;
+        for (let frontierDepth = this.depth; frontierDepth >= 0; frontierDepth--) {
+          let { type, match } = this.frontier[frontierDepth], wrap2, inject = null;
+          if (pass == 1 && (first2 ? match.matchType(first2.type) || (inject = match.fillBefore(Fragment.from(first2), false)) : parent && type.compatibleContent(parent.type)))
+            return { sliceDepth, frontierDepth, parent, inject };
+          else if (pass == 2 && first2 && (wrap2 = match.findWrapping(first2.type)))
+            return { sliceDepth, frontierDepth, parent, wrap: wrap2 };
+          if (parent && match.matchType(parent.type))
+            break;
+        }
+      }
+    }
+  }
+  openMore() {
+    let { content, openStart, openEnd } = this.unplaced;
+    let inner = contentAt(content, openStart);
+    if (!inner.childCount || inner.firstChild.isLeaf)
+      return false;
+    this.unplaced = new Slice(content, openStart + 1, Math.max(openEnd, inner.size + openStart >= content.size - openEnd ? openStart + 1 : 0));
+    return true;
+  }
+  dropNode() {
+    let { content, openStart, openEnd } = this.unplaced;
+    let inner = contentAt(content, openStart);
+    if (inner.childCount <= 1 && openStart > 0) {
+      let openAtEnd = content.size - openStart <= openStart + inner.size;
+      this.unplaced = new Slice(dropFromFragment(content, openStart - 1, 1), openStart - 1, openAtEnd ? openStart - 1 : openEnd);
+    } else {
+      this.unplaced = new Slice(dropFromFragment(content, openStart, 1), openStart, openEnd);
+    }
+  }
+  // Move content from the unplaced slice at `sliceDepth` to the
+  // frontier node at `frontierDepth`. Close that frontier node when
+  // applicable.
+  placeNodes({ sliceDepth, frontierDepth, parent, inject, wrap: wrap2 }) {
+    while (this.depth > frontierDepth)
+      this.closeFrontierNode();
+    if (wrap2)
+      for (let i = 0; i < wrap2.length; i++)
+        this.openFrontierNode(wrap2[i]);
+    let slice = this.unplaced, fragment = parent ? parent.content : slice.content;
+    let openStart = slice.openStart - sliceDepth;
+    let taken = 0, add = [];
+    let { match, type } = this.frontier[frontierDepth];
+    if (inject) {
+      for (let i = 0; i < inject.childCount; i++)
+        add.push(inject.child(i));
+      match = match.matchFragment(inject);
+    }
+    let openEndCount = fragment.size + sliceDepth - (slice.content.size - slice.openEnd);
+    while (taken < fragment.childCount) {
+      let next = fragment.child(taken), matches2 = match.matchType(next.type);
+      if (!matches2)
+        break;
+      taken++;
+      if (taken > 1 || openStart == 0 || next.content.size) {
+        match = matches2;
+        add.push(closeNodeStart(next.mark(type.allowedMarks(next.marks)), taken == 1 ? openStart : 0, taken == fragment.childCount ? openEndCount : -1));
+      }
+    }
+    let toEnd = taken == fragment.childCount;
+    if (!toEnd)
+      openEndCount = -1;
+    this.placed = addToFragment(this.placed, frontierDepth, Fragment.from(add));
+    this.frontier[frontierDepth].match = match;
+    if (toEnd && openEndCount < 0 && parent && parent.type == this.frontier[this.depth].type && this.frontier.length > 1)
+      this.closeFrontierNode();
+    for (let i = 0, cur = fragment; i < openEndCount; i++) {
+      let node = cur.lastChild;
+      this.frontier.push({ type: node.type, match: node.contentMatchAt(node.childCount) });
+      cur = node.content;
+    }
+    this.unplaced = !toEnd ? new Slice(dropFromFragment(slice.content, sliceDepth, taken), slice.openStart, slice.openEnd) : sliceDepth == 0 ? Slice.empty : new Slice(dropFromFragment(slice.content, sliceDepth - 1, 1), sliceDepth - 1, openEndCount < 0 ? slice.openEnd : sliceDepth - 1);
+  }
+  mustMoveInline() {
+    if (!this.$to.parent.isTextblock)
+      return -1;
+    let top = this.frontier[this.depth], level;
+    if (!top.type.isTextblock || !contentAfterFits(this.$to, this.$to.depth, top.type, top.match, false) || this.$to.depth == this.depth && (level = this.findCloseLevel(this.$to)) && level.depth == this.depth)
+      return -1;
+    let { depth } = this.$to, after = this.$to.after(depth);
+    while (depth > 1 && after == this.$to.end(--depth))
+      ++after;
+    return after;
+  }
+  findCloseLevel($to) {
+    scan: for (let i = Math.min(this.depth, $to.depth); i >= 0; i--) {
+      let { match, type } = this.frontier[i];
+      let dropInner = i < $to.depth && $to.end(i + 1) == $to.pos + ($to.depth - (i + 1));
+      let fit = contentAfterFits($to, i, type, match, dropInner);
+      if (!fit)
+        continue;
+      for (let d = i - 1; d >= 0; d--) {
+        let { match: match2, type: type2 } = this.frontier[d];
+        let matches2 = contentAfterFits($to, d, type2, match2, true);
+        if (!matches2 || matches2.childCount)
+          continue scan;
+      }
+      return { depth: i, fit, move: dropInner ? $to.doc.resolve($to.after(i + 1)) : $to };
+    }
+  }
+  close($to) {
+    let close2 = this.findCloseLevel($to);
+    if (!close2)
+      return null;
+    while (this.depth > close2.depth)
+      this.closeFrontierNode();
+    if (close2.fit.childCount)
+      this.placed = addToFragment(this.placed, close2.depth, close2.fit);
+    $to = close2.move;
+    for (let d = close2.depth + 1; d <= $to.depth; d++) {
+      let node = $to.node(d), add = node.type.contentMatch.fillBefore(node.content, true, $to.index(d));
+      this.openFrontierNode(node.type, node.attrs, add);
+    }
+    return $to;
+  }
+  openFrontierNode(type, attrs = null, content) {
+    let top = this.frontier[this.depth];
+    top.match = top.match.matchType(type);
+    this.placed = addToFragment(this.placed, this.depth, Fragment.from(type.create(attrs, content)));
+    this.frontier.push({ type, match: type.contentMatch });
+  }
+  closeFrontierNode() {
+    let open = this.frontier.pop();
+    let add = open.match.fillBefore(Fragment.empty, true);
+    if (add.childCount)
+      this.placed = addToFragment(this.placed, this.frontier.length, add);
+  }
+}
+function dropFromFragment(fragment, depth, count) {
+  if (depth == 0)
+    return fragment.cutByIndex(count, fragment.childCount);
+  return fragment.replaceChild(0, fragment.firstChild.copy(dropFromFragment(fragment.firstChild.content, depth - 1, count)));
+}
+function addToFragment(fragment, depth, content) {
+  if (depth == 0)
+    return fragment.append(content);
+  return fragment.replaceChild(fragment.childCount - 1, fragment.lastChild.copy(addToFragment(fragment.lastChild.content, depth - 1, content)));
+}
+function contentAt(fragment, depth) {
+  for (let i = 0; i < depth; i++)
+    fragment = fragment.firstChild.content;
+  return fragment;
+}
+function closeNodeStart(node, openStart, openEnd) {
+  if (openStart <= 0)
+    return node;
+  let frag = node.content;
+  if (openStart > 1)
+    frag = frag.replaceChild(0, closeNodeStart(frag.firstChild, openStart - 1, frag.childCount == 1 ? openEnd - 1 : 0));
+  if (openStart > 0) {
+    frag = node.type.contentMatch.fillBefore(frag).append(frag);
+    if (openEnd <= 0)
+      frag = frag.append(node.type.contentMatch.matchFragment(frag).fillBefore(Fragment.empty, true));
+  }
+  return node.copy(frag);
+}
+function contentAfterFits($to, depth, type, match, open) {
+  let node = $to.node(depth), index = open ? $to.indexAfter(depth) : $to.index(depth);
+  if (index == node.childCount && !type.compatibleContent(node.type))
+    return null;
+  let fit = match.fillBefore(node.content, true, index);
+  return fit && !invalidMarks(type, node.content, index) ? fit : null;
+}
+function invalidMarks(type, fragment, start) {
+  for (let i = start; i < fragment.childCount; i++)
+    if (!type.allowsMarks(fragment.child(i).marks))
+      return true;
+  return false;
+}
+function definesContent(type) {
+  return type.spec.defining || type.spec.definingForContent;
+}
+function replaceRange(tr, from, to, slice) {
+  if (!slice.size)
+    return tr.deleteRange(from, to);
+  let $from = tr.doc.resolve(from), $to = tr.doc.resolve(to);
+  if (fitsTrivially($from, $to, slice))
+    return tr.step(new ReplaceStep(from, to, slice));
+  let targetDepths = coveredDepths($from, $to);
+  if (targetDepths[targetDepths.length - 1] == 0)
+    targetDepths.pop();
+  let preferredTarget = -($from.depth + 1);
+  targetDepths.unshift(preferredTarget);
+  for (let d = $from.depth, pos = $from.pos - 1; d > 0; d--, pos--) {
+    let spec = $from.node(d).type.spec;
+    if (spec.defining || spec.definingAsContext || spec.isolating)
+      break;
+    if (targetDepths.indexOf(d) > -1)
+      preferredTarget = d;
+    else if ($from.before(d) == pos)
+      targetDepths.splice(1, 0, -d);
+  }
+  let preferredTargetIndex = targetDepths.indexOf(preferredTarget);
+  let leftNodes = [], preferredDepth = slice.openStart;
+  for (let content = slice.content, i = 0; ; i++) {
+    let node = content.firstChild;
+    leftNodes.push(node);
+    if (i == slice.openStart)
+      break;
+    content = node.content;
+  }
+  for (let d = preferredDepth - 1; d >= 0; d--) {
+    let leftNode = leftNodes[d], def = definesContent(leftNode.type);
+    if (def && !leftNode.sameMarkup($from.node(Math.abs(preferredTarget) - 1)))
+      preferredDepth = d;
+    else if (def || !leftNode.type.isTextblock)
+      break;
+  }
+  for (let j = slice.openStart; j >= 0; j--) {
+    let openDepth = (j + preferredDepth + 1) % (slice.openStart + 1);
+    let insert = leftNodes[openDepth];
+    if (!insert)
+      continue;
+    for (let i = 0; i < targetDepths.length; i++) {
+      let targetDepth = targetDepths[(i + preferredTargetIndex) % targetDepths.length], expand = true;
+      if (targetDepth < 0) {
+        expand = false;
+        targetDepth = -targetDepth;
+      }
+      let parent = $from.node(targetDepth - 1), index = $from.index(targetDepth - 1);
+      if (parent.canReplaceWith(index, index, insert.type, insert.marks))
+        return tr.replace($from.before(targetDepth), expand ? $to.after(targetDepth) : to, new Slice(closeFragment(slice.content, 0, slice.openStart, openDepth), openDepth, slice.openEnd));
+    }
+  }
+  let startSteps = tr.steps.length;
+  for (let i = targetDepths.length - 1; i >= 0; i--) {
+    tr.replace(from, to, slice);
+    if (tr.steps.length > startSteps)
+      break;
+    let depth = targetDepths[i];
+    if (depth < 0)
+      continue;
+    from = $from.before(depth);
+    to = $to.after(depth);
+  }
+}
+function closeFragment(fragment, depth, oldOpen, newOpen, parent) {
+  if (depth < oldOpen) {
+    let first2 = fragment.firstChild;
+    fragment = fragment.replaceChild(0, first2.copy(closeFragment(first2.content, depth + 1, oldOpen, newOpen, first2)));
+  }
+  if (depth > newOpen) {
+    let match = parent.contentMatchAt(0);
+    let start = match.fillBefore(fragment).append(fragment);
+    fragment = start.append(match.matchFragment(start).fillBefore(Fragment.empty, true));
+  }
+  return fragment;
+}
+function replaceRangeWith(tr, from, to, node) {
+  if (!node.isInline && from == to && tr.doc.resolve(from).parent.content.size) {
+    let point = insertPoint(tr.doc, from, node.type);
+    if (point != null)
+      from = to = point;
+  }
+  tr.replaceRange(from, to, new Slice(Fragment.from(node), 0, 0));
+}
+function deleteRange$1(tr, from, to) {
+  let $from = tr.doc.resolve(from), $to = tr.doc.resolve(to);
+  if ($from.parent.isTextblock && $to.parent.isTextblock && $from.start() != $to.start() && $from.parentOffset == 0 && $to.parentOffset == 0) {
+    let shared = $from.sharedDepth(to), isolated = false;
+    for (let d = $from.depth; d > shared; d--)
+      if ($from.node(d).type.spec.isolating)
+        isolated = true;
+    for (let d = $to.depth; d > shared; d--)
+      if ($to.node(d).type.spec.isolating)
+        isolated = true;
+    if (!isolated) {
+      for (let d = $from.depth; d > 0 && from == $from.start(d); d--)
+        from = $from.before(d);
+      for (let d = $to.depth; d > 0 && to == $to.start(d); d--)
+        to = $to.before(d);
+      $from = tr.doc.resolve(from);
+      $to = tr.doc.resolve(to);
+    }
+  }
+  let covered = coveredDepths($from, $to);
+  for (let i = 0; i < covered.length; i++) {
+    let depth = covered[i], last = i == covered.length - 1;
+    if (last && depth == 0 || $from.node(depth).type.contentMatch.validEnd)
+      return tr.delete($from.start(depth), $to.end(depth));
+    if (depth > 0 && (last || $from.node(depth - 1).canReplace($from.index(depth - 1), $to.indexAfter(depth - 1))))
+      return tr.delete($from.before(depth), $to.after(depth));
+  }
+  for (let d = 1; d <= $from.depth && d <= $to.depth; d++) {
+    if (from - $from.start(d) == $from.depth - d && to > $from.end(d) && $to.end(d) - to != $to.depth - d && $from.start(d - 1) == $to.start(d - 1) && $from.node(d - 1).canReplace($from.index(d - 1), $to.index(d - 1)))
+      return tr.delete($from.before(d), to);
+  }
+  tr.delete(from, to);
+}
+function coveredDepths($from, $to) {
+  let result = [], minDepth = Math.min($from.depth, $to.depth);
+  for (let d = minDepth; d >= 0; d--) {
+    let start = $from.start(d);
+    if (start < $from.pos - ($from.depth - d) || $to.end(d) > $to.pos + ($to.depth - d) || $from.node(d).type.spec.isolating || $to.node(d).type.spec.isolating)
+      break;
+    if (start == $to.start(d) || d == $from.depth && d == $to.depth && $from.parent.inlineContent && $to.parent.inlineContent && d && $to.start(d - 1) == start - 1)
+      result.push(d);
+  }
+  return result;
+}
+class AttrStep extends Step {
+  /**
+  Construct an attribute step.
+  */
+  constructor(pos, attr, value) {
+    super();
+    this.pos = pos;
+    this.attr = attr;
+    this.value = value;
+  }
+  apply(doc) {
+    let node = doc.nodeAt(this.pos);
+    if (!node)
+      return StepResult.fail("No node at attribute step's position");
+    let attrs = /* @__PURE__ */ Object.create(null);
+    for (let name in node.attrs)
+      attrs[name] = node.attrs[name];
+    attrs[this.attr] = this.value;
+    let updated = node.type.create(attrs, null, node.marks);
+    return StepResult.fromReplace(doc, this.pos, this.pos + 1, new Slice(Fragment.from(updated), 0, node.isLeaf ? 0 : 1));
+  }
+  getMap() {
+    return StepMap.empty;
+  }
+  invert(doc) {
+    return new AttrStep(this.pos, this.attr, doc.nodeAt(this.pos).attrs[this.attr]);
+  }
+  map(mapping) {
+    let pos = mapping.mapResult(this.pos, 1);
+    return pos.deletedAfter ? null : new AttrStep(pos.pos, this.attr, this.value);
+  }
+  toJSON() {
+    return { stepType: "attr", pos: this.pos, attr: this.attr, value: this.value };
+  }
+  static fromJSON(schema, json) {
+    if (typeof json.pos != "number" || typeof json.attr != "string")
+      throw new RangeError("Invalid input for AttrStep.fromJSON");
+    return new AttrStep(json.pos, json.attr, json.value);
+  }
+}
+Step.jsonID("attr", AttrStep);
+class DocAttrStep extends Step {
+  /**
+  Construct an attribute step.
+  */
+  constructor(attr, value) {
+    super();
+    this.attr = attr;
+    this.value = value;
+  }
+  apply(doc) {
+    let attrs = /* @__PURE__ */ Object.create(null);
+    for (let name in doc.attrs)
+      attrs[name] = doc.attrs[name];
+    attrs[this.attr] = this.value;
+    let updated = doc.type.create(attrs, doc.content, doc.marks);
+    return StepResult.ok(updated);
+  }
+  getMap() {
+    return StepMap.empty;
+  }
+  invert(doc) {
+    return new DocAttrStep(this.attr, doc.attrs[this.attr]);
+  }
+  map(mapping) {
+    return this;
+  }
+  toJSON() {
+    return { stepType: "docAttr", attr: this.attr, value: this.value };
+  }
+  static fromJSON(schema, json) {
+    if (typeof json.attr != "string")
+      throw new RangeError("Invalid input for DocAttrStep.fromJSON");
+    return new DocAttrStep(json.attr, json.value);
+  }
+}
+Step.jsonID("docAttr", DocAttrStep);
+let TransformError = class extends Error {
+};
+TransformError = function TransformError2(message) {
+  let err = Error.call(this, message);
+  err.__proto__ = TransformError2.prototype;
+  return err;
+};
+TransformError.prototype = Object.create(Error.prototype);
+TransformError.prototype.constructor = TransformError;
+TransformError.prototype.name = "TransformError";
+class Transform {
+  /**
+  Create a transform that starts with the given document.
+  */
+  constructor(doc) {
+    this.doc = doc;
+    this.steps = [];
+    this.docs = [];
+    this.mapping = new Mapping();
+  }
+  /**
+  The starting document.
+  */
+  get before() {
+    return this.docs.length ? this.docs[0] : this.doc;
+  }
+  /**
+  Apply a new step in this transform, saving the result. Throws an
+  error when the step fails.
+  */
+  step(step) {
+    let result = this.maybeStep(step);
+    if (result.failed)
+      throw new TransformError(result.failed);
+    return this;
+  }
+  /**
+  Try to apply a step in this transformation, ignoring it if it
+  fails. Returns the step result.
+  */
+  maybeStep(step) {
+    let result = step.apply(this.doc);
+    if (!result.failed)
+      this.addStep(step, result.doc);
+    return result;
+  }
+  /**
+  True when the document has been changed (when there are any
+  steps).
+  */
+  get docChanged() {
+    return this.steps.length > 0;
+  }
+  /**
+  Return a single range, in post-transform document positions,
+  that covers all content changed by this transform. Returns null
+  if no replacements are made. Note that this will ignore changes
+  that add/remove marks without replacing the underlying content.
+  */
+  changedRange() {
+    let from = 1e9, to = -1e9;
+    for (let i = 0; i < this.mapping.maps.length; i++) {
+      let map = this.mapping.maps[i];
+      if (i) {
+        from = map.map(from, 1);
+        to = map.map(to, -1);
+      }
+      map.forEach((_f, _t, fromB, toB) => {
+        from = Math.min(from, fromB);
+        to = Math.max(to, toB);
+      });
+    }
+    return from == 1e9 ? null : { from, to };
+  }
+  /**
+  @internal
+  */
+  addStep(step, doc) {
+    this.docs.push(this.doc);
+    this.steps.push(step);
+    this.mapping.appendMap(step.getMap());
+    this.doc = doc;
+  }
+  /**
+  Replace the part of the document between `from` and `to` with the
+  given `slice`.
+  */
+  replace(from, to = from, slice = Slice.empty) {
+    let step = replaceStep(this.doc, from, to, slice);
+    if (step)
+      this.step(step);
+    return this;
+  }
+  /**
+  Replace the given range with the given content, which may be a
+  fragment, node, or array of nodes.
+  */
+  replaceWith(from, to, content) {
+    return this.replace(from, to, new Slice(Fragment.from(content), 0, 0));
+  }
+  /**
+  Delete the content between the given positions.
+  */
+  delete(from, to) {
+    return this.replace(from, to, Slice.empty);
+  }
+  /**
+  Insert the given content at the given position.
+  */
+  insert(pos, content) {
+    return this.replaceWith(pos, pos, content);
+  }
+  /**
+  Replace a range of the document with a given slice, using
+  `from`, `to`, and the slice's
+  [`openStart`](https://prosemirror.net/docs/ref/#model.Slice.openStart) property as hints, rather
+  than fixed start and end points. This method may grow the
+  replaced area or close open nodes in the slice in order to get a
+  fit that is more in line with WYSIWYG expectations, by dropping
+  fully covered parent nodes of the replaced region when they are
+  marked [non-defining as
+  context](https://prosemirror.net/docs/ref/#model.NodeSpec.definingAsContext), or including an
+  open parent node from the slice that _is_ marked as [defining
+  its content](https://prosemirror.net/docs/ref/#model.NodeSpec.definingForContent).
+  
+  This is the method, for example, to handle paste. The similar
+  [`replace`](https://prosemirror.net/docs/ref/#transform.Transform.replace) method is a more
+  primitive tool which will _not_ move the start and end of its given
+  range, and is useful in situations where you need more precise
+  control over what happens.
+  */
+  replaceRange(from, to, slice) {
+    replaceRange(this, from, to, slice);
+    return this;
+  }
+  /**
+  Replace the given range with a node, but use `from` and `to` as
+  hints, rather than precise positions. When from and to are the same
+  and are at the start or end of a parent node in which the given
+  node doesn't fit, this method may _move_ them out towards a parent
+  that does allow the given node to be placed. When the given range
+  completely covers a parent node, this method may completely replace
+  that parent node.
+  */
+  replaceRangeWith(from, to, node) {
+    replaceRangeWith(this, from, to, node);
+    return this;
+  }
+  /**
+  Delete the given range, expanding it to cover fully covered
+  parent nodes until a valid replace is found.
+  */
+  deleteRange(from, to) {
+    deleteRange$1(this, from, to);
+    return this;
+  }
+  /**
+  Split the content in the given range off from its parent, if there
+  is sibling content before or after it, and move it up the tree to
+  the depth specified by `target`. You'll probably want to use
+  [`liftTarget`](https://prosemirror.net/docs/ref/#transform.liftTarget) to compute `target`, to make
+  sure the lift is valid.
+  */
+  lift(range, target) {
+    lift$2(this, range, target);
+    return this;
+  }
+  /**
+  Join the blocks around the given position. If depth is 2, their
+  last and first siblings are also joined, and so on.
+  */
+  join(pos, depth = 1) {
+    join(this, pos, depth);
+    return this;
+  }
+  /**
+  Wrap the given [range](https://prosemirror.net/docs/ref/#model.NodeRange) in the given set of wrappers.
+  The wrappers are assumed to be valid in this position, and should
+  probably be computed with [`findWrapping`](https://prosemirror.net/docs/ref/#transform.findWrapping).
+  */
+  wrap(range, wrappers) {
+    wrap(this, range, wrappers);
+    return this;
+  }
+  /**
+  Set the type of all textblocks (partly) between `from` and `to` to
+  the given node type with the given attributes.
+  */
+  setBlockType(from, to = from, type, attrs = null) {
+    setBlockType$1(this, from, to, type, attrs);
+    return this;
+  }
+  /**
+  Change the type, attributes, and/or marks of the node at `pos`.
+  When `type` isn't given, the existing node type is preserved,
+  */
+  setNodeMarkup(pos, type, attrs = null, marks) {
+    setNodeMarkup(this, pos, type, attrs, marks);
+    return this;
+  }
+  /**
+  Set a single attribute on a given node to a new value.
+  The `pos` addresses the document content. Use `setDocAttribute`
+  to set attributes on the document itself.
+  */
+  setNodeAttribute(pos, attr, value) {
+    this.step(new AttrStep(pos, attr, value));
+    return this;
+  }
+  /**
+  Set a single attribute on the document to a new value.
+  */
+  setDocAttribute(attr, value) {
+    this.step(new DocAttrStep(attr, value));
+    return this;
+  }
+  /**
+  Add a mark to the node at position `pos`.
+  */
+  addNodeMark(pos, mark) {
+    this.step(new AddNodeMarkStep(pos, mark));
+    return this;
+  }
+  /**
+  Remove a mark (or all marks of the given type) from the node at
+  position `pos`.
+  */
+  removeNodeMark(pos, mark) {
+    let node = this.doc.nodeAt(pos);
+    if (!node)
+      throw new RangeError("No node at position " + pos);
+    if (mark instanceof Mark$1) {
+      if (mark.isInSet(node.marks))
+        this.step(new RemoveNodeMarkStep(pos, mark));
+    } else {
+      let set = node.marks, found2, steps = [];
+      while (found2 = mark.isInSet(set)) {
+        steps.push(new RemoveNodeMarkStep(pos, found2));
+        set = found2.removeFromSet(set);
+      }
+      for (let i = steps.length - 1; i >= 0; i--)
+        this.step(steps[i]);
+    }
+    return this;
+  }
+  /**
+  Split the node at the given position, and optionally, if `depth` is
+  greater than one, any number of nodes above that. By default, the
+  parts split off will inherit the node type of the original node.
+  This can be changed by passing an array of types and attributes to
+  use after the split (with the outermost nodes coming first).
+  */
+  split(pos, depth = 1, typesAfter) {
+    split(this, pos, depth, typesAfter);
+    return this;
+  }
+  /**
+  Add the given mark to the inline content between `from` and `to`.
+  */
+  addMark(from, to, mark) {
+    addMark(this, from, to, mark);
+    return this;
+  }
+  /**
+  Remove marks from inline nodes between `from` and `to`. When
+  `mark` is a single mark, remove precisely that mark. When it is
+  a mark type, remove all marks of that type. When it is null,
+  remove all marks of any type.
+  */
+  removeMark(from, to, mark) {
+    removeMark(this, from, to, mark);
+    return this;
+  }
+  /**
+  Removes all marks and nodes from the content of the node at
+  `pos` that don't match the given new parent node type. Accepts
+  an optional starting [content match](https://prosemirror.net/docs/ref/#model.ContentMatch) as
+  third argument.
+  */
+  clearIncompatible(pos, parentType, match) {
+    clearIncompatible(this, pos, parentType, match);
+    return this;
+  }
+}
+const classesById = /* @__PURE__ */ Object.create(null);
+class Selection {
+  /**
+  Initialize a selection with the head and anchor and ranges. If no
+  ranges are given, constructs a single range across `$anchor` and
+  `$head`.
+  */
+  constructor($anchor, $head, ranges) {
+    this.$anchor = $anchor;
+    this.$head = $head;
+    this.ranges = ranges || [new SelectionRange($anchor.min($head), $anchor.max($head))];
+  }
+  /**
+  The selection's anchor, as an unresolved position.
+  */
+  get anchor() {
+    return this.$anchor.pos;
+  }
+  /**
+  The selection's head.
+  */
+  get head() {
+    return this.$head.pos;
+  }
+  /**
+  The lower bound of the selection's main range.
+  */
+  get from() {
+    return this.$from.pos;
+  }
+  /**
+  The upper bound of the selection's main range.
+  */
+  get to() {
+    return this.$to.pos;
+  }
+  /**
+  The resolved lower  bound of the selection's main range.
+  */
+  get $from() {
+    return this.ranges[0].$from;
+  }
+  /**
+  The resolved upper bound of the selection's main range.
+  */
+  get $to() {
+    return this.ranges[0].$to;
+  }
+  /**
+  Indicates whether the selection contains any content.
+  */
+  get empty() {
+    let ranges = this.ranges;
+    for (let i = 0; i < ranges.length; i++)
+      if (ranges[i].$from.pos != ranges[i].$to.pos)
+        return false;
+    return true;
+  }
+  /**
+  Get the content of this selection as a slice.
+  */
+  content() {
+    return this.$from.doc.slice(this.from, this.to, true);
+  }
+  /**
+  Replace the selection with a slice or, if no slice is given,
+  delete the selection. Will append to the given transaction.
+  */
+  replace(tr, content = Slice.empty) {
+    let lastNode = content.content.lastChild, lastParent = null;
+    for (let i = 0; i < content.openEnd; i++) {
+      lastParent = lastNode;
+      lastNode = lastNode.lastChild;
+    }
+    let mapFrom = tr.steps.length, ranges = this.ranges;
+    for (let i = 0; i < ranges.length; i++) {
+      let { $from, $to } = ranges[i], mapping = tr.mapping.slice(mapFrom);
+      tr.replaceRange(mapping.map($from.pos), mapping.map($to.pos), i ? Slice.empty : content);
+      if (i == 0)
+        selectionToInsertionEnd$1(tr, mapFrom, (lastNode ? lastNode.isInline : lastParent && lastParent.isTextblock) ? -1 : 1);
+    }
+  }
+  /**
+  Replace the selection with the given node, appending the changes
+  to the given transaction.
+  */
+  replaceWith(tr, node) {
+    let mapFrom = tr.steps.length, ranges = this.ranges;
+    for (let i = 0; i < ranges.length; i++) {
+      let { $from, $to } = ranges[i], mapping = tr.mapping.slice(mapFrom);
+      let from = mapping.map($from.pos), to = mapping.map($to.pos);
+      if (i) {
+        tr.deleteRange(from, to);
+      } else {
+        tr.replaceRangeWith(from, to, node);
+        selectionToInsertionEnd$1(tr, mapFrom, node.isInline ? -1 : 1);
+      }
+    }
+  }
+  /**
+  Find a valid cursor or leaf node selection starting at the given
+  position and searching back if `dir` is negative, and forward if
+  positive. When `textOnly` is true, only consider cursor
+  selections. Will return null when no valid selection position is
+  found.
+  */
+  static findFrom($pos, dir, textOnly = false) {
+    let inner = $pos.parent.inlineContent ? new TextSelection($pos) : findSelectionIn($pos.node(0), $pos.parent, $pos.pos, $pos.index(), dir, textOnly);
+    if (inner)
+      return inner;
+    for (let depth = $pos.depth - 1; depth >= 0; depth--) {
+      let found2 = dir < 0 ? findSelectionIn($pos.node(0), $pos.node(depth), $pos.before(depth + 1), $pos.index(depth), dir, textOnly) : findSelectionIn($pos.node(0), $pos.node(depth), $pos.after(depth + 1), $pos.index(depth) + 1, dir, textOnly);
+      if (found2)
+        return found2;
+    }
+    return null;
+  }
+  /**
+  Find a valid cursor or leaf node selection near the given
+  position. Searches forward first by default, but if `bias` is
+  negative, it will search backwards first.
+  */
+  static near($pos, bias = 1) {
+    return this.findFrom($pos, bias) || this.findFrom($pos, -bias) || new AllSelection($pos.node(0));
+  }
+  /**
+  Find the cursor or leaf node selection closest to the start of
+  the given document. Will return an
+  [`AllSelection`](https://prosemirror.net/docs/ref/#state.AllSelection) if no valid position
+  exists.
+  */
+  static atStart(doc) {
+    return findSelectionIn(doc, doc, 0, 0, 1) || new AllSelection(doc);
+  }
+  /**
+  Find the cursor or leaf node selection closest to the end of the
+  given document.
+  */
+  static atEnd(doc) {
+    return findSelectionIn(doc, doc, doc.content.size, doc.childCount, -1) || new AllSelection(doc);
+  }
+  /**
+  Deserialize the JSON representation of a selection. Must be
+  implemented for custom classes (as a static class method).
+  */
+  static fromJSON(doc, json) {
+    if (!json || !json.type)
+      throw new RangeError("Invalid input for Selection.fromJSON");
+    let cls = classesById[json.type];
+    if (!cls)
+      throw new RangeError(`No selection type ${json.type} defined`);
+    return cls.fromJSON(doc, json);
+  }
+  /**
+  To be able to deserialize selections from JSON, custom selection
+  classes must register themselves with an ID string, so that they
+  can be disambiguated. Try to pick something that's unlikely to
+  clash with classes from other modules.
+  */
+  static jsonID(id, selectionClass) {
+    if (id in classesById)
+      throw new RangeError("Duplicate use of selection JSON ID " + id);
+    classesById[id] = selectionClass;
+    selectionClass.prototype.jsonID = id;
+    return selectionClass;
+  }
+  /**
+  Get a [bookmark](https://prosemirror.net/docs/ref/#state.SelectionBookmark) for this selection,
+  which is a value that can be mapped without having access to a
+  current document, and later resolved to a real selection for a
+  given document again. (This is used mostly by the history to
+  track and restore old selections.) The default implementation of
+  this method just converts the selection to a text selection and
+  returns the bookmark for that.
+  */
+  getBookmark() {
+    return TextSelection.between(this.$anchor, this.$head).getBookmark();
+  }
+}
+Selection.prototype.visible = true;
+class SelectionRange {
+  /**
+  Create a range.
+  */
+  constructor($from, $to) {
+    this.$from = $from;
+    this.$to = $to;
+  }
+}
+let warnedAboutTextSelection = false;
+function checkTextSelection($pos) {
+  if (!warnedAboutTextSelection && !$pos.parent.inlineContent) {
+    warnedAboutTextSelection = true;
+    console["warn"]("TextSelection endpoint not pointing into a node with inline content (" + $pos.parent.type.name + ")");
+  }
+}
+class TextSelection extends Selection {
+  /**
+  Construct a text selection between the given points.
+  */
+  constructor($anchor, $head = $anchor) {
+    checkTextSelection($anchor);
+    checkTextSelection($head);
+    super($anchor, $head);
+  }
+  /**
+  Returns a resolved position if this is a cursor selection (an
+  empty text selection), and null otherwise.
+  */
+  get $cursor() {
+    return this.$anchor.pos == this.$head.pos ? this.$head : null;
+  }
+  map(doc, mapping) {
+    let $head = doc.resolve(mapping.map(this.head));
+    if (!$head.parent.inlineContent)
+      return Selection.near($head);
+    let $anchor = doc.resolve(mapping.map(this.anchor));
+    return new TextSelection($anchor.parent.inlineContent ? $anchor : $head, $head);
+  }
+  replace(tr, content = Slice.empty) {
+    super.replace(tr, content);
+    if (content == Slice.empty) {
+      let marks = this.$from.marksAcross(this.$to);
+      if (marks)
+        tr.ensureMarks(marks);
+    }
+  }
+  eq(other) {
+    return other instanceof TextSelection && other.anchor == this.anchor && other.head == this.head;
+  }
+  getBookmark() {
+    return new TextBookmark(this.anchor, this.head);
+  }
+  toJSON() {
+    return { type: "text", anchor: this.anchor, head: this.head };
+  }
+  /**
+  @internal
+  */
+  static fromJSON(doc, json) {
+    if (typeof json.anchor != "number" || typeof json.head != "number")
+      throw new RangeError("Invalid input for TextSelection.fromJSON");
+    return new TextSelection(doc.resolve(json.anchor), doc.resolve(json.head));
+  }
+  /**
+  Create a text selection from non-resolved positions.
+  */
+  static create(doc, anchor, head = anchor) {
+    let $anchor = doc.resolve(anchor);
+    return new this($anchor, head == anchor ? $anchor : doc.resolve(head));
+  }
+  /**
+  Return a text selection that spans the given positions or, if
+  they aren't text positions, find a text selection near them.
+  `bias` determines whether the method searches forward (default)
+  or backwards (negative number) first. Will fall back to calling
+  [`Selection.near`](https://prosemirror.net/docs/ref/#state.Selection^near) when the document
+  doesn't contain a valid text position.
+  */
+  static between($anchor, $head, bias) {
+    let dPos = $anchor.pos - $head.pos;
+    if (!bias || dPos)
+      bias = dPos >= 0 ? 1 : -1;
+    if (!$head.parent.inlineContent) {
+      let found2 = Selection.findFrom($head, bias, true) || Selection.findFrom($head, -bias, true);
+      if (found2)
+        $head = found2.$head;
+      else
+        return Selection.near($head, bias);
+    }
+    if (!$anchor.parent.inlineContent) {
+      if (dPos == 0) {
+        $anchor = $head;
+      } else {
+        $anchor = (Selection.findFrom($anchor, -bias, true) || Selection.findFrom($anchor, bias, true)).$anchor;
+        if ($anchor.pos < $head.pos != dPos < 0)
+          $anchor = $head;
+      }
+    }
+    return new TextSelection($anchor, $head);
+  }
+}
+Selection.jsonID("text", TextSelection);
+class TextBookmark {
+  constructor(anchor, head) {
+    this.anchor = anchor;
+    this.head = head;
+  }
+  map(mapping) {
+    return new TextBookmark(mapping.map(this.anchor), mapping.map(this.head));
+  }
+  resolve(doc) {
+    return TextSelection.between(doc.resolve(this.anchor), doc.resolve(this.head));
+  }
+}
+class NodeSelection extends Selection {
+  /**
+  Create a node selection. Does not verify the validity of its
+  argument.
+  */
+  constructor($pos) {
+    let node = $pos.nodeAfter;
+    let $end = $pos.node(0).resolve($pos.pos + node.nodeSize);
+    super($pos, $end);
+    this.node = node;
+  }
+  map(doc, mapping) {
+    let { deleted, pos } = mapping.mapResult(this.anchor);
+    let $pos = doc.resolve(pos);
+    if (deleted)
+      return Selection.near($pos);
+    return new NodeSelection($pos);
+  }
+  content() {
+    return new Slice(Fragment.from(this.node), 0, 0);
+  }
+  eq(other) {
+    return other instanceof NodeSelection && other.anchor == this.anchor;
+  }
+  toJSON() {
+    return { type: "node", anchor: this.anchor };
+  }
+  getBookmark() {
+    return new NodeBookmark(this.anchor);
+  }
+  /**
+  @internal
+  */
+  static fromJSON(doc, json) {
+    if (typeof json.anchor != "number")
+      throw new RangeError("Invalid input for NodeSelection.fromJSON");
+    return new NodeSelection(doc.resolve(json.anchor));
+  }
+  /**
+  Create a node selection from non-resolved positions.
+  */
+  static create(doc, from) {
+    return new NodeSelection(doc.resolve(from));
+  }
+  /**
+  Determines whether the given node may be selected as a node
+  selection.
+  */
+  static isSelectable(node) {
+    return !node.isText && node.type.spec.selectable !== false;
+  }
+}
+NodeSelection.prototype.visible = false;
+Selection.jsonID("node", NodeSelection);
+class NodeBookmark {
+  constructor(anchor) {
+    this.anchor = anchor;
+  }
+  map(mapping) {
+    let { deleted, pos } = mapping.mapResult(this.anchor);
+    return deleted ? new TextBookmark(pos, pos) : new NodeBookmark(pos);
+  }
+  resolve(doc) {
+    let $pos = doc.resolve(this.anchor), node = $pos.nodeAfter;
+    if (node && NodeSelection.isSelectable(node))
+      return new NodeSelection($pos);
+    return Selection.near($pos);
+  }
+}
+class AllSelection extends Selection {
+  /**
+  Create an all-selection over the given document.
+  */
+  constructor(doc) {
+    super(doc.resolve(0), doc.resolve(doc.content.size));
+  }
+  replace(tr, content = Slice.empty) {
+    if (content == Slice.empty) {
+      tr.delete(0, tr.doc.content.size);
+      let sel = Selection.atStart(tr.doc);
+      if (!sel.eq(tr.selection))
+        tr.setSelection(sel);
+    } else {
+      super.replace(tr, content);
+    }
+  }
+  toJSON() {
+    return { type: "all" };
+  }
+  /**
+  @internal
+  */
+  static fromJSON(doc) {
+    return new AllSelection(doc);
+  }
+  map(doc) {
+    return new AllSelection(doc);
+  }
+  eq(other) {
+    return other instanceof AllSelection;
+  }
+  getBookmark() {
+    return AllBookmark;
+  }
+}
+Selection.jsonID("all", AllSelection);
+const AllBookmark = {
+  map() {
+    return this;
+  },
+  resolve(doc) {
+    return new AllSelection(doc);
+  }
+};
+function findSelectionIn(doc, node, pos, index, dir, text = false) {
+  if (node.inlineContent)
+    return TextSelection.create(doc, pos);
+  for (let i = index - (dir > 0 ? 0 : 1); dir > 0 ? i < node.childCount : i >= 0; i += dir) {
+    let child = node.child(i);
+    if (!child.isAtom) {
+      let inner = findSelectionIn(doc, child, pos + dir, dir < 0 ? child.childCount : 0, dir, text);
+      if (inner)
+        return inner;
+    } else if (!text && NodeSelection.isSelectable(child)) {
+      return NodeSelection.create(doc, pos - (dir < 0 ? child.nodeSize : 0));
+    }
+    pos += child.nodeSize * dir;
+  }
+  return null;
+}
+function selectionToInsertionEnd$1(tr, startLen, bias) {
+  let last = tr.steps.length - 1;
+  if (last < startLen)
+    return;
+  let step = tr.steps[last];
+  if (!(step instanceof ReplaceStep || step instanceof ReplaceAroundStep))
+    return;
+  let map = tr.mapping.maps[last], end;
+  map.forEach((_from, _to, _newFrom, newTo) => {
+    if (end == null)
+      end = newTo;
+  });
+  tr.setSelection(Selection.near(tr.doc.resolve(end), bias));
+}
+function bind(f, self) {
+  return !self || !f ? f : f.bind(self);
+}
+class FieldDesc {
+  constructor(name, desc, self) {
+    this.name = name;
+    this.init = bind(desc.init, self);
+    this.apply = bind(desc.apply, self);
+  }
+}
+[
+  new FieldDesc("doc", {
+    init(config) {
+      return config.doc || config.schema.topNodeType.createAndFill();
+    },
+    apply(tr) {
+      return tr.doc;
+    }
+  }),
+  new FieldDesc("selection", {
+    init(config, instance) {
+      return config.selection || Selection.atStart(instance.doc);
+    },
+    apply(tr) {
+      return tr.selection;
+    }
+  }),
+  new FieldDesc("storedMarks", {
+    init(config) {
+      return config.storedMarks || null;
+    },
+    apply(tr, _marks, _old, state) {
+      return state.selection.$cursor ? tr.storedMarks : null;
+    }
+  }),
+  new FieldDesc("scrollToSelection", {
+    init() {
+      return 0;
+    },
+    apply(tr, prev) {
+      return tr.scrolledIntoView ? prev + 1 : prev;
+    }
+  })
+];
+function bindProps(obj, self, target) {
+  for (let prop in obj) {
+    let val = obj[prop];
+    if (val instanceof Function)
+      val = val.bind(self);
+    else if (prop == "handleDOMEvents")
+      val = bindProps(val, self, {});
+    target[prop] = val;
+  }
+  return target;
+}
+class Plugin {
+  /**
+  Create a plugin.
+  */
+  constructor(spec) {
+    this.spec = spec;
+    this.props = {};
+    if (spec.props)
+      bindProps(spec.props, this, this.props);
+    this.key = spec.key ? spec.key.key : createKey("plugin");
+  }
+  /**
+  Extract the plugin's state field from an editor state.
+  */
+  getState(state) {
+    return state[this.key];
+  }
+}
+const keys = /* @__PURE__ */ Object.create(null);
+function createKey(name) {
+  if (name in keys)
+    return name + "$" + ++keys[name];
+  keys[name] = 0;
+  return name + "$";
+}
+class PluginKey {
+  /**
+  Create a plugin key.
+  */
+  constructor(name = "key") {
+    this.key = createKey(name);
+  }
+  /**
+  Get the active plugin with this key, if any, from an editor
+  state.
+  */
+  get(state) {
+    return state.config.pluginsByKey[this.key];
+  }
+  /**
+  Get the plugin's state from an editor state.
+  */
+  getState(state) {
+    return state[this.key];
+  }
+}
+const deleteSelection$1 = (state, dispatch) => {
+  if (state.selection.empty)
+    return false;
+  if (dispatch)
+    dispatch(state.tr.deleteSelection().scrollIntoView());
+  return true;
+};
+function atBlockStart(state, view) {
+  let { $cursor } = state.selection;
+  if (!$cursor || (view ? !view.endOfTextblock("backward", state) : $cursor.parentOffset > 0))
+    return null;
+  return $cursor;
+}
+const joinBackward$1 = (state, dispatch, view) => {
+  let $cursor = atBlockStart(state, view);
+  if (!$cursor)
+    return false;
+  let $cut = findCutBefore($cursor);
+  if (!$cut) {
+    let range = $cursor.blockRange(), target = range && liftTarget(range);
+    if (target == null)
+      return false;
+    if (dispatch)
+      dispatch(state.tr.lift(range, target).scrollIntoView());
+    return true;
+  }
+  let before = $cut.nodeBefore;
+  if (deleteBarrier(state, $cut, dispatch, -1))
+    return true;
+  if ($cursor.parent.content.size == 0 && (textblockAt(before, "end") || NodeSelection.isSelectable(before))) {
+    for (let depth = $cursor.depth; ; depth--) {
+      let delStep = replaceStep(state.doc, $cursor.before(depth), $cursor.after(depth), Slice.empty);
+      if (delStep && delStep.slice.size < delStep.to - delStep.from) {
+        if (dispatch) {
+          let tr = state.tr.step(delStep);
+          tr.setSelection(textblockAt(before, "end") ? Selection.findFrom(tr.doc.resolve(tr.mapping.map($cut.pos, -1)), -1) : NodeSelection.create(tr.doc, $cut.pos - before.nodeSize));
+          dispatch(tr.scrollIntoView());
+        }
+        return true;
+      }
+      if (depth == 1 || $cursor.node(depth - 1).childCount > 1)
+        break;
+    }
+  }
+  if (before.isAtom && $cut.depth == $cursor.depth - 1) {
+    if (dispatch)
+      dispatch(state.tr.delete($cut.pos - before.nodeSize, $cut.pos).scrollIntoView());
+    return true;
+  }
+  return false;
+};
+const joinTextblockBackward$1 = (state, dispatch, view) => {
+  let $cursor = atBlockStart(state, view);
+  if (!$cursor)
+    return false;
+  let $cut = findCutBefore($cursor);
+  return $cut ? joinTextblocksAround(state, $cut, dispatch) : false;
+};
+const joinTextblockForward$1 = (state, dispatch, view) => {
+  let $cursor = atBlockEnd(state, view);
+  if (!$cursor)
+    return false;
+  let $cut = findCutAfter($cursor);
+  return $cut ? joinTextblocksAround(state, $cut, dispatch) : false;
+};
+function joinTextblocksAround(state, $cut, dispatch) {
+  let before = $cut.nodeBefore, beforeText = before, beforePos = $cut.pos - 1;
+  for (; !beforeText.isTextblock; beforePos--) {
+    if (beforeText.type.spec.isolating)
+      return false;
+    let child = beforeText.lastChild;
+    if (!child)
+      return false;
+    beforeText = child;
+  }
+  let after = $cut.nodeAfter, afterText = after, afterPos = $cut.pos + 1;
+  for (; !afterText.isTextblock; afterPos++) {
+    if (afterText.type.spec.isolating)
+      return false;
+    let child = afterText.firstChild;
+    if (!child)
+      return false;
+    afterText = child;
+  }
+  let step = replaceStep(state.doc, beforePos, afterPos, Slice.empty);
+  if (!step || step.from != beforePos || step instanceof ReplaceStep && step.slice.size >= afterPos - beforePos)
+    return false;
+  if (dispatch) {
+    let tr = state.tr.step(step);
+    tr.setSelection(TextSelection.create(tr.doc, beforePos));
+    dispatch(tr.scrollIntoView());
+  }
+  return true;
+}
+function textblockAt(node, side, only = false) {
+  for (let scan = node; scan; scan = side == "start" ? scan.firstChild : scan.lastChild) {
+    if (scan.isTextblock)
+      return true;
+    if (only && scan.childCount != 1)
+      return false;
+  }
+  return false;
+}
+const selectNodeBackward$1 = (state, dispatch, view) => {
+  let { $head, empty } = state.selection, $cut = $head;
+  if (!empty)
+    return false;
+  if ($head.parent.isTextblock) {
+    if (view ? !view.endOfTextblock("backward", state) : $head.parentOffset > 0)
+      return false;
+    $cut = findCutBefore($head);
+  }
+  let node = $cut && $cut.nodeBefore;
+  if (!node || !NodeSelection.isSelectable(node))
+    return false;
+  if (dispatch)
+    dispatch(state.tr.setSelection(NodeSelection.create(state.doc, $cut.pos - node.nodeSize)).scrollIntoView());
+  return true;
+};
+function findCutBefore($pos) {
+  if (!$pos.parent.type.spec.isolating)
+    for (let i = $pos.depth - 1; i >= 0; i--) {
+      if ($pos.index(i) > 0)
+        return $pos.doc.resolve($pos.before(i + 1));
+      if ($pos.node(i).type.spec.isolating)
+        break;
+    }
+  return null;
+}
+function atBlockEnd(state, view) {
+  let { $cursor } = state.selection;
+  if (!$cursor || (view ? !view.endOfTextblock("forward", state) : $cursor.parentOffset < $cursor.parent.content.size))
+    return null;
+  return $cursor;
+}
+const joinForward$1 = (state, dispatch, view) => {
+  let $cursor = atBlockEnd(state, view);
+  if (!$cursor)
+    return false;
+  let $cut = findCutAfter($cursor);
+  if (!$cut)
+    return false;
+  let after = $cut.nodeAfter;
+  if (deleteBarrier(state, $cut, dispatch, 1))
+    return true;
+  if ($cursor.parent.content.size == 0 && (textblockAt(after, "start") || NodeSelection.isSelectable(after))) {
+    let delStep = replaceStep(state.doc, $cursor.before(), $cursor.after(), Slice.empty);
+    if (delStep && delStep.slice.size < delStep.to - delStep.from) {
+      if (dispatch) {
+        let tr = state.tr.step(delStep);
+        tr.setSelection(textblockAt(after, "start") ? Selection.findFrom(tr.doc.resolve(tr.mapping.map($cut.pos)), 1) : NodeSelection.create(tr.doc, tr.mapping.map($cut.pos)));
+        dispatch(tr.scrollIntoView());
+      }
+      return true;
+    }
+  }
+  if (after.isAtom && $cut.depth == $cursor.depth - 1) {
+    if (dispatch)
+      dispatch(state.tr.delete($cut.pos, $cut.pos + after.nodeSize).scrollIntoView());
+    return true;
+  }
+  return false;
+};
+const selectNodeForward$1 = (state, dispatch, view) => {
+  let { $head, empty } = state.selection, $cut = $head;
+  if (!empty)
+    return false;
+  if ($head.parent.isTextblock) {
+    if (view ? !view.endOfTextblock("forward", state) : $head.parentOffset < $head.parent.content.size)
+      return false;
+    $cut = findCutAfter($head);
+  }
+  let node = $cut && $cut.nodeAfter;
+  if (!node || !NodeSelection.isSelectable(node))
+    return false;
+  if (dispatch)
+    dispatch(state.tr.setSelection(NodeSelection.create(state.doc, $cut.pos)).scrollIntoView());
+  return true;
+};
+function findCutAfter($pos) {
+  if (!$pos.parent.type.spec.isolating)
+    for (let i = $pos.depth - 1; i >= 0; i--) {
+      let parent = $pos.node(i);
+      if ($pos.index(i) + 1 < parent.childCount)
+        return $pos.doc.resolve($pos.after(i + 1));
+      if (parent.type.spec.isolating)
+        break;
+    }
+  return null;
+}
+const joinUp$1 = (state, dispatch) => {
+  let sel = state.selection, nodeSel = sel instanceof NodeSelection, point;
+  if (nodeSel) {
+    if (sel.node.isTextblock || !canJoin(state.doc, sel.from))
+      return false;
+    point = sel.from;
+  } else {
+    point = joinPoint(state.doc, sel.from, -1);
+    if (point == null)
+      return false;
+  }
+  if (dispatch) {
+    let tr = state.tr.join(point);
+    if (nodeSel)
+      tr.setSelection(NodeSelection.create(tr.doc, point - state.doc.resolve(point).nodeBefore.nodeSize));
+    dispatch(tr.scrollIntoView());
+  }
+  return true;
+};
+const joinDown$1 = (state, dispatch) => {
+  let sel = state.selection, point;
+  if (sel instanceof NodeSelection) {
+    if (sel.node.isTextblock || !canJoin(state.doc, sel.to))
+      return false;
+    point = sel.to;
+  } else {
+    point = joinPoint(state.doc, sel.to, 1);
+    if (point == null)
+      return false;
+  }
+  if (dispatch)
+    dispatch(state.tr.join(point).scrollIntoView());
+  return true;
+};
+const lift$1 = (state, dispatch) => {
+  let { $from, $to } = state.selection;
+  let range = $from.blockRange($to), target = range && liftTarget(range);
+  if (target == null)
+    return false;
+  if (dispatch)
+    dispatch(state.tr.lift(range, target).scrollIntoView());
+  return true;
+};
+const newlineInCode$1 = (state, dispatch) => {
+  let { $head, $anchor } = state.selection;
+  if (!$head.parent.type.spec.code || !$head.sameParent($anchor))
+    return false;
+  if (dispatch)
+    dispatch(state.tr.insertText("\n").scrollIntoView());
+  return true;
+};
+function defaultBlockAt$1(match) {
+  for (let i = 0; i < match.edgeCount; i++) {
+    let { type } = match.edge(i);
+    if (type.isTextblock && !type.hasRequiredAttrs())
+      return type;
+  }
+  return null;
+}
+const exitCode$1 = (state, dispatch) => {
+  let { $head, $anchor } = state.selection;
+  if (!$head.parent.type.spec.code || !$head.sameParent($anchor))
+    return false;
+  let above = $head.node(-1), after = $head.indexAfter(-1), type = defaultBlockAt$1(above.contentMatchAt(after));
+  if (!type || !above.canReplaceWith(after, after, type))
+    return false;
+  if (dispatch) {
+    let pos = $head.after(), tr = state.tr.replaceWith(pos, pos, type.createAndFill());
+    tr.setSelection(Selection.near(tr.doc.resolve(pos), 1));
+    dispatch(tr.scrollIntoView());
+  }
+  return true;
+};
+const createParagraphNear$1 = (state, dispatch) => {
+  let sel = state.selection, { $from, $to } = sel;
+  if (sel instanceof AllSelection || $from.parent.inlineContent || $to.parent.inlineContent)
+    return false;
+  let type = defaultBlockAt$1($to.parent.contentMatchAt($to.indexAfter()));
+  if (!type || !type.isTextblock)
+    return false;
+  if (dispatch) {
+    let side = (!$from.parentOffset && $to.index() < $to.parent.childCount ? $from : $to).pos;
+    let tr = state.tr.insert(side, type.createAndFill());
+    tr.setSelection(TextSelection.create(tr.doc, side + 1));
+    dispatch(tr.scrollIntoView());
+  }
+  return true;
+};
+const liftEmptyBlock$1 = (state, dispatch) => {
+  let { $cursor } = state.selection;
+  if (!$cursor || $cursor.parent.content.size)
+    return false;
+  if ($cursor.depth > 1 && $cursor.after() != $cursor.end(-1)) {
+    let before = $cursor.before();
+    if (canSplit(state.doc, before)) {
+      if (dispatch)
+        dispatch(state.tr.split(before).scrollIntoView());
+      return true;
+    }
+  }
+  let range = $cursor.blockRange(), target = range && liftTarget(range);
+  if (target == null)
+    return false;
+  if (dispatch)
+    dispatch(state.tr.lift(range, target).scrollIntoView());
+  return true;
+};
+function splitBlockAs(splitNode) {
+  return (state, dispatch) => {
+    let { $from, $to } = state.selection;
+    if (state.selection instanceof NodeSelection && state.selection.node.isBlock) {
+      if (!$from.parentOffset || !canSplit(state.doc, $from.pos))
+        return false;
+      if (dispatch)
+        dispatch(state.tr.split($from.pos).scrollIntoView());
+      return true;
+    }
+    if (!$from.depth)
+      return false;
+    let types = [];
+    let splitDepth, deflt, atEnd = false, atStart = false;
+    for (let d = $from.depth; ; d--) {
+      let node = $from.node(d);
+      if (node.isBlock) {
+        atEnd = $from.end(d) == $from.pos + ($from.depth - d);
+        atStart = $from.start(d) == $from.pos - ($from.depth - d);
+        deflt = defaultBlockAt$1($from.node(d - 1).contentMatchAt($from.indexAfter(d - 1)));
+        types.unshift(atEnd && deflt ? { type: deflt } : null);
+        splitDepth = d;
+        break;
+      } else {
+        if (d == 1)
+          return false;
+        types.unshift(null);
+      }
+    }
+    let tr = state.tr;
+    if (state.selection instanceof TextSelection || state.selection instanceof AllSelection)
+      tr.deleteSelection();
+    let splitPos = tr.mapping.map($from.pos);
+    let can = canSplit(tr.doc, splitPos, types.length, types);
+    if (!can) {
+      types[0] = deflt ? { type: deflt } : null;
+      can = canSplit(tr.doc, splitPos, types.length, types);
+    }
+    if (!can)
+      return false;
+    tr.split(splitPos, types.length, types);
+    if (!atEnd && atStart && $from.node(splitDepth).type != deflt) {
+      let first2 = tr.mapping.map($from.before(splitDepth)), $first = tr.doc.resolve(first2);
+      if (deflt && $from.node(splitDepth - 1).canReplaceWith($first.index(), $first.index() + 1, deflt))
+        tr.setNodeMarkup(tr.mapping.map($from.before(splitDepth)), deflt);
+    }
+    if (dispatch)
+      dispatch(tr.scrollIntoView());
+    return true;
+  };
+}
+const splitBlock$1 = splitBlockAs();
+const selectParentNode$1 = (state, dispatch) => {
+  let { $from, to } = state.selection, pos;
+  let same = $from.sharedDepth(to);
+  if (same == 0)
+    return false;
+  pos = $from.before(same);
+  if (dispatch)
+    dispatch(state.tr.setSelection(NodeSelection.create(state.doc, pos)));
+  return true;
+};
+function joinMaybeClear(state, $pos, dispatch) {
+  let before = $pos.nodeBefore, after = $pos.nodeAfter, index = $pos.index();
+  if (!before || !after || !before.type.compatibleContent(after.type))
+    return false;
+  if (!before.content.size && $pos.parent.canReplace(index - 1, index)) {
+    if (dispatch)
+      dispatch(state.tr.delete($pos.pos - before.nodeSize, $pos.pos).scrollIntoView());
+    return true;
+  }
+  if (!$pos.parent.canReplace(index, index + 1) || !(after.isTextblock || canJoin(state.doc, $pos.pos)))
+    return false;
+  if (dispatch)
+    dispatch(state.tr.join($pos.pos).scrollIntoView());
+  return true;
+}
+function deleteBarrier(state, $cut, dispatch, dir) {
+  let before = $cut.nodeBefore, after = $cut.nodeAfter, conn, match;
+  let isolated = before.type.spec.isolating || after.type.spec.isolating;
+  if (!isolated && joinMaybeClear(state, $cut, dispatch))
+    return true;
+  let canDelAfter = !isolated && $cut.parent.canReplace($cut.index(), $cut.index() + 1);
+  if (canDelAfter && (conn = (match = before.contentMatchAt(before.childCount)).findWrapping(after.type)) && match.matchType(conn[0] || after.type).validEnd) {
+    if (dispatch) {
+      let end = $cut.pos + after.nodeSize, wrap2 = Fragment.empty;
+      for (let i = conn.length - 1; i >= 0; i--)
+        wrap2 = Fragment.from(conn[i].create(null, wrap2));
+      wrap2 = Fragment.from(before.copy(wrap2));
+      let tr = state.tr.step(new ReplaceAroundStep($cut.pos - 1, end, $cut.pos, end, new Slice(wrap2, 1, 0), conn.length, true));
+      let $joinAt = tr.doc.resolve(end + 2 * conn.length);
+      if ($joinAt.nodeAfter && $joinAt.nodeAfter.type == before.type && canJoin(tr.doc, $joinAt.pos))
+        tr.join($joinAt.pos);
+      dispatch(tr.scrollIntoView());
+    }
+    return true;
+  }
+  let selAfter = after.type.spec.isolating || dir > 0 && isolated ? null : Selection.findFrom($cut, 1);
+  let range = selAfter && selAfter.$from.blockRange(selAfter.$to), target = range && liftTarget(range);
+  if (target != null && target >= $cut.depth) {
+    if (dispatch)
+      dispatch(state.tr.lift(range, target).scrollIntoView());
+    return true;
+  }
+  if (canDelAfter && textblockAt(after, "start", true) && textblockAt(before, "end")) {
+    let at = before, wrap2 = [];
+    for (; ; ) {
+      wrap2.push(at);
+      if (at.isTextblock)
+        break;
+      at = at.lastChild;
+    }
+    let afterText = after, afterDepth = 1;
+    for (; !afterText.isTextblock; afterText = afterText.firstChild)
+      afterDepth++;
+    if (at.canReplace(at.childCount, at.childCount, afterText.content)) {
+      if (dispatch) {
+        let end = Fragment.empty;
+        for (let i = wrap2.length - 1; i >= 0; i--)
+          end = Fragment.from(wrap2[i].copy(end));
+        let tr = state.tr.step(new ReplaceAroundStep($cut.pos - wrap2.length, $cut.pos + after.nodeSize, $cut.pos + afterDepth, $cut.pos + after.nodeSize - afterDepth, new Slice(end, wrap2.length, 0), 0, true));
+        dispatch(tr.scrollIntoView());
+      }
+      return true;
+    }
+  }
+  return false;
+}
+function selectTextblockSide(side) {
+  return function(state, dispatch) {
+    let sel = state.selection, $pos = side < 0 ? sel.$from : sel.$to;
+    let depth = $pos.depth;
+    while ($pos.node(depth).isInline) {
+      if (!depth)
+        return false;
+      depth--;
+    }
+    if (!$pos.node(depth).isTextblock)
+      return false;
+    if (dispatch)
+      dispatch(state.tr.setSelection(TextSelection.create(state.doc, side < 0 ? $pos.start(depth) : $pos.end(depth))));
+    return true;
+  };
+}
+const selectTextblockStart$1 = selectTextblockSide(-1);
+const selectTextblockEnd$1 = selectTextblockSide(1);
+function wrapIn$1(nodeType, attrs = null) {
+  return function(state, dispatch) {
+    let { $from, $to } = state.selection;
+    let range = $from.blockRange($to), wrapping = range && findWrapping(range, nodeType, attrs);
+    if (!wrapping)
+      return false;
+    if (dispatch)
+      dispatch(state.tr.wrap(range, wrapping).scrollIntoView());
+    return true;
+  };
+}
+function setBlockType(nodeType, attrs = null) {
+  return function(state, dispatch) {
+    let applicable = false;
+    for (let i = 0; i < state.selection.ranges.length && !applicable; i++) {
+      let { $from: { pos: from }, $to: { pos: to } } = state.selection.ranges[i];
+      state.doc.nodesBetween(from, to, (node, pos) => {
+        if (applicable)
+          return false;
+        if (!node.isTextblock || node.hasMarkup(nodeType, attrs))
+          return;
+        if (node.type == nodeType) {
+          applicable = true;
+        } else {
+          let $pos = state.doc.resolve(pos), index = $pos.index();
+          applicable = $pos.parent.canReplaceWith(index, index + 1, nodeType);
+        }
+      });
+    }
+    if (!applicable)
+      return false;
+    if (dispatch) {
+      let tr = state.tr;
+      for (let i = 0; i < state.selection.ranges.length; i++) {
+        let { $from: { pos: from }, $to: { pos: to } } = state.selection.ranges[i];
+        tr.setBlockType(from, to, nodeType, attrs);
+      }
+      dispatch(tr.scrollIntoView());
+    }
+    return true;
+  };
+}
+function chainCommands(...commands) {
+  return function(state, dispatch, view) {
+    for (let i = 0; i < commands.length; i++)
+      if (commands[i](state, dispatch, view))
+        return true;
+    return false;
+  };
+}
+chainCommands(deleteSelection$1, joinBackward$1, selectNodeBackward$1);
+chainCommands(deleteSelection$1, joinForward$1, selectNodeForward$1);
+({
+  "Enter": chainCommands(newlineInCode$1, createParagraphNear$1, liftEmptyBlock$1, splitBlock$1)
+});
+typeof navigator != "undefined" ? /Mac|iP(hone|[oa]d)/.test(navigator.platform) : typeof os != "undefined" && os.platform ? os.platform() == "darwin" : false;
+function wrapInList$1(listType, attrs = null) {
+  return function(state, dispatch) {
+    let { $from, $to } = state.selection;
+    let range = $from.blockRange($to);
+    if (!range)
+      return false;
+    let tr = dispatch ? state.tr : null;
+    if (!wrapRangeInList(tr, range, listType, attrs))
+      return false;
+    if (dispatch)
+      dispatch(tr.scrollIntoView());
+    return true;
+  };
+}
+function wrapRangeInList(tr, range, listType, attrs = null) {
+  let doJoin = false, outerRange = range, doc = range.$from.doc;
+  if (range.depth >= 2 && range.$from.node(range.depth - 1).type.compatibleContent(listType) && range.startIndex == 0) {
+    if (range.$from.index(range.depth - 1) == 0)
+      return false;
+    let $insert = doc.resolve(range.start - 2);
+    outerRange = new NodeRange($insert, $insert, range.depth);
+    if (range.endIndex < range.parent.childCount)
+      range = new NodeRange(range.$from, doc.resolve(range.$to.end(range.depth)), range.depth);
+    doJoin = true;
+  }
+  let wrap2 = findWrapping(outerRange, listType, attrs, range);
+  if (!wrap2)
+    return false;
+  if (tr)
+    doWrapInList(tr, range, wrap2, doJoin, listType);
+  return true;
+}
+function doWrapInList(tr, range, wrappers, joinBefore, listType) {
+  let content = Fragment.empty;
+  for (let i = wrappers.length - 1; i >= 0; i--)
+    content = Fragment.from(wrappers[i].type.create(wrappers[i].attrs, content));
+  tr.step(new ReplaceAroundStep(range.start - (joinBefore ? 2 : 0), range.end, range.start, range.end, new Slice(content, 0, 0), wrappers.length, true));
+  let found2 = 0;
+  for (let i = 0; i < wrappers.length; i++)
+    if (wrappers[i].type == listType)
+      found2 = i + 1;
+  let splitDepth = wrappers.length - found2;
+  let splitPos = range.start + wrappers.length - (joinBefore ? 2 : 0), parent = range.parent;
+  for (let i = range.startIndex, e = range.endIndex, first2 = true; i < e; i++, first2 = false) {
+    if (!first2 && canSplit(tr.doc, splitPos, splitDepth)) {
+      tr.split(splitPos, splitDepth);
+      splitPos += 2 * splitDepth;
+    }
+    splitPos += parent.child(i).nodeSize;
+  }
+  return tr;
+}
+function liftListItem$1(itemType) {
+  return function(state, dispatch) {
+    let { $from, $to } = state.selection;
+    let range = $from.blockRange($to, (node) => node.childCount > 0 && node.firstChild.type == itemType);
+    if (!range)
+      return false;
+    if (!dispatch)
+      return true;
+    if ($from.node(range.depth - 1).type == itemType)
+      return liftToOuterList(state, dispatch, itemType, range);
+    else
+      return liftOutOfList(state, dispatch, range);
+  };
+}
+function liftToOuterList(state, dispatch, itemType, range) {
+  let tr = state.tr, end = range.end, endOfList = range.$to.end(range.depth);
+  if (end < endOfList) {
+    tr.step(new ReplaceAroundStep(end - 1, endOfList, end, endOfList, new Slice(Fragment.from(itemType.create(null, range.parent.copy())), 1, 0), 1, true));
+    range = new NodeRange(tr.doc.resolve(range.$from.pos), tr.doc.resolve(endOfList), range.depth);
+  }
+  const target = liftTarget(range);
+  if (target == null)
+    return false;
+  tr.lift(range, target);
+  let $after = tr.doc.resolve(tr.mapping.map(end, -1) - 1);
+  if (canJoin(tr.doc, $after.pos) && $after.nodeBefore.type == $after.nodeAfter.type)
+    tr.join($after.pos);
+  dispatch(tr.scrollIntoView());
+  return true;
+}
+function liftOutOfList(state, dispatch, range) {
+  let tr = state.tr, list = range.parent;
+  for (let pos = range.end, i = range.endIndex - 1, e = range.startIndex; i > e; i--) {
+    pos -= list.child(i).nodeSize;
+    tr.delete(pos - 1, pos + 1);
+  }
+  let $start = tr.doc.resolve(range.start), item = $start.nodeAfter;
+  if (tr.mapping.map(range.end) != range.start + $start.nodeAfter.nodeSize)
+    return false;
+  let atStart = range.startIndex == 0, atEnd = range.endIndex == list.childCount;
+  let parent = $start.node(-1), indexBefore = $start.index(-1);
+  if (!parent.canReplace(indexBefore + (atStart ? 0 : 1), indexBefore + 1, item.content.append(atEnd ? Fragment.empty : Fragment.from(list))))
+    return false;
+  let start = $start.pos, end = start + item.nodeSize;
+  tr.step(new ReplaceAroundStep(start - (atStart ? 1 : 0), end + (atEnd ? 1 : 0), start + 1, end - 1, new Slice((atStart ? Fragment.empty : Fragment.from(list.copy(Fragment.empty))).append(atEnd ? Fragment.empty : Fragment.from(list.copy(Fragment.empty))), atStart ? 0 : 1, atEnd ? 0 : 1), atStart ? 0 : 1));
+  dispatch(tr.scrollIntoView());
+  return true;
+}
+function sinkListItem$1(itemType) {
+  return function(state, dispatch) {
+    let { $from, $to } = state.selection;
+    let range = $from.blockRange($to, (node) => node.childCount > 0 && node.firstChild.type == itemType);
+    if (!range)
+      return false;
+    let startIndex = range.startIndex;
+    if (startIndex == 0)
+      return false;
+    let parent = range.parent, nodeBefore = parent.child(startIndex - 1);
+    if (nodeBefore.type != itemType)
+      return false;
+    if (dispatch) {
+      let nestedBefore = nodeBefore.lastChild && nodeBefore.lastChild.type == parent.type;
+      let inner = Fragment.from(nestedBefore ? itemType.create() : null);
+      let slice = new Slice(Fragment.from(itemType.create(null, Fragment.from(parent.type.create(null, inner)))), nestedBefore ? 3 : 1, 0);
+      let before = range.start, after = range.end;
+      dispatch(state.tr.step(new ReplaceAroundStep(before - (nestedBefore ? 3 : 1), after, before, after, slice, 1, true)).scrollIntoView());
+    }
+    return true;
+  };
+}
+var __defProp$1 = Object.defineProperty;
+var __export$1 = (target, all) => {
+  for (var name in all)
+    __defProp$1(target, name, { get: all[name], enumerable: true });
+};
+function createChainableState(config) {
+  const { state, transaction } = config;
+  let { selection } = transaction;
+  let { doc } = transaction;
+  let { storedMarks } = transaction;
+  return {
+    ...state,
+    apply: state.apply.bind(state),
+    applyTransaction: state.applyTransaction.bind(state),
+    plugins: state.plugins,
+    schema: state.schema,
+    reconfigure: state.reconfigure.bind(state),
+    toJSON: state.toJSON.bind(state),
+    get storedMarks() {
+      return storedMarks;
+    },
+    get selection() {
+      return selection;
+    },
+    get doc() {
+      return doc;
+    },
+    get tr() {
+      selection = transaction.selection;
+      doc = transaction.doc;
+      storedMarks = transaction.storedMarks;
+      return transaction;
+    }
+  };
+}
+var CommandManager = class {
+  constructor(props) {
+    this.editor = props.editor;
+    this.rawCommands = this.editor.extensionManager.commands;
+    this.customState = props.state;
+  }
+  get hasCustomState() {
+    return !!this.customState;
+  }
+  get state() {
+    return this.customState || this.editor.state;
+  }
+  get commands() {
+    const { rawCommands, editor, state } = this;
+    const { view } = editor;
+    const { tr } = state;
+    const props = this.buildProps(tr);
+    return Object.fromEntries(
+      Object.entries(rawCommands).map(([name, command2]) => {
+        const method = (...args) => {
+          const callback = command2(...args)(props);
+          if (!tr.getMeta("preventDispatch") && !this.hasCustomState) {
+            view.dispatch(tr);
+          }
+          return callback;
+        };
+        return [name, method];
+      })
+    );
+  }
+  get chain() {
+    return () => this.createChain();
+  }
+  get can() {
+    return () => this.createCan();
+  }
+  createChain(startTr, shouldDispatch = true) {
+    const { rawCommands, editor, state } = this;
+    const { view } = editor;
+    const callbacks = [];
+    const hasStartTransaction = !!startTr;
+    const tr = startTr || state.tr;
+    const run3 = () => {
+      if (!hasStartTransaction && shouldDispatch && !tr.getMeta("preventDispatch") && !this.hasCustomState) {
+        view.dispatch(tr);
+      }
+      return callbacks.every((callback) => callback === true);
+    };
+    const chain = {
+      ...Object.fromEntries(
+        Object.entries(rawCommands).map(([name, command2]) => {
+          const chainedCommand = (...args) => {
+            const props = this.buildProps(tr, shouldDispatch);
+            const callback = command2(...args)(props);
+            callbacks.push(callback);
+            return chain;
+          };
+          return [name, chainedCommand];
+        })
+      ),
+      run: run3
+    };
+    return chain;
+  }
+  createCan(startTr) {
+    const { rawCommands, state } = this;
+    const dispatch = false;
+    const tr = startTr || state.tr;
+    const props = this.buildProps(tr, dispatch);
+    const formattedCommands = Object.fromEntries(
+      Object.entries(rawCommands).map(([name, command2]) => {
+        return [name, (...args) => command2(...args)({ ...props, dispatch: void 0 })];
+      })
+    );
+    return {
+      ...formattedCommands,
+      chain: () => this.createChain(tr, dispatch)
+    };
+  }
+  buildProps(tr, shouldDispatch = true) {
+    const { rawCommands, editor, state } = this;
+    const { view } = editor;
+    const props = {
+      tr,
+      editor,
+      view,
+      state: createChainableState({
+        state,
+        transaction: tr
+      }),
+      dispatch: shouldDispatch ? () => void 0 : void 0,
+      chain: () => this.createChain(tr, shouldDispatch),
+      can: () => this.createCan(tr),
+      get commands() {
+        return Object.fromEntries(
+          Object.entries(rawCommands).map(([name, command2]) => {
+            return [name, (...args) => command2(...args)(props)];
+          })
+        );
+      }
+    };
+    return props;
+  }
+};
+var commands_exports = {};
+__export$1(commands_exports, {
+  blur: () => blur,
+  clearContent: () => clearContent,
+  clearNodes: () => clearNodes,
+  command: () => command,
+  createParagraphNear: () => createParagraphNear,
+  cut: () => cut,
+  deleteCurrentNode: () => deleteCurrentNode,
+  deleteNode: () => deleteNode,
+  deleteRange: () => deleteRange,
+  deleteSelection: () => deleteSelection,
+  enter: () => enter,
+  exitCode: () => exitCode,
+  extendMarkRange: () => extendMarkRange,
+  first: () => first,
+  focus: () => focus,
+  forEach: () => forEach,
+  insertContent: () => insertContent,
+  insertContentAt: () => insertContentAt,
+  joinBackward: () => joinBackward,
+  joinDown: () => joinDown,
+  joinForward: () => joinForward,
+  joinItemBackward: () => joinItemBackward,
+  joinItemForward: () => joinItemForward,
+  joinTextblockBackward: () => joinTextblockBackward,
+  joinTextblockForward: () => joinTextblockForward,
+  joinUp: () => joinUp,
+  keyboardShortcut: () => keyboardShortcut,
+  lift: () => lift,
+  liftEmptyBlock: () => liftEmptyBlock,
+  liftListItem: () => liftListItem,
+  newlineInCode: () => newlineInCode,
+  resetAttributes: () => resetAttributes,
+  scrollIntoView: () => scrollIntoView,
+  selectAll: () => selectAll,
+  selectNodeBackward: () => selectNodeBackward,
+  selectNodeForward: () => selectNodeForward,
+  selectParentNode: () => selectParentNode,
+  selectTextblockEnd: () => selectTextblockEnd,
+  selectTextblockStart: () => selectTextblockStart,
+  setContent: () => setContent,
+  setMark: () => setMark,
+  setMeta: () => setMeta,
+  setNode: () => setNode,
+  setNodeSelection: () => setNodeSelection,
+  setTextDirection: () => setTextDirection,
+  setTextSelection: () => setTextSelection,
+  sinkListItem: () => sinkListItem,
+  splitBlock: () => splitBlock,
+  splitListItem: () => splitListItem,
+  toggleList: () => toggleList,
+  toggleMark: () => toggleMark,
+  toggleNode: () => toggleNode,
+  toggleWrap: () => toggleWrap,
+  undoInputRule: () => undoInputRule,
+  unsetAllMarks: () => unsetAllMarks,
+  unsetMark: () => unsetMark,
+  unsetTextDirection: () => unsetTextDirection,
+  updateAttributes: () => updateAttributes,
+  wrapIn: () => wrapIn,
+  wrapInList: () => wrapInList
+});
+var blur = () => ({ editor, view }) => {
+  requestAnimationFrame(() => {
+    var _a;
+    if (!editor.isDestroyed) {
+      view.dom.blur();
+      (_a = window == null ? void 0 : window.getSelection()) == null ? void 0 : _a.removeAllRanges();
+    }
+  });
+  return true;
+};
+var clearContent = (emitUpdate = true) => ({ commands }) => {
+  return commands.setContent("", { emitUpdate });
+};
+var clearNodes = () => ({ state, tr, dispatch }) => {
+  const { selection } = tr;
+  const { ranges } = selection;
+  if (!dispatch) {
+    return true;
+  }
+  ranges.forEach(({ $from, $to }) => {
+    state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+      if (node.type.isText) {
+        return;
+      }
+      const { doc, mapping } = tr;
+      const $mappedFrom = doc.resolve(mapping.map(pos));
+      const $mappedTo = doc.resolve(mapping.map(pos + node.nodeSize));
+      const nodeRange = $mappedFrom.blockRange($mappedTo);
+      if (!nodeRange) {
+        return;
+      }
+      const targetLiftDepth = liftTarget(nodeRange);
+      if (node.type.isTextblock) {
+        const { defaultType } = $mappedFrom.parent.contentMatchAt($mappedFrom.index());
+        tr.setNodeMarkup(nodeRange.start, defaultType);
+      }
+      if (targetLiftDepth || targetLiftDepth === 0) {
+        tr.lift(nodeRange, targetLiftDepth);
+      }
+    });
+  });
+  return true;
+};
+var command = (fn) => (props) => {
+  return fn(props);
+};
+var createParagraphNear = () => ({ state, dispatch }) => {
+  return createParagraphNear$1(state, dispatch);
+};
+var cut = (originRange, targetPos) => ({ editor, tr }) => {
+  const { state } = editor;
+  const contentSlice = state.doc.slice(originRange.from, originRange.to);
+  tr.deleteRange(originRange.from, originRange.to);
+  const newPos = tr.mapping.map(targetPos);
+  tr.insert(newPos, contentSlice.content);
+  tr.setSelection(new TextSelection(tr.doc.resolve(Math.max(newPos - 1, 0))));
+  return true;
+};
+var deleteCurrentNode = () => ({ tr, dispatch }) => {
+  const { selection } = tr;
+  const currentNode = selection.$anchor.node();
+  if (currentNode.content.size > 0) {
+    return false;
+  }
+  const $pos = tr.selection.$anchor;
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    const node = $pos.node(depth);
+    if (node.type === currentNode.type) {
+      if (dispatch) {
+        const from = $pos.before(depth);
+        const to = $pos.after(depth);
+        tr.delete(from, to).scrollIntoView();
+      }
+      return true;
+    }
+  }
+  return false;
+};
+function getNodeType(nameOrType, schema) {
+  if (typeof nameOrType === "string") {
+    if (!schema.nodes[nameOrType]) {
+      throw Error(
+        `There is no node type named '${nameOrType}'. Maybe you forgot to add the extension?`
+      );
+    }
+    return schema.nodes[nameOrType];
+  }
+  return nameOrType;
+}
+var deleteNode = (typeOrName) => ({ tr, state, dispatch }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  const $pos = tr.selection.$anchor;
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    const node = $pos.node(depth);
+    if (node.type === type) {
+      if (dispatch) {
+        const from = $pos.before(depth);
+        const to = $pos.after(depth);
+        tr.delete(from, to).scrollIntoView();
+      }
+      return true;
+    }
+  }
+  return false;
+};
+var deleteRange = (range) => ({ tr, dispatch }) => {
+  const { from, to } = range;
+  if (dispatch) {
+    tr.delete(from, to);
+  }
+  return true;
+};
+var hasTextContent = (nodeSpec) => {
+  if (!nodeSpec.content) {
+    return false;
+  }
+  const textRegex = /^text(\*|\+)/;
+  return textRegex.test(nodeSpec.content);
+};
+var expandSelectionForSide = ($pos, schema, side) => {
+  if (!$pos.parent.isInline) {
+    return $pos.pos;
+  }
+  if (side === "left" && $pos.pos > $pos.start() || side === "right" && $pos.pos < $pos.end()) {
+    return $pos.pos;
+  }
+  const parentContent = schema.nodes[$pos.parent.type.name].spec;
+  if (!hasTextContent(parentContent)) {
+    return $pos.pos;
+  }
+  return side === "left" ? $pos.start() - 1 : $pos.end() + 1;
+};
+var expandSelectionForInlineText = ($from, $to, schema) => {
+  const from = expandSelectionForSide($from, schema, "left");
+  const to = expandSelectionForSide($to, schema, "right");
+  return { from, to };
+};
+var deleteSelection = () => ({ state, dispatch }) => {
+  if (state.selection.empty) {
+    return false;
+  }
+  if (dispatch) {
+    const tr = state.tr;
+    const { ranges } = state.selection;
+    const mapFrom = tr.steps.length;
+    ranges.forEach((range) => {
+      const mapping = tr.mapping.slice(mapFrom);
+      const $from = tr.doc.resolve(mapping.map(range.$from.pos));
+      const $to = tr.doc.resolve(mapping.map(range.$to.pos));
+      const { from, to } = expandSelectionForInlineText($from, $to, state.schema);
+      tr.deleteRange(from, to);
+    });
+    tr.scrollIntoView();
+    dispatch(tr);
+  }
+  return true;
+};
+var enter = () => ({ commands }) => {
+  return commands.keyboardShortcut("Enter");
+};
+var exitCode = () => ({ state, dispatch }) => {
+  return exitCode$1(state, dispatch);
+};
+function isRegExp(value) {
+  return Object.prototype.toString.call(value) === "[object RegExp]";
+}
+function objectIncludes(object1, object2, options = { strict: true }) {
+  const keys2 = Object.keys(object2);
+  if (!keys2.length) {
+    return true;
+  }
+  return keys2.every((key) => {
+    if (options.strict) {
+      return object2[key] === object1[key];
+    }
+    if (isRegExp(object2[key])) {
+      return object2[key].test(object1[key]);
+    }
+    return object2[key] === object1[key];
+  });
+}
+function findMarkInSet(marks, type, attributes = {}) {
+  return marks.find((item) => {
+    return item.type === type && objectIncludes(
+      // Only check equality for the attributes that are provided
+      Object.fromEntries(Object.keys(attributes).map((k) => [k, item.attrs[k]])),
+      attributes
+    );
+  });
+}
+function isMarkInSet(marks, type, attributes = {}) {
+  return !!findMarkInSet(marks, type, attributes);
+}
+function getMarkRange($pos, type, attributes) {
+  if (!$pos || !type) {
+    return;
+  }
+  let start = $pos.parent.childAfter($pos.parentOffset);
+  if (!start.node || !start.node.marks.some((mark2) => mark2.type === type)) {
+    start = $pos.parent.childBefore($pos.parentOffset);
+  }
+  if (!start.node || !start.node.marks.some((mark2) => mark2.type === type)) {
+    return;
+  }
+  if (!attributes) {
+    const firstMark = start.node.marks.find((mark2) => mark2.type === type);
+    if (firstMark) {
+      attributes = firstMark.attrs;
+    }
+  }
+  const mark = findMarkInSet([...start.node.marks], type, attributes);
+  if (!mark) {
+    return;
+  }
+  let startIndex = start.index;
+  let startPos = $pos.start() + start.offset;
+  let endIndex = startIndex + 1;
+  let endPos = startPos + start.node.nodeSize;
+  while (startIndex > 0 && isMarkInSet([...$pos.parent.child(startIndex - 1).marks], type, attributes)) {
+    startIndex -= 1;
+    startPos -= $pos.parent.child(startIndex).nodeSize;
+  }
+  while (endIndex < $pos.parent.childCount && isMarkInSet([...$pos.parent.child(endIndex).marks], type, attributes)) {
+    endPos += $pos.parent.child(endIndex).nodeSize;
+    endIndex += 1;
+  }
+  return {
+    from: startPos,
+    to: endPos
+  };
+}
+function getMarkType(nameOrType, schema) {
+  if (typeof nameOrType === "string") {
+    if (!schema.marks[nameOrType]) {
+      throw Error(
+        `There is no mark type named '${nameOrType}'. Maybe you forgot to add the extension?`
+      );
+    }
+    return schema.marks[nameOrType];
+  }
+  return nameOrType;
+}
+var extendMarkRange = (typeOrName, attributes) => ({ tr, state, dispatch }) => {
+  const type = getMarkType(typeOrName, state.schema);
+  const { doc, selection } = tr;
+  const { $from, from, to } = selection;
+  if (dispatch) {
+    const range = getMarkRange($from, type, attributes);
+    if (range && range.from <= from && range.to >= to) {
+      const newSelection = TextSelection.create(doc, range.from, range.to);
+      tr.setSelection(newSelection);
+    }
+  }
+  return true;
+};
+var first = (commands) => (props) => {
+  const items = typeof commands === "function" ? commands(props) : commands;
+  for (let i = 0; i < items.length; i += 1) {
+    if (items[i](props)) {
+      return true;
+    }
+  }
+  return false;
+};
+function isTextSelection(value) {
+  return value instanceof TextSelection;
+}
+function minMax(value = 0, min = 0, max = 0) {
+  return Math.min(Math.max(value, min), max);
+}
+function resolveFocusPosition(doc, position = null) {
+  if (!position) {
+    return null;
+  }
+  const selectionAtStart = Selection.atStart(doc);
+  const selectionAtEnd = Selection.atEnd(doc);
+  if (position === "start" || position === true) {
+    return selectionAtStart;
+  }
+  if (position === "end") {
+    return selectionAtEnd;
+  }
+  const minPos = selectionAtStart.from;
+  const maxPos = selectionAtEnd.to;
+  if (position === "all") {
+    return TextSelection.create(
+      doc,
+      minMax(0, minPos, maxPos),
+      minMax(doc.content.size, minPos, maxPos)
+    );
+  }
+  return TextSelection.create(
+    doc,
+    minMax(position, minPos, maxPos),
+    minMax(position, minPos, maxPos)
+  );
+}
+function isAndroid() {
+  return navigator.platform === "Android" || /android/i.test(navigator.userAgent);
+}
+function isiOS() {
+  return ["iPad Simulator", "iPhone Simulator", "iPod Simulator", "iPad", "iPhone", "iPod"].includes(
+    navigator.platform
+  ) || // iPad on iOS 13 detection
+  navigator.userAgent.includes("Mac") && "ontouchend" in document;
+}
+function isSafari() {
+  return typeof navigator !== "undefined" ? /^((?!chrome|android).)*safari/i.test(navigator.userAgent) : false;
+}
+var focus = (position = null, options = {}) => ({ editor, view, tr, dispatch }) => {
+  options = {
+    scrollIntoView: true,
+    ...options
+  };
+  const delayedFocus = () => {
+    if (isiOS() || isAndroid()) {
+      view.dom.focus();
+    }
+    if (isSafari() && !isiOS() && !isAndroid()) {
+      view.dom.focus({ preventScroll: true });
+    }
+    requestAnimationFrame(() => {
+      if (!editor.isDestroyed) {
+        view.focus();
+        if (options == null ? void 0 : options.scrollIntoView) {
+          editor.commands.scrollIntoView();
+        }
+      }
+    });
+  };
+  try {
+    if (view.hasFocus() && position === null || position === false) {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  if (dispatch && position === null && !isTextSelection(editor.state.selection)) {
+    delayedFocus();
+    return true;
+  }
+  const selection = resolveFocusPosition(tr.doc, position) || editor.state.selection;
+  const isSameSelection = editor.state.selection.eq(selection);
+  if (dispatch) {
+    if (!isSameSelection) {
+      tr.setSelection(selection);
+    }
+    if (isSameSelection && tr.storedMarks) {
+      tr.setStoredMarks(tr.storedMarks);
+    }
+    delayedFocus();
+  }
+  return true;
+};
+var forEach = (items, fn) => (props) => {
+  return items.every((item, index) => fn(item, { ...props, index }));
+};
+var insertContent = (value, options) => ({ tr, commands }) => {
+  return commands.insertContentAt(
+    { from: tr.selection.from, to: tr.selection.to },
+    value,
+    options
+  );
+};
+var removeWhitespaces = (node) => {
+  const children = node.childNodes;
+  for (let i = children.length - 1; i >= 0; i -= 1) {
+    const child = children[i];
+    if (child.nodeType === 3 && child.nodeValue && /^(\n\s\s|\n)$/.test(child.nodeValue)) {
+      node.removeChild(child);
+    } else if (child.nodeType === 1) {
+      removeWhitespaces(child);
+    }
+  }
+  return node;
+};
+function elementFromString(value) {
+  if (typeof window === "undefined") {
+    throw new Error(
+      "[tiptap error]: there is no window object available, so this function cannot be used"
+    );
+  }
+  const wrappedValue = `<body>${value}</body>`;
+  const html = new window.DOMParser().parseFromString(wrappedValue, "text/html").body;
+  return removeWhitespaces(html);
+}
+function createNodeFromContent(content, schema, options) {
+  if (content instanceof Node || content instanceof Fragment) {
+    return content;
+  }
+  options = {
+    slice: true,
+    parseOptions: {},
+    ...options
+  };
+  const isJSONContent = typeof content === "object" && content !== null;
+  const isTextContent = typeof content === "string";
+  if (isJSONContent) {
+    try {
+      const isArrayContent = Array.isArray(content) && content.length > 0;
+      if (isArrayContent) {
+        return Fragment.fromArray(content.map((item) => schema.nodeFromJSON(item)));
+      }
+      const node = schema.nodeFromJSON(content);
+      if (options.errorOnInvalidContent) {
+        node.check();
+      }
+      return node;
+    } catch (error2) {
+      if (options.errorOnInvalidContent) {
+        throw new Error("[tiptap error]: Invalid JSON content", { cause: error2 });
+      }
+      console.warn("[tiptap warn]: Invalid content.", "Passed value:", content, "Error:", error2);
+      return createNodeFromContent("", schema, options);
+    }
+  }
+  if (isTextContent) {
+    if (options.errorOnInvalidContent) {
+      let hasInvalidContent = false;
+      let invalidContent = "";
+      const contentCheckSchema = new Schema({
+        topNode: schema.spec.topNode,
+        marks: schema.spec.marks,
+        // Prosemirror's schemas are executed such that: the last to execute, matches last
+        // This means that we can add a catch-all node at the end of the schema to catch any content that we don't know how to handle
+        nodes: schema.spec.nodes.append({
+          __tiptap__private__unknown__catch__all__node: {
+            content: "inline*",
+            group: "block",
+            parseDOM: [
+              {
+                tag: "*",
+                getAttrs: (e) => {
+                  hasInvalidContent = true;
+                  invalidContent = typeof e === "string" ? e : e.outerHTML;
+                  return null;
+                }
+              }
+            ]
+          }
+        })
+      });
+      if (options.slice) {
+        DOMParser.fromSchema(contentCheckSchema).parseSlice(
+          elementFromString(content),
+          options.parseOptions
+        );
+      } else {
+        DOMParser.fromSchema(contentCheckSchema).parse(
+          elementFromString(content),
+          options.parseOptions
+        );
+      }
+      if (options.errorOnInvalidContent && hasInvalidContent) {
+        throw new Error("[tiptap error]: Invalid HTML content", {
+          cause: new Error(`Invalid element found: ${invalidContent}`)
+        });
+      }
+    }
+    const parser = DOMParser.fromSchema(schema);
+    if (options.slice) {
+      return parser.parseSlice(elementFromString(content), options.parseOptions).content;
+    }
+    return parser.parse(elementFromString(content), options.parseOptions);
+  }
+  return createNodeFromContent("", schema, options);
+}
+function selectionToInsertionEnd(tr, startLen, bias) {
+  const last = tr.steps.length - 1;
+  if (last < startLen) {
+    return;
+  }
+  const step = tr.steps[last];
+  if (!(step instanceof ReplaceStep || step instanceof ReplaceAroundStep)) {
+    return;
+  }
+  const map = tr.mapping.maps[last];
+  let end = 0;
+  map.forEach((_from, _to, _newFrom, newTo) => {
+    if (end === 0) {
+      end = newTo;
+    }
+  });
+  tr.setSelection(Selection.near(tr.doc.resolve(end), bias));
+}
+var isFragment = (nodeOrFragment) => {
+  return !("type" in nodeOrFragment);
+};
+var insertContentAt = (position, value, options) => ({ tr, dispatch, editor }) => {
+  var _a;
+  if (dispatch) {
+    options = {
+      parseOptions: editor.options.parseOptions,
+      updateSelection: true,
+      applyInputRules: false,
+      applyPasteRules: false,
+      ...options
+    };
+    let content;
+    const emitContentError = (error2) => {
+      editor.emit("contentError", {
+        editor,
+        error: error2,
+        disableCollaboration: () => {
+          if ("collaboration" in editor.storage && typeof editor.storage.collaboration === "object" && editor.storage.collaboration) {
+            editor.storage.collaboration.isDisabled = true;
+          }
+        }
+      });
+    };
+    const parseOptions = {
+      preserveWhitespace: "full",
+      ...options.parseOptions
+    };
+    if (!options.errorOnInvalidContent && !editor.options.enableContentCheck && editor.options.emitContentError) {
+      try {
+        createNodeFromContent(value, editor.schema, {
+          parseOptions,
+          errorOnInvalidContent: true
+        });
+      } catch (e) {
+        emitContentError(e);
+      }
+    }
+    try {
+      content = createNodeFromContent(value, editor.schema, {
+        parseOptions,
+        errorOnInvalidContent: (_a = options.errorOnInvalidContent) != null ? _a : editor.options.enableContentCheck
+      });
+    } catch (e) {
+      emitContentError(e);
+      return false;
+    }
+    let { from, to } = typeof position === "number" ? { from: position, to: position } : { from: position.from, to: position.to };
+    let isOnlyTextContent = true;
+    let isOnlyBlockContent = true;
+    const nodes = isFragment(content) ? content : [content];
+    nodes.forEach((node) => {
+      node.check();
+      isOnlyTextContent = isOnlyTextContent ? node.isText && node.marks.length === 0 : false;
+      isOnlyBlockContent = isOnlyBlockContent ? node.isBlock : false;
+    });
+    if (from === to && isOnlyBlockContent) {
+      const { parent } = tr.doc.resolve(from);
+      const isEmptyTextBlock = parent.isTextblock && !parent.type.spec.code && !parent.childCount;
+      if (isEmptyTextBlock) {
+        from -= 1;
+        to += 1;
+      }
+    }
+    let newContent;
+    if (isOnlyTextContent) {
+      if (Array.isArray(value)) {
+        newContent = value.map((v) => v.text || "").join("");
+      } else if (value instanceof Fragment) {
+        let text = "";
+        value.forEach((node) => {
+          if (node.text) {
+            text += node.text;
+          }
+        });
+        newContent = text;
+      } else if (typeof value === "object" && !!value && !!value.text) {
+        newContent = value.text;
+      } else {
+        newContent = value;
+      }
+      tr.insertText(newContent, from, to);
+    } else {
+      newContent = content;
+      const $from = tr.doc.resolve(from);
+      const $fromNode = $from.node();
+      const fromSelectionAtStart = $from.parentOffset === 0;
+      const isTextSelection2 = $fromNode.isText || $fromNode.isTextblock;
+      const hasContent = $fromNode.content.size > 0;
+      if (fromSelectionAtStart && isTextSelection2 && hasContent && isOnlyBlockContent) {
+        from = Math.max(0, from - 1);
+      }
+      tr.replaceWith(from, to, newContent);
+    }
+    if (options.updateSelection) {
+      selectionToInsertionEnd(tr, tr.steps.length - 1, -1);
+    }
+    if (options.applyInputRules) {
+      tr.setMeta("applyInputRules", { from, text: newContent });
+    }
+    if (options.applyPasteRules) {
+      tr.setMeta("applyPasteRules", { from, text: newContent });
+    }
+  }
+  return true;
+};
+var joinUp = () => ({ state, dispatch }) => {
+  return joinUp$1(state, dispatch);
+};
+var joinDown = () => ({ state, dispatch }) => {
+  return joinDown$1(state, dispatch);
+};
+var joinBackward = () => ({ state, dispatch }) => {
+  return joinBackward$1(state, dispatch);
+};
+var joinForward = () => ({ state, dispatch }) => {
+  return joinForward$1(state, dispatch);
+};
+var joinItemBackward = () => ({ state, dispatch, tr }) => {
+  try {
+    const point = joinPoint(state.doc, state.selection.$from.pos, -1);
+    if (point === null || point === void 0) {
+      return false;
+    }
+    tr.join(point, 2);
+    if (dispatch) {
+      dispatch(tr);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+var joinItemForward = () => ({ state, dispatch, tr }) => {
+  try {
+    const point = joinPoint(state.doc, state.selection.$from.pos, 1);
+    if (point === null || point === void 0) {
+      return false;
+    }
+    tr.join(point, 2);
+    if (dispatch) {
+      dispatch(tr);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+var joinTextblockBackward = () => ({ state, dispatch }) => {
+  return joinTextblockBackward$1(state, dispatch);
+};
+var joinTextblockForward = () => ({ state, dispatch }) => {
+  return joinTextblockForward$1(state, dispatch);
+};
+function isMacOS() {
+  return typeof navigator !== "undefined" ? /Mac/.test(navigator.platform) : false;
+}
+function normalizeKeyName(name) {
+  const parts = name.split(/-(?!$)/);
+  let result = parts[parts.length - 1];
+  if (result === "Space") {
+    result = " ";
+  }
+  let alt;
+  let ctrl;
+  let shift;
+  let meta;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const mod = parts[i];
+    if (/^(cmd|meta|m)$/i.test(mod)) {
+      meta = true;
+    } else if (/^a(lt)?$/i.test(mod)) {
+      alt = true;
+    } else if (/^(c|ctrl|control)$/i.test(mod)) {
+      ctrl = true;
+    } else if (/^s(hift)?$/i.test(mod)) {
+      shift = true;
+    } else if (/^mod$/i.test(mod)) {
+      if (isiOS() || isMacOS()) {
+        meta = true;
+      } else {
+        ctrl = true;
+      }
+    } else {
+      throw new Error(`Unrecognized modifier name: ${mod}`);
+    }
+  }
+  if (alt) {
+    result = `Alt-${result}`;
+  }
+  if (ctrl) {
+    result = `Ctrl-${result}`;
+  }
+  if (meta) {
+    result = `Meta-${result}`;
+  }
+  if (shift) {
+    result = `Shift-${result}`;
+  }
+  return result;
+}
+var keyboardShortcut = (name) => ({ editor, view, tr, dispatch }) => {
+  const keys2 = normalizeKeyName(name).split(/-(?!$)/);
+  const key = keys2.find((item) => !["Alt", "Ctrl", "Meta", "Shift"].includes(item));
+  const event = new KeyboardEvent("keydown", {
+    key: key === "Space" ? " " : key,
+    altKey: keys2.includes("Alt"),
+    ctrlKey: keys2.includes("Ctrl"),
+    metaKey: keys2.includes("Meta"),
+    shiftKey: keys2.includes("Shift"),
+    bubbles: true,
+    cancelable: true
+  });
+  const capturedTransaction = editor.captureTransaction(() => {
+    view.someProp("handleKeyDown", (f) => f(view, event));
+  });
+  capturedTransaction == null ? void 0 : capturedTransaction.steps.forEach((step) => {
+    const newStep = step.map(tr.mapping);
+    if (newStep && dispatch) {
+      tr.maybeStep(newStep);
+    }
+  });
+  return true;
+};
+function isNodeActive(state, typeOrName, attributes = {}) {
+  const { from, to, empty } = state.selection;
+  const type = typeOrName ? getNodeType(typeOrName, state.schema) : null;
+  const nodeRanges = [];
+  state.doc.nodesBetween(from, to, (node, pos) => {
+    if (node.isText) {
+      return;
+    }
+    const relativeFrom = Math.max(from, pos);
+    const relativeTo = Math.min(to, pos + node.nodeSize);
+    nodeRanges.push({
+      node,
+      from: relativeFrom,
+      to: relativeTo
+    });
+  });
+  const selectionRange = to - from;
+  const matchedNodeRanges = nodeRanges.filter((nodeRange) => {
+    if (!type) {
+      return true;
+    }
+    return type.name === nodeRange.node.type.name;
+  }).filter((nodeRange) => objectIncludes(nodeRange.node.attrs, attributes, { strict: false }));
+  if (empty) {
+    return !!matchedNodeRanges.length;
+  }
+  const range = matchedNodeRanges.reduce((sum, nodeRange) => sum + nodeRange.to - nodeRange.from, 0);
+  return range >= selectionRange;
+}
+var lift = (typeOrName, attributes = {}) => ({ state, dispatch }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  const isActive2 = isNodeActive(state, type, attributes);
+  if (!isActive2) {
+    return false;
+  }
+  return lift$1(state, dispatch);
+};
+var liftEmptyBlock = () => ({ state, dispatch }) => {
+  return liftEmptyBlock$1(state, dispatch);
+};
+var liftListItem = (typeOrName) => ({ state, dispatch }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  return liftListItem$1(type)(state, dispatch);
+};
+var newlineInCode = () => ({ state, dispatch }) => {
+  return newlineInCode$1(state, dispatch);
+};
+function getSchemaTypeNameByName(name, schema) {
+  if (schema.nodes[name]) {
+    return "node";
+  }
+  if (schema.marks[name]) {
+    return "mark";
+  }
+  return null;
+}
+function deleteProps(obj, propOrProps) {
+  const props = typeof propOrProps === "string" ? [propOrProps] : propOrProps;
+  return Object.keys(obj).reduce((newObj, prop) => {
+    if (!props.includes(prop)) {
+      newObj[prop] = obj[prop];
+    }
+    return newObj;
+  }, {});
+}
+var resetAttributes = (typeOrName, attributes) => ({ tr, state, dispatch }) => {
+  let nodeType = null;
+  let markType = null;
+  const schemaType = getSchemaTypeNameByName(
+    typeof typeOrName === "string" ? typeOrName : typeOrName.name,
+    state.schema
+  );
+  if (!schemaType) {
+    return false;
+  }
+  if (schemaType === "node") {
+    nodeType = getNodeType(typeOrName, state.schema);
+  }
+  if (schemaType === "mark") {
+    markType = getMarkType(typeOrName, state.schema);
+  }
+  let canReset = false;
+  tr.selection.ranges.forEach((range) => {
+    state.doc.nodesBetween(range.$from.pos, range.$to.pos, (node, pos) => {
+      if (nodeType && nodeType === node.type) {
+        canReset = true;
+        if (dispatch) {
+          tr.setNodeMarkup(pos, void 0, deleteProps(node.attrs, attributes));
+        }
+      }
+      if (markType && node.marks.length) {
+        node.marks.forEach((mark) => {
+          if (markType === mark.type) {
+            canReset = true;
+            if (dispatch) {
+              tr.addMark(
+                pos,
+                pos + node.nodeSize,
+                markType.create(deleteProps(mark.attrs, attributes))
+              );
+            }
+          }
+        });
+      }
+    });
+  });
+  return canReset;
+};
+var scrollIntoView = () => ({ tr, dispatch }) => {
+  if (dispatch) {
+    tr.scrollIntoView();
+  }
+  return true;
+};
+var selectAll = () => ({ tr, dispatch }) => {
+  if (dispatch) {
+    const selection = new AllSelection(tr.doc);
+    tr.setSelection(selection);
+  }
+  return true;
+};
+var selectNodeBackward = () => ({ state, dispatch }) => {
+  return selectNodeBackward$1(state, dispatch);
+};
+var selectNodeForward = () => ({ state, dispatch }) => {
+  return selectNodeForward$1(state, dispatch);
+};
+var selectParentNode = () => ({ state, dispatch }) => {
+  return selectParentNode$1(state, dispatch);
+};
+var selectTextblockEnd = () => ({ state, dispatch }) => {
+  return selectTextblockEnd$1(state, dispatch);
+};
+var selectTextblockStart = () => ({ state, dispatch }) => {
+  return selectTextblockStart$1(state, dispatch);
+};
+function createDocument(content, schema, parseOptions = {}, options = {}) {
+  return createNodeFromContent(content, schema, {
+    slice: false,
+    parseOptions,
+    errorOnInvalidContent: options.errorOnInvalidContent
+  });
+}
+var setContent = (content, { errorOnInvalidContent, emitUpdate = true, parseOptions = {} } = {}) => ({ editor, tr, dispatch, commands }) => {
+  const { doc } = tr;
+  if (parseOptions.preserveWhitespace !== "full") {
+    const document2 = createDocument(content, editor.schema, parseOptions, {
+      errorOnInvalidContent: errorOnInvalidContent != null ? errorOnInvalidContent : editor.options.enableContentCheck
+    });
+    if (dispatch) {
+      tr.replaceWith(0, doc.content.size, document2).setMeta("preventUpdate", !emitUpdate);
+    }
+    return true;
+  }
+  if (dispatch) {
+    tr.setMeta("preventUpdate", !emitUpdate);
+  }
+  return commands.insertContentAt({ from: 0, to: doc.content.size }, content, {
+    parseOptions,
+    errorOnInvalidContent: errorOnInvalidContent != null ? errorOnInvalidContent : editor.options.enableContentCheck
+  });
+};
+function getMarkAttributes(state, typeOrName) {
+  const type = getMarkType(typeOrName, state.schema);
+  const { from, to, empty } = state.selection;
+  const marks = [];
+  if (empty) {
+    if (state.storedMarks) {
+      marks.push(...state.storedMarks);
+    }
+    marks.push(...state.selection.$head.marks());
+  } else {
+    state.doc.nodesBetween(from, to, (node) => {
+      marks.push(...node.marks);
+    });
+  }
+  const mark = marks.find((markItem) => markItem.type.name === type.name);
+  if (!mark) {
+    return {};
+  }
+  return { ...mark.attrs };
+}
+function combineTransactionSteps(oldDoc, transactions) {
+  const transform = new Transform(oldDoc);
+  transactions.forEach((transaction) => {
+    transaction.steps.forEach((step) => {
+      transform.step(step);
+    });
+  });
+  return transform;
+}
+function defaultBlockAt(match) {
+  for (let i = 0; i < match.edgeCount; i += 1) {
+    const { type } = match.edge(i);
+    if (type.isTextblock && !type.hasRequiredAttrs()) {
+      return type;
+    }
+  }
+  return null;
+}
+function findParentNodeClosestToPos($pos, predicate) {
+  for (let i = $pos.depth; i > 0; i -= 1) {
+    const node = $pos.node(i);
+    if (predicate(node)) {
+      return {
+        pos: i > 0 ? $pos.before(i) : 0,
+        start: $pos.start(i),
+        depth: i,
+        node
+      };
+    }
+  }
+}
+function findParentNode(predicate) {
+  return (selection) => findParentNodeClosestToPos(selection.$from, predicate);
+}
+function getExtensionField(extension, field, context) {
+  if (extension.config[field] === void 0 && extension.parent) {
+    return getExtensionField(extension.parent, field, context);
+  }
+  if (typeof extension.config[field] === "function") {
+    const value = extension.config[field].bind({
+      ...context,
+      parent: extension.parent ? getExtensionField(extension.parent, field, context) : null
+    });
+    return value;
+  }
+  return extension.config[field];
+}
+function flattenExtensions(extensions) {
+  return extensions.map((extension) => {
+    const context = {
+      name: extension.name,
+      options: extension.options,
+      storage: extension.storage
+    };
+    const addExtensions = getExtensionField(
+      extension,
+      "addExtensions",
+      context
+    );
+    if (addExtensions) {
+      return [extension, ...flattenExtensions(addExtensions())];
+    }
+    return extension;
+  }).flat(10);
+}
+function isFunction(value) {
+  return typeof value === "function";
+}
+function callOrReturn(value, context = void 0, ...props) {
+  if (isFunction(value)) {
+    if (context) {
+      return value.bind(context)(...props);
+    }
+    return value(...props);
+  }
+  return value;
+}
+function isEmptyObject(value = {}) {
+  return Object.keys(value).length === 0 && value.constructor === Object;
+}
+function splitExtensions(extensions) {
+  const baseExtensions = extensions.filter(
+    (extension) => extension.type === "extension"
+  );
+  const nodeExtensions = extensions.filter((extension) => extension.type === "node");
+  const markExtensions = extensions.filter((extension) => extension.type === "mark");
+  return {
+    baseExtensions,
+    nodeExtensions,
+    markExtensions
+  };
+}
+function getAttributesFromExtensions(extensions) {
+  const extensionAttributes = [];
+  const { nodeExtensions, markExtensions } = splitExtensions(extensions);
+  const nodeAndMarkExtensions = [...nodeExtensions, ...markExtensions];
+  const defaultAttribute = {
+    default: null,
+    validate: void 0,
+    rendered: true,
+    renderHTML: null,
+    parseHTML: null,
+    keepOnSplit: true,
+    isRequired: false
+  };
+  const nodeExtensionTypes = nodeExtensions.filter((ext) => ext.name !== "text").map((ext) => ext.name);
+  const markExtensionTypes = markExtensions.map((ext) => ext.name);
+  const allExtensionTypes = [...nodeExtensionTypes, ...markExtensionTypes];
+  extensions.forEach((extension) => {
+    const context = {
+      name: extension.name,
+      options: extension.options,
+      storage: extension.storage,
+      extensions: nodeAndMarkExtensions
+    };
+    const addGlobalAttributes = getExtensionField(
+      extension,
+      "addGlobalAttributes",
+      context
+    );
+    if (!addGlobalAttributes) {
+      return;
+    }
+    const globalAttributes = addGlobalAttributes();
+    globalAttributes.forEach((globalAttribute) => {
+      let resolvedTypes;
+      if (Array.isArray(globalAttribute.types)) {
+        resolvedTypes = globalAttribute.types;
+      } else if (globalAttribute.types === "*") {
+        resolvedTypes = allExtensionTypes;
+      } else if (globalAttribute.types === "nodes") {
+        resolvedTypes = nodeExtensionTypes;
+      } else if (globalAttribute.types === "marks") {
+        resolvedTypes = markExtensionTypes;
+      } else {
+        resolvedTypes = [];
+      }
+      resolvedTypes.forEach((type) => {
+        Object.entries(globalAttribute.attributes).forEach(([name, attribute]) => {
+          extensionAttributes.push({
+            type,
+            name,
+            attribute: {
+              ...defaultAttribute,
+              ...attribute
+            }
+          });
+        });
+      });
+    });
+  });
+  nodeAndMarkExtensions.forEach((extension) => {
+    const context = {
+      name: extension.name,
+      options: extension.options,
+      storage: extension.storage
+    };
+    const addAttributes = getExtensionField(extension, "addAttributes", context);
+    if (!addAttributes) {
+      return;
+    }
+    const attributes = addAttributes();
+    Object.entries(attributes).forEach(([name, attribute]) => {
+      const mergedAttr = {
+        ...defaultAttribute,
+        ...attribute
+      };
+      if (typeof (mergedAttr == null ? void 0 : mergedAttr.default) === "function") {
+        mergedAttr.default = mergedAttr.default();
+      }
+      if ((mergedAttr == null ? void 0 : mergedAttr.isRequired) && (mergedAttr == null ? void 0 : mergedAttr.default) === void 0) {
+        delete mergedAttr.default;
+      }
+      extensionAttributes.push({
+        type: extension.name,
+        name,
+        attribute: mergedAttr
+      });
+    });
+  });
+  return extensionAttributes;
+}
+function splitStyleDeclarations(styles) {
+  const result = [];
+  let current = "";
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let parenDepth = 0;
+  const length = styles.length;
+  for (let i = 0; i < length; i += 1) {
+    const char = styles[i];
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      current += char;
+      continue;
+    }
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      current += char;
+      continue;
+    }
+    if (!inSingleQuote && !inDoubleQuote) {
+      if (char === "(") {
+        parenDepth += 1;
+        current += char;
+        continue;
+      }
+      if (char === ")" && parenDepth > 0) {
+        parenDepth -= 1;
+        current += char;
+        continue;
+      }
+      if (char === ";" && parenDepth === 0) {
+        result.push(current);
+        current = "";
+        continue;
+      }
+    }
+    current += char;
+  }
+  if (current) {
+    result.push(current);
+  }
+  return result;
+}
+function parseStyleEntries(styles) {
+  const pairs = [];
+  const declarations = splitStyleDeclarations(styles || "");
+  const numDeclarations = declarations.length;
+  for (let i = 0; i < numDeclarations; i += 1) {
+    const declaration = declarations[i];
+    const firstColonIndex = declaration.indexOf(":");
+    if (firstColonIndex === -1) {
+      continue;
+    }
+    const property = declaration.slice(0, firstColonIndex).trim();
+    const value = declaration.slice(firstColonIndex + 1).trim();
+    if (property && value) {
+      pairs.push([property, value]);
+    }
+  }
+  return pairs;
+}
+function mergeAttributes(...objects) {
+  return objects.filter((item) => !!item).reduce((items, item) => {
+    const mergedAttributes = { ...items };
+    Object.entries(item).forEach(([key, value]) => {
+      const exists = mergedAttributes[key];
+      if (!exists) {
+        mergedAttributes[key] = value;
+        return;
+      }
+      if (key === "class") {
+        const valueClasses = value ? String(value).split(" ") : [];
+        const existingClasses = mergedAttributes[key] ? mergedAttributes[key].split(" ") : [];
+        const insertClasses = valueClasses.filter(
+          (valueClass) => !existingClasses.includes(valueClass)
+        );
+        mergedAttributes[key] = [...existingClasses, ...insertClasses].join(" ");
+      } else if (key === "style") {
+        const styleMap = new Map([
+          ...parseStyleEntries(mergedAttributes[key]),
+          ...parseStyleEntries(value)
+        ]);
+        mergedAttributes[key] = Array.from(styleMap.entries()).map(([property, val]) => `${property}: ${val}`).join("; ");
+      } else {
+        mergedAttributes[key] = value;
+      }
+    });
+    return mergedAttributes;
+  }, {});
+}
+function getRenderedAttributes(nodeOrMark, extensionAttributes) {
+  return extensionAttributes.filter((attribute) => attribute.type === nodeOrMark.type.name).filter((item) => item.attribute.rendered).map((item) => {
+    if (!item.attribute.renderHTML) {
+      return {
+        [item.name]: nodeOrMark.attrs[item.name]
+      };
+    }
+    return item.attribute.renderHTML(nodeOrMark.attrs) || {};
+  }).reduce((attributes, attribute) => mergeAttributes(attributes, attribute), {});
+}
+function fromString(value) {
+  if (typeof value !== "string") {
+    return value;
+  }
+  if (value.match(/^[+-]?(?:\d*\.)?\d+$/)) {
+    return Number(value);
+  }
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return value;
+}
+function injectExtensionAttributesToParseRule(parseRule, extensionAttributes) {
+  if ("style" in parseRule) {
+    return parseRule;
+  }
+  return {
+    ...parseRule,
+    getAttrs: (node) => {
+      const oldAttributes = parseRule.getAttrs ? parseRule.getAttrs(node) : parseRule.attrs;
+      if (oldAttributes === false) {
+        return false;
+      }
+      const newAttributes = extensionAttributes.reduce((items, item) => {
+        const value = item.attribute.parseHTML ? item.attribute.parseHTML(node) : fromString(node.getAttribute(item.name));
+        if (value === null || value === void 0) {
+          return items;
+        }
+        return {
+          ...items,
+          [item.name]: value
+        };
+      }, {});
+      return { ...oldAttributes, ...newAttributes };
+    }
+  };
+}
+function cleanUpSchemaItem(data) {
+  return Object.fromEntries(
+    // @ts-ignore
+    Object.entries(data).filter(([key, value]) => {
+      if (key === "attrs" && isEmptyObject(value)) {
+        return false;
+      }
+      return value !== null && value !== void 0;
+    })
+  );
+}
+function buildAttributeSpec(extensionAttribute) {
+  var _a, _b;
+  const spec = {};
+  if (!((_a = extensionAttribute == null ? void 0 : extensionAttribute.attribute) == null ? void 0 : _a.isRequired) && "default" in ((extensionAttribute == null ? void 0 : extensionAttribute.attribute) || {})) {
+    spec.default = extensionAttribute.attribute.default;
+  }
+  if (((_b = extensionAttribute == null ? void 0 : extensionAttribute.attribute) == null ? void 0 : _b.validate) !== void 0) {
+    spec.validate = extensionAttribute.attribute.validate;
+  }
+  return [extensionAttribute.name, spec];
+}
+function getSchemaByResolvedExtensions(extensions, editor) {
+  var _a;
+  const allAttributes = getAttributesFromExtensions(extensions);
+  const { nodeExtensions, markExtensions } = splitExtensions(extensions);
+  const topNode = (_a = nodeExtensions.find((extension) => getExtensionField(extension, "topNode"))) == null ? void 0 : _a.name;
+  const nodes = Object.fromEntries(
+    nodeExtensions.map((extension) => {
+      const extensionAttributes = allAttributes.filter(
+        (attribute) => attribute.type === extension.name
+      );
+      const context = {
+        name: extension.name,
+        options: extension.options,
+        storage: extension.storage,
+        editor
+      };
+      const extraNodeFields = extensions.reduce((fields, e) => {
+        const extendNodeSchema = getExtensionField(
+          e,
+          "extendNodeSchema",
+          context
+        );
+        return {
+          ...fields,
+          ...extendNodeSchema ? extendNodeSchema(extension) : {}
+        };
+      }, {});
+      const schema = cleanUpSchemaItem({
+        ...extraNodeFields,
+        content: callOrReturn(
+          getExtensionField(extension, "content", context)
+        ),
+        marks: callOrReturn(getExtensionField(extension, "marks", context)),
+        group: callOrReturn(getExtensionField(extension, "group", context)),
+        inline: callOrReturn(getExtensionField(extension, "inline", context)),
+        atom: callOrReturn(getExtensionField(extension, "atom", context)),
+        selectable: callOrReturn(
+          getExtensionField(extension, "selectable", context)
+        ),
+        draggable: callOrReturn(
+          getExtensionField(extension, "draggable", context)
+        ),
+        code: callOrReturn(getExtensionField(extension, "code", context)),
+        whitespace: callOrReturn(
+          getExtensionField(extension, "whitespace", context)
+        ),
+        linebreakReplacement: callOrReturn(
+          getExtensionField(
+            extension,
+            "linebreakReplacement",
+            context
+          )
+        ),
+        defining: callOrReturn(
+          getExtensionField(extension, "defining", context)
+        ),
+        isolating: callOrReturn(
+          getExtensionField(extension, "isolating", context)
+        ),
+        attrs: Object.fromEntries(extensionAttributes.map(buildAttributeSpec))
+      });
+      const parseHTML = callOrReturn(
+        getExtensionField(extension, "parseHTML", context)
+      );
+      if (parseHTML) {
+        schema.parseDOM = parseHTML.map(
+          (parseRule) => injectExtensionAttributesToParseRule(parseRule, extensionAttributes)
+        );
+      }
+      const renderHTML = getExtensionField(
+        extension,
+        "renderHTML",
+        context
+      );
+      if (renderHTML) {
+        schema.toDOM = (node) => renderHTML({
+          node,
+          HTMLAttributes: getRenderedAttributes(node, extensionAttributes)
+        });
+      }
+      const renderText = getExtensionField(
+        extension,
+        "renderText",
+        context
+      );
+      if (renderText) {
+        schema.toText = renderText;
+      }
+      return [extension.name, schema];
+    })
+  );
+  const marks = Object.fromEntries(
+    markExtensions.map((extension) => {
+      const extensionAttributes = allAttributes.filter(
+        (attribute) => attribute.type === extension.name
+      );
+      const context = {
+        name: extension.name,
+        options: extension.options,
+        storage: extension.storage,
+        editor
+      };
+      const extraMarkFields = extensions.reduce((fields, e) => {
+        const extendMarkSchema = getExtensionField(
+          e,
+          "extendMarkSchema",
+          context
+        );
+        return {
+          ...fields,
+          ...extendMarkSchema ? extendMarkSchema(extension) : {}
+        };
+      }, {});
+      const schema = cleanUpSchemaItem({
+        ...extraMarkFields,
+        inclusive: callOrReturn(
+          getExtensionField(extension, "inclusive", context)
+        ),
+        excludes: callOrReturn(
+          getExtensionField(extension, "excludes", context)
+        ),
+        group: callOrReturn(getExtensionField(extension, "group", context)),
+        spanning: callOrReturn(
+          getExtensionField(extension, "spanning", context)
+        ),
+        code: callOrReturn(getExtensionField(extension, "code", context)),
+        attrs: Object.fromEntries(extensionAttributes.map(buildAttributeSpec))
+      });
+      const parseHTML = callOrReturn(
+        getExtensionField(extension, "parseHTML", context)
+      );
+      if (parseHTML) {
+        schema.parseDOM = parseHTML.map(
+          (parseRule) => injectExtensionAttributesToParseRule(parseRule, extensionAttributes)
+        );
+      }
+      const renderHTML = getExtensionField(
+        extension,
+        "renderHTML",
+        context
+      );
+      if (renderHTML) {
+        schema.toDOM = (mark) => renderHTML({
+          mark,
+          HTMLAttributes: getRenderedAttributes(mark, extensionAttributes)
+        });
+      }
+      return [extension.name, schema];
+    })
+  );
+  return new Schema({
+    topNode,
+    nodes,
+    marks
+  });
+}
+function findDuplicates(items) {
+  const filtered = items.filter((el, index) => items.indexOf(el) !== index);
+  return Array.from(new Set(filtered));
+}
+function sortExtensions(extensions) {
+  const defaultPriority = 100;
+  return extensions.sort((a, b) => {
+    const priorityA = getExtensionField(a, "priority") || defaultPriority;
+    const priorityB = getExtensionField(b, "priority") || defaultPriority;
+    if (priorityA > priorityB) {
+      return -1;
+    }
+    if (priorityA < priorityB) {
+      return 1;
+    }
+    return 0;
+  });
+}
+function resolveExtensions(extensions) {
+  const resolvedExtensions = sortExtensions(flattenExtensions(extensions));
+  const duplicatedNames = findDuplicates(resolvedExtensions.map((extension) => extension.name));
+  if (duplicatedNames.length) {
+    console.warn(
+      `[tiptap warn]: Duplicate extension names found: [${duplicatedNames.map((item) => `'${item}'`).join(", ")}]. This can lead to issues.`
+    );
+  }
+  return resolvedExtensions;
+}
+function getSchema(extensions, editor) {
+  const resolvedExtensions = resolveExtensions(extensions);
+  return getSchemaByResolvedExtensions(resolvedExtensions, editor);
+}
+function getTextBetween(startNode, range, options) {
+  const { from, to } = range;
+  const { blockSeparator = "\n\n", textSerializers = {} } = options || {};
+  let text = "";
+  startNode.nodesBetween(from, to, (node, pos, parent, index) => {
+    var _a;
+    if (node.isBlock && pos > from) {
+      text += blockSeparator;
+    }
+    const textSerializer = textSerializers == null ? void 0 : textSerializers[node.type.name];
+    if (textSerializer) {
+      if (parent) {
+        text += textSerializer({
+          node,
+          pos,
+          parent,
+          index,
+          range
+        });
+      }
+      return false;
+    }
+    if (node.isText) {
+      text += (_a = node == null ? void 0 : node.text) == null ? void 0 : _a.slice(Math.max(from, pos) - pos, to - pos);
+    }
+  });
+  return text;
+}
+function getTextSerializersFromSchema(schema) {
+  return Object.fromEntries(
+    Object.entries(schema.nodes).filter(([, node]) => node.spec.toText).map(([name, node]) => [name, node.spec.toText])
+  );
+}
+function removeDuplicates(array, by = JSON.stringify) {
+  const seen = {};
+  return array.filter((item) => {
+    const key = by(item);
+    return Object.prototype.hasOwnProperty.call(seen, key) ? false : seen[key] = true;
+  });
+}
+function simplifyChangedRanges(changes) {
+  const uniqueChanges = removeDuplicates(changes);
+  return uniqueChanges.length === 1 ? uniqueChanges : uniqueChanges.filter((change, index) => {
+    const rest = uniqueChanges.filter((_, i) => i !== index);
+    return !rest.some((otherChange) => {
+      return change.oldRange.from >= otherChange.oldRange.from && change.oldRange.to <= otherChange.oldRange.to && change.newRange.from >= otherChange.newRange.from && change.newRange.to <= otherChange.newRange.to;
+    });
+  });
+}
+function getChangedRanges(transform) {
+  const { mapping, steps } = transform;
+  const changes = [];
+  mapping.maps.forEach((stepMap, index) => {
+    const ranges = [];
+    if (!stepMap.ranges.length) {
+      const { from, to } = steps[index];
+      if (from === void 0 || to === void 0) {
+        return;
+      }
+      ranges.push({ from, to });
+    } else {
+      stepMap.forEach((from, to) => {
+        ranges.push({ from, to });
+      });
+    }
+    ranges.forEach(({ from, to }) => {
+      const newStart = mapping.slice(index).map(from, -1);
+      const newEnd = mapping.slice(index).map(to);
+      const oldStart = mapping.invert().map(newStart, -1);
+      const oldEnd = mapping.invert().map(newEnd);
+      changes.push({
+        oldRange: {
+          from: oldStart,
+          to: oldEnd
+        },
+        newRange: {
+          from: newStart,
+          to: newEnd
+        }
+      });
+    });
+  });
+  return simplifyChangedRanges(changes);
+}
+function getMarksBetween(from, to, doc) {
+  const marks = [];
+  if (from === to) {
+    doc.resolve(from).marks().forEach((mark) => {
+      const $pos = doc.resolve(from);
+      const range = getMarkRange($pos, mark.type);
+      if (!range) {
+        return;
+      }
+      marks.push({
+        mark,
+        ...range
+      });
+    });
+  } else {
+    doc.nodesBetween(from, to, (node, pos) => {
+      if (!node || (node == null ? void 0 : node.nodeSize) === void 0) {
+        return;
+      }
+      marks.push(
+        ...node.marks.map((mark) => ({
+          from: pos,
+          to: pos + node.nodeSize,
+          mark
+        }))
+      );
+    });
+  }
+  return marks;
+}
+var getNodeAtPosition = (state, typeOrName, pos, maxDepth = 20) => {
+  const $pos = state.doc.resolve(pos);
+  let currentDepth = maxDepth;
+  let node = null;
+  while (currentDepth > 0 && node === null) {
+    const currentNode = $pos.node(currentDepth);
+    if ((currentNode == null ? void 0 : currentNode.type.name) === typeOrName) {
+      node = currentNode;
+    } else {
+      currentDepth -= 1;
+    }
+  }
+  return [node, currentDepth];
+};
+function getSplittedAttributes(extensionAttributes, typeName, attributes) {
+  return Object.fromEntries(
+    Object.entries(attributes).filter(([name]) => {
+      const extensionAttribute = extensionAttributes.find((item) => {
+        return item.type === typeName && item.name === name;
+      });
+      if (!extensionAttribute) {
+        return false;
+      }
+      return extensionAttribute.attribute.keepOnSplit;
+    })
+  );
+}
+function isMarkActive(state, typeOrName, attributes = {}) {
+  const { empty, ranges } = state.selection;
+  const type = typeOrName ? getMarkType(typeOrName, state.schema) : null;
+  if (empty) {
+    return !!(state.storedMarks || state.selection.$from.marks()).filter((mark) => {
+      if (!type) {
+        return true;
+      }
+      return type.name === mark.type.name;
+    }).find((mark) => objectIncludes(mark.attrs, attributes, { strict: false }));
+  }
+  let selectionRange = 0;
+  const markRanges = [];
+  ranges.forEach(({ $from, $to }) => {
+    const from = $from.pos;
+    const to = $to.pos;
+    state.doc.nodesBetween(from, to, (node, pos) => {
+      if (type && node.inlineContent && !node.type.allowsMarkType(type)) {
+        return false;
+      }
+      if (!node.isText && !node.marks.length) {
+        return;
+      }
+      const relativeFrom = Math.max(from, pos);
+      const relativeTo = Math.min(to, pos + node.nodeSize);
+      const range2 = relativeTo - relativeFrom;
+      selectionRange += range2;
+      markRanges.push(
+        ...node.marks.map((mark) => ({
+          mark,
+          from: relativeFrom,
+          to: relativeTo
+        }))
+      );
+    });
+  });
+  if (selectionRange === 0) {
+    return false;
+  }
+  const matchedRange = markRanges.filter((markRange) => {
+    if (!type) {
+      return true;
+    }
+    return type.name === markRange.mark.type.name;
+  }).filter((markRange) => objectIncludes(markRange.mark.attrs, attributes, { strict: false })).reduce((sum, markRange) => sum + markRange.to - markRange.from, 0);
+  const excludedRange = markRanges.filter((markRange) => {
+    if (!type) {
+      return true;
+    }
+    return markRange.mark.type !== type && markRange.mark.type.excludes(type);
+  }).reduce((sum, markRange) => sum + markRange.to - markRange.from, 0);
+  const range = matchedRange > 0 ? matchedRange + excludedRange : matchedRange;
+  return range >= selectionRange;
+}
+var isAtEndOfNode = (state, nodeType) => {
+  const { $from, $to, $anchor } = state.selection;
+  if (nodeType) {
+    const parentNode = findParentNode((node) => node.type.name === nodeType)(state.selection);
+    if (!parentNode) {
+      return false;
+    }
+    const $parentPos = state.doc.resolve(parentNode.pos + 1);
+    if ($anchor.pos + 1 === $parentPos.end()) {
+      return true;
+    }
+    return false;
+  }
+  if ($to.parentOffset < $to.parent.nodeSize - 2 || $from.pos !== $to.pos) {
+    return false;
+  }
+  return true;
+};
+var isAtStartOfNode = (state) => {
+  const { $from, $to } = state.selection;
+  if ($from.parentOffset > 0 || $from.pos !== $to.pos) {
+    return false;
+  }
+  return true;
+};
+function isList(name, extensions) {
+  const { nodeExtensions } = splitExtensions(extensions);
+  const extension = nodeExtensions.find((item) => item.name === name);
+  if (!extension) {
+    return false;
+  }
+  const context = {
+    name: extension.name,
+    options: extension.options,
+    storage: extension.storage
+  };
+  const group = callOrReturn(getExtensionField(extension, "group", context));
+  if (typeof group !== "string") {
+    return false;
+  }
+  return group.split(" ").includes("list");
+}
+function isNodeEmpty(node, {
+  checkChildren = true,
+  ignoreWhitespace = false
+} = {}) {
+  var _a;
+  if (ignoreWhitespace) {
+    if (node.type.name === "hardBreak") {
+      return true;
+    }
+    if (node.isText) {
+      return !/\S/.test((_a = node.text) != null ? _a : "");
+    }
+  }
+  if (node.isText) {
+    return !node.text;
+  }
+  if (node.isAtom || node.isLeaf) {
+    return false;
+  }
+  if (node.content.childCount === 0) {
+    return true;
+  }
+  if (checkChildren) {
+    let isContentEmpty = true;
+    node.content.forEach((childNode) => {
+      if (isContentEmpty === false) {
+        return;
+      }
+      if (!isNodeEmpty(childNode, { ignoreWhitespace, checkChildren })) {
+        isContentEmpty = false;
+      }
+    });
+    return isContentEmpty;
+  }
+  return false;
+}
+function canSetMark(state, tr, newMarkType) {
+  var _a;
+  const { selection } = tr;
+  let cursor = null;
+  if (isTextSelection(selection)) {
+    cursor = selection.$cursor;
+  }
+  if (cursor) {
+    const currentMarks = (_a = state.storedMarks) != null ? _a : cursor.marks();
+    const parentAllowsMarkType = cursor.parent.type.allowsMarkType(newMarkType);
+    return parentAllowsMarkType && (!!newMarkType.isInSet(currentMarks) || !currentMarks.some((mark) => mark.type.excludes(newMarkType)));
+  }
+  const { ranges } = selection;
+  return ranges.some(({ $from, $to }) => {
+    let someNodeSupportsMark = $from.depth === 0 ? state.doc.inlineContent && state.doc.type.allowsMarkType(newMarkType) : false;
+    state.doc.nodesBetween($from.pos, $to.pos, (node, _pos, parent) => {
+      if (someNodeSupportsMark) {
+        return false;
+      }
+      if (node.isInline) {
+        const parentAllowsMarkType = !parent || parent.type.allowsMarkType(newMarkType);
+        const currentMarksAllowMarkType = !!newMarkType.isInSet(node.marks) || !node.marks.some((otherMark) => otherMark.type.excludes(newMarkType));
+        someNodeSupportsMark = parentAllowsMarkType && currentMarksAllowMarkType;
+      }
+      return !someNodeSupportsMark;
+    });
+    return someNodeSupportsMark;
+  });
+}
+var setMark = (typeOrName, attributes = {}) => ({ tr, state, dispatch }) => {
+  const { selection } = tr;
+  const { empty, ranges } = selection;
+  const type = getMarkType(typeOrName, state.schema);
+  if (dispatch) {
+    if (empty) {
+      const oldAttributes = getMarkAttributes(state, type);
+      tr.addStoredMark(
+        type.create({
+          ...oldAttributes,
+          ...attributes
+        })
+      );
+    } else {
+      ranges.forEach((range) => {
+        const from = range.$from.pos;
+        const to = range.$to.pos;
+        state.doc.nodesBetween(from, to, (node, pos) => {
+          const trimmedFrom = Math.max(pos, from);
+          const trimmedTo = Math.min(pos + node.nodeSize, to);
+          const someHasMark = node.marks.find((mark) => mark.type === type);
+          if (someHasMark) {
+            node.marks.forEach((mark) => {
+              if (type === mark.type) {
+                tr.addMark(
+                  trimmedFrom,
+                  trimmedTo,
+                  type.create({
+                    ...mark.attrs,
+                    ...attributes
+                  })
+                );
+              }
+            });
+          } else {
+            tr.addMark(trimmedFrom, trimmedTo, type.create(attributes));
+          }
+        });
+      });
+    }
+  }
+  return canSetMark(state, tr, type);
+};
+var setMeta = (key, value) => ({ tr }) => {
+  tr.setMeta(key, value);
+  return true;
+};
+var setNode = (typeOrName, attributes = {}) => ({ state, dispatch, chain }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  let attributesToCopy;
+  if (state.selection.$anchor.sameParent(state.selection.$head)) {
+    attributesToCopy = state.selection.$anchor.parent.attrs;
+  }
+  if (!type.isTextblock) {
+    console.warn('[tiptap warn]: Currently "setNode()" only supports text block nodes.');
+    return false;
+  }
+  return chain().command(({ commands }) => {
+    const canSetBlock = setBlockType(type, { ...attributesToCopy, ...attributes })(state);
+    if (canSetBlock) {
+      return true;
+    }
+    return commands.clearNodes();
+  }).command(({ state: updatedState }) => {
+    return setBlockType(type, { ...attributesToCopy, ...attributes })(updatedState, dispatch);
+  }).run();
+};
+var setNodeSelection = (position) => ({ tr, dispatch }) => {
+  if (dispatch) {
+    const { doc } = tr;
+    const from = minMax(position, 0, doc.content.size);
+    const selection = NodeSelection.create(doc, from);
+    tr.setSelection(selection);
+  }
+  return true;
+};
+var setTextDirection = (direction, position) => ({ tr, state, dispatch }) => {
+  const { selection } = state;
+  let from;
+  let to;
+  if (typeof position === "number") {
+    from = position;
+    to = position;
+  } else if (position && "from" in position && "to" in position) {
+    from = position.from;
+    to = position.to;
+  } else {
+    from = selection.from;
+    to = selection.to;
+  }
+  if (dispatch) {
+    tr.doc.nodesBetween(from, to, (node, pos) => {
+      if (node.isText) {
+        return;
+      }
+      tr.setNodeMarkup(pos, void 0, {
+        ...node.attrs,
+        dir: direction
+      });
+    });
+  }
+  return true;
+};
+var setTextSelection = (position) => ({ tr, dispatch }) => {
+  if (dispatch) {
+    const { doc } = tr;
+    const { from, to } = typeof position === "number" ? { from: position, to: position } : position;
+    const minPos = TextSelection.atStart(doc).from;
+    const maxPos = TextSelection.atEnd(doc).to;
+    const resolvedFrom = minMax(from, minPos, maxPos);
+    const resolvedEnd = minMax(to, minPos, maxPos);
+    const selection = TextSelection.create(doc, resolvedFrom, resolvedEnd);
+    tr.setSelection(selection);
+  }
+  return true;
+};
+var sinkListItem = (typeOrName) => ({ state, dispatch }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  return sinkListItem$1(type)(state, dispatch);
+};
+function ensureMarks(state, splittableMarks) {
+  const marks = state.storedMarks || state.selection.$to.parentOffset && state.selection.$from.marks();
+  if (marks) {
+    const filteredMarks = marks.filter((mark) => splittableMarks == null ? void 0 : splittableMarks.includes(mark.type.name));
+    state.tr.ensureMarks(filteredMarks);
+  }
+}
+var splitBlock = ({ keepMarks = true } = {}) => ({ tr, state, dispatch, editor }) => {
+  const { selection, doc } = tr;
+  const { $from, $to } = selection;
+  const extensionAttributes = editor.extensionManager.attributes;
+  const newAttributes = getSplittedAttributes(
+    extensionAttributes,
+    $from.node().type.name,
+    $from.node().attrs
+  );
+  if (selection instanceof NodeSelection && selection.node.isBlock) {
+    if (!$from.parentOffset || !canSplit(doc, $from.pos)) {
+      return false;
+    }
+    if (dispatch) {
+      if (keepMarks) {
+        ensureMarks(state, editor.extensionManager.splittableMarks);
+      }
+      tr.split($from.pos).scrollIntoView();
+    }
+    return true;
+  }
+  if (!$from.parent.isBlock) {
+    return false;
+  }
+  const atEnd = $to.parentOffset === $to.parent.content.size;
+  const deflt = $from.depth === 0 ? void 0 : defaultBlockAt($from.node(-1).contentMatchAt($from.indexAfter(-1)));
+  let types = atEnd && deflt ? [
+    {
+      type: deflt,
+      attrs: newAttributes
+    }
+  ] : void 0;
+  let can = canSplit(tr.doc, tr.mapping.map($from.pos), 1, types);
+  if (!types && !can && canSplit(tr.doc, tr.mapping.map($from.pos), 1, deflt ? [{ type: deflt }] : void 0)) {
+    can = true;
+    types = deflt ? [
+      {
+        type: deflt,
+        attrs: newAttributes
+      }
+    ] : void 0;
+  }
+  if (dispatch) {
+    if (can) {
+      if (selection instanceof TextSelection) {
+        tr.deleteSelection();
+      }
+      tr.split(tr.mapping.map($from.pos), 1, types);
+      if (deflt && !atEnd && !$from.parentOffset && $from.parent.type !== deflt) {
+        const first2 = tr.mapping.map($from.before());
+        const $first = tr.doc.resolve(first2);
+        if ($from.node(-1).canReplaceWith($first.index(), $first.index() + 1, deflt)) {
+          tr.setNodeMarkup(tr.mapping.map($from.before()), deflt);
+        }
+      }
+    }
+    if (keepMarks) {
+      ensureMarks(state, editor.extensionManager.splittableMarks);
+    }
+    tr.scrollIntoView();
+  }
+  return can;
+};
+var splitListItem = (typeOrName, overrideAttrs = {}) => ({ tr, state, dispatch, editor }) => {
+  var _a;
+  const type = getNodeType(typeOrName, state.schema);
+  const { $from, $to } = state.selection;
+  const node = state.selection.node;
+  if (node && node.isBlock || $from.depth < 2 || !$from.sameParent($to)) {
+    return false;
+  }
+  const grandParent = $from.node(-1);
+  if (grandParent.type !== type) {
+    return false;
+  }
+  const extensionAttributes = editor.extensionManager.attributes;
+  if ($from.parent.content.size === 0 && $from.node(-1).childCount === $from.indexAfter(-1)) {
+    if ($from.depth === 2 || $from.node(-3).type !== type || $from.index(-2) !== $from.node(-2).childCount - 1) {
+      return false;
+    }
+    if (dispatch) {
+      let wrap2 = Fragment.empty;
+      const depthBefore = $from.index(-1) ? 1 : $from.index(-2) ? 2 : 3;
+      for (let d = $from.depth - depthBefore; d >= $from.depth - 3; d -= 1) {
+        wrap2 = Fragment.from($from.node(d).copy(wrap2));
+      }
+      const depthAfter = (
+        // oxlint-disable-next-line no-nested-ternary
+        $from.indexAfter(-1) < $from.node(-2).childCount ? 1 : $from.indexAfter(-2) < $from.node(-3).childCount ? 2 : 3
+      );
+      const newNextTypeAttributes2 = {
+        ...getSplittedAttributes(extensionAttributes, $from.node().type.name, $from.node().attrs),
+        ...overrideAttrs
+      };
+      const nextType2 = ((_a = type.contentMatch.defaultType) == null ? void 0 : _a.createAndFill(newNextTypeAttributes2)) || void 0;
+      wrap2 = wrap2.append(Fragment.from(type.createAndFill(null, nextType2) || void 0));
+      const start = $from.before($from.depth - (depthBefore - 1));
+      tr.replace(start, $from.after(-depthAfter), new Slice(wrap2, 4 - depthBefore, 0));
+      let sel = -1;
+      tr.doc.nodesBetween(start, tr.doc.content.size, (n, pos) => {
+        if (sel > -1) {
+          return false;
+        }
+        if (n.isTextblock && n.content.size === 0) {
+          sel = pos + 1;
+        }
+      });
+      if (sel > -1) {
+        tr.setSelection(TextSelection.near(tr.doc.resolve(sel)));
+      }
+      tr.scrollIntoView();
+    }
+    return true;
+  }
+  const nextType = $to.pos === $from.end() ? grandParent.contentMatchAt(0).defaultType : null;
+  const newTypeAttributes = {
+    ...getSplittedAttributes(extensionAttributes, grandParent.type.name, grandParent.attrs),
+    ...overrideAttrs
+  };
+  const newNextTypeAttributes = {
+    ...getSplittedAttributes(extensionAttributes, $from.node().type.name, $from.node().attrs),
+    ...overrideAttrs
+  };
+  tr.delete($from.pos, $to.pos);
+  const types = nextType ? [
+    { type, attrs: newTypeAttributes },
+    { type: nextType, attrs: newNextTypeAttributes }
+  ] : [{ type, attrs: newTypeAttributes }];
+  if (!canSplit(tr.doc, $from.pos, 2)) {
+    return false;
+  }
+  if (dispatch) {
+    const { selection, storedMarks } = state;
+    const { splittableMarks } = editor.extensionManager;
+    const marks = storedMarks || selection.$to.parentOffset && selection.$from.marks();
+    tr.split($from.pos, 2, types).scrollIntoView();
+    if (!marks || !dispatch) {
+      return true;
+    }
+    const filteredMarks = marks.filter((mark) => splittableMarks.includes(mark.type.name));
+    tr.ensureMarks(filteredMarks);
+  }
+  return true;
+};
+function normalizeListType(type) {
+  return !type || type === "1" ? null : type;
+}
+function areListTypesCompatible(typeA, typeB) {
+  return normalizeListType(typeA) === normalizeListType(typeB);
+}
+var joinListBackwards = (tr, listType) => {
+  const list = findParentNode((node) => node.type === listType)(tr.selection);
+  if (!list) {
+    return true;
+  }
+  const before = tr.doc.resolve(Math.max(0, list.pos - 1)).before(list.depth);
+  if (before === void 0) {
+    return true;
+  }
+  const nodeBefore = tr.doc.nodeAt(before);
+  const canJoinBackwards = list.node.type === (nodeBefore == null ? void 0 : nodeBefore.type) && canJoin(tr.doc, list.pos);
+  if (!canJoinBackwards) {
+    return true;
+  }
+  if (!areListTypesCompatible(list.node.attrs.type, nodeBefore == null ? void 0 : nodeBefore.attrs.type)) {
+    return true;
+  }
+  tr.join(list.pos);
+  return true;
+};
+var joinListForwards = (tr, listType) => {
+  const list = findParentNode((node) => node.type === listType)(tr.selection);
+  if (!list) {
+    return true;
+  }
+  const after = tr.doc.resolve(list.start).after(list.depth);
+  if (after === void 0) {
+    return true;
+  }
+  const nodeAfter = tr.doc.nodeAt(after);
+  const canJoinForwards = list.node.type === (nodeAfter == null ? void 0 : nodeAfter.type) && canJoin(tr.doc, after);
+  if (!canJoinForwards) {
+    return true;
+  }
+  if (!areListTypesCompatible(list.node.attrs.type, nodeAfter == null ? void 0 : nodeAfter.attrs.type)) {
+    return true;
+  }
+  tr.join(after);
+  return true;
+};
+function createInnerSelectionForWholeDocList(tr) {
+  const doc = tr.doc;
+  const list = doc.firstChild;
+  if (!list) {
+    return null;
+  }
+  const $start = doc.resolve(1);
+  const $end = doc.resolve(list.nodeSize - 1);
+  return TextSelection.between($start, $end);
+}
+var toggleList = (listTypeOrName, itemTypeOrName, keepMarks, attributes = {}) => ({ editor, tr, state, dispatch, chain, commands, can }) => {
+  const { extensions, splittableMarks } = editor.extensionManager;
+  const listType = getNodeType(listTypeOrName, state.schema);
+  const itemType = getNodeType(itemTypeOrName, state.schema);
+  const { selection, storedMarks } = state;
+  const { $from, $to } = selection;
+  const range = $from.blockRange($to);
+  const marks = storedMarks || selection.$to.parentOffset && selection.$from.marks();
+  if (!range) {
+    return false;
+  }
+  const parentList = findParentNode((node) => isList(node.type.name, extensions))(selection);
+  const isAllSelection = selection.from === 0 && selection.to === state.doc.content.size;
+  const topLevelNodes = state.doc.content.content;
+  const soleTopLevelNode = topLevelNodes.length === 1 ? topLevelNodes[0] : null;
+  const allSelectionList = isAllSelection && soleTopLevelNode && isList(soleTopLevelNode.type.name, extensions) ? {
+    node: soleTopLevelNode,
+    pos: 0
+  } : null;
+  const currentList = parentList != null ? parentList : allSelectionList;
+  const isInsideExistingList = !!parentList && range.depth >= 1 && range.depth - parentList.depth <= 1;
+  const hasWholeDocSelectedList = !!allSelectionList;
+  if ((isInsideExistingList || hasWholeDocSelectedList) && currentList) {
+    if (currentList.node.type === listType) {
+      if (isAllSelection && hasWholeDocSelectedList) {
+        return chain().command(({ tr: trx, dispatch: disp }) => {
+          const nextSelection = createInnerSelectionForWholeDocList(trx);
+          if (!nextSelection) {
+            return false;
+          }
+          trx.setSelection(nextSelection);
+          if (disp) {
+            disp(trx);
+          }
+          return true;
+        }).liftListItem(itemType).run();
+      }
+      return commands.liftListItem(itemType);
+    }
+    if (isList(currentList.node.type.name, extensions) && listType.validContent(currentList.node.content)) {
+      return chain().command(() => {
+        tr.setNodeMarkup(currentList.pos, listType);
+        return true;
+      }).command(() => joinListBackwards(tr, listType)).command(() => joinListForwards(tr, listType)).run();
+    }
+  }
+  if (!keepMarks || !marks || !dispatch) {
+    return chain().command(() => {
+      const canWrapInList = can().wrapInList(listType, attributes);
+      if (canWrapInList) {
+        return true;
+      }
+      return commands.clearNodes();
+    }).wrapInList(listType, attributes).command(() => joinListBackwards(tr, listType)).command(() => joinListForwards(tr, listType)).run();
+  }
+  return chain().command(() => {
+    const canWrapInList = can().wrapInList(listType, attributes);
+    const filteredMarks = marks.filter((mark) => splittableMarks.includes(mark.type.name));
+    tr.ensureMarks(filteredMarks);
+    if (canWrapInList) {
+      return true;
+    }
+    return commands.clearNodes();
+  }).wrapInList(listType, attributes).command(() => joinListBackwards(tr, listType)).command(() => joinListForwards(tr, listType)).run();
+};
+var toggleMark = (typeOrName, attributes = {}, options = {}) => ({ state, commands }) => {
+  const { extendEmptyMarkRange = false } = options;
+  const type = getMarkType(typeOrName, state.schema);
+  const isActive2 = isMarkActive(state, type, attributes);
+  if (isActive2) {
+    return commands.unsetMark(type, { extendEmptyMarkRange });
+  }
+  return commands.setMark(type, attributes);
+};
+var toggleNode = (typeOrName, toggleTypeOrName, attributes = {}) => ({ state, commands }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  const toggleType = getNodeType(toggleTypeOrName, state.schema);
+  const isActive2 = isNodeActive(state, type, attributes);
+  let attributesToCopy;
+  if (state.selection.$anchor.sameParent(state.selection.$head)) {
+    attributesToCopy = state.selection.$anchor.parent.attrs;
+  }
+  if (isActive2) {
+    return commands.setNode(toggleType, attributesToCopy);
+  }
+  return commands.setNode(type, { ...attributesToCopy, ...attributes });
+};
+var toggleWrap = (typeOrName, attributes = {}) => ({ state, commands }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  const isActive2 = isNodeActive(state, type, attributes);
+  if (isActive2) {
+    return commands.lift(type);
+  }
+  return commands.wrapIn(type, attributes);
+};
+var undoInputRule = () => ({ state, dispatch }) => {
+  const plugins = state.plugins;
+  for (let i = 0; i < plugins.length; i += 1) {
+    const plugin = plugins[i];
+    let undoable;
+    if (plugin.spec.isInputRules && (undoable = plugin.getState(state))) {
+      if (dispatch) {
+        const tr = state.tr;
+        const toUndo = undoable.transform;
+        for (let j = toUndo.steps.length - 1; j >= 0; j -= 1) {
+          tr.step(toUndo.steps[j].invert(toUndo.docs[j]));
+        }
+        if (undoable.text) {
+          const marks = tr.doc.resolve(undoable.from).marks();
+          tr.replaceWith(undoable.from, undoable.to, state.schema.text(undoable.text, marks));
+        } else {
+          tr.delete(undoable.from, undoable.to);
+        }
+      }
+      return true;
+    }
+  }
+  return false;
+};
+var unsetAllMarks = (options = {}) => ({ tr, dispatch, editor }) => {
+  const { ignoreClearable = false } = options;
+  const { selection } = tr;
+  const { empty, ranges } = selection;
+  if (empty) {
+    return true;
+  }
+  const { nonClearableMarks } = editor.extensionManager;
+  if (dispatch) {
+    const clearableMarkTypes = Object.values(editor.schema.marks).filter(
+      (markType) => ignoreClearable || !nonClearableMarks.includes(markType.name)
+    );
+    ranges.forEach((range) => {
+      for (const markType of clearableMarkTypes) {
+        tr.removeMark(range.$from.pos, range.$to.pos, markType);
+      }
+    });
+  }
+  return true;
+};
+var unsetMark = (typeOrName, options = {}) => ({ tr, state, dispatch }) => {
+  var _a;
+  const { extendEmptyMarkRange = false } = options;
+  const { selection } = tr;
+  const type = getMarkType(typeOrName, state.schema);
+  const { $from, empty, ranges } = selection;
+  if (!dispatch) {
+    return true;
+  }
+  if (empty && extendEmptyMarkRange) {
+    let { from, to } = selection;
+    const attrs = (_a = $from.marks().find((mark) => mark.type === type)) == null ? void 0 : _a.attrs;
+    const range = getMarkRange($from, type, attrs);
+    if (range) {
+      from = range.from;
+      to = range.to;
+    }
+    tr.removeMark(from, to, type);
+  } else {
+    ranges.forEach((range) => {
+      tr.removeMark(range.$from.pos, range.$to.pos, type);
+    });
+  }
+  tr.removeStoredMark(type);
+  return true;
+};
+var unsetTextDirection = (position) => ({ tr, state, dispatch }) => {
+  const { selection } = state;
+  let from;
+  let to;
+  if (typeof position === "number") {
+    from = position;
+    to = position;
+  } else if (position && "from" in position && "to" in position) {
+    from = position.from;
+    to = position.to;
+  } else {
+    from = selection.from;
+    to = selection.to;
+  }
+  if (dispatch) {
+    tr.doc.nodesBetween(from, to, (node, pos) => {
+      if (node.isText) {
+        return;
+      }
+      const newAttrs = { ...node.attrs };
+      delete newAttrs.dir;
+      tr.setNodeMarkup(pos, void 0, newAttrs);
+    });
+  }
+  return true;
+};
+var updateAttributes = (typeOrName, attributes = {}) => ({ tr, state, dispatch }) => {
+  let nodeType = null;
+  let markType = null;
+  const schemaType = getSchemaTypeNameByName(
+    typeof typeOrName === "string" ? typeOrName : typeOrName.name,
+    state.schema
+  );
+  if (!schemaType) {
+    return false;
+  }
+  if (schemaType === "node") {
+    nodeType = getNodeType(typeOrName, state.schema);
+  }
+  if (schemaType === "mark") {
+    markType = getMarkType(typeOrName, state.schema);
+  }
+  let canUpdate = false;
+  tr.selection.ranges.forEach((range) => {
+    const from = range.$from.pos;
+    const to = range.$to.pos;
+    let lastPos;
+    let lastNode;
+    let trimmedFrom;
+    let trimmedTo;
+    if (tr.selection.empty) {
+      state.doc.nodesBetween(from, to, (node, pos) => {
+        if (nodeType && nodeType === node.type) {
+          canUpdate = true;
+          trimmedFrom = Math.max(pos, from);
+          trimmedTo = Math.min(pos + node.nodeSize, to);
+          lastPos = pos;
+          lastNode = node;
+        }
+      });
+    } else {
+      state.doc.nodesBetween(from, to, (node, pos) => {
+        if (pos < from && nodeType && nodeType === node.type) {
+          canUpdate = true;
+          trimmedFrom = Math.max(pos, from);
+          trimmedTo = Math.min(pos + node.nodeSize, to);
+          lastPos = pos;
+          lastNode = node;
+        }
+        if (pos >= from && pos <= to) {
+          if (nodeType && nodeType === node.type) {
+            canUpdate = true;
+            if (dispatch) {
+              tr.setNodeMarkup(pos, void 0, {
+                ...node.attrs,
+                ...attributes
+              });
+            }
+          }
+          if (markType && node.marks.length) {
+            node.marks.forEach((mark) => {
+              if (markType === mark.type) {
+                canUpdate = true;
+                if (dispatch) {
+                  const trimmedFrom2 = Math.max(pos, from);
+                  const trimmedTo2 = Math.min(pos + node.nodeSize, to);
+                  tr.addMark(
+                    trimmedFrom2,
+                    trimmedTo2,
+                    markType.create({
+                      ...mark.attrs,
+                      ...attributes
+                    })
+                  );
+                }
+              }
+            });
+          }
+        }
+      });
+    }
+    if (lastNode) {
+      if (lastPos !== void 0 && dispatch) {
+        tr.setNodeMarkup(lastPos, void 0, {
+          ...lastNode.attrs,
+          ...attributes
+        });
+      }
+      if (markType && lastNode.marks.length) {
+        lastNode.marks.forEach((mark) => {
+          if (markType === mark.type && dispatch) {
+            tr.addMark(
+              trimmedFrom,
+              trimmedTo,
+              markType.create({
+                ...mark.attrs,
+                ...attributes
+              })
+            );
+          }
+        });
+      }
+    }
+  });
+  return canUpdate;
+};
+var wrapIn = (typeOrName, attributes = {}) => ({ state, dispatch }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  return wrapIn$1(type, attributes)(state, dispatch);
+};
+var wrapInList = (typeOrName, attributes = {}) => ({ state, dispatch }) => {
+  const type = getNodeType(typeOrName, state.schema);
+  return wrapInList$1(type, attributes)(state, dispatch);
+};
+function getStyleProperty(element, propertyName) {
+  const styleAttr = element.getAttribute("style");
+  if (!styleAttr) {
+    return null;
+  }
+  const decls = styleAttr.split(";").map((decl) => decl.trim()).filter(Boolean);
+  const target = propertyName.toLowerCase();
+  for (let i = decls.length - 1; i >= 0; i -= 1) {
+    const decl = decls[i];
+    const colonIndex = decl.indexOf(":");
+    if (colonIndex === -1) {
+      continue;
+    }
+    const prop = decl.slice(0, colonIndex).trim().toLowerCase();
+    if (prop === target) {
+      return decl.slice(colonIndex + 1).trim();
+    }
+  }
+  return null;
+}
+function getType(value) {
+  return Object.prototype.toString.call(value).slice(8, -1);
+}
+function isPlainObject(value) {
+  if (getType(value) !== "Object") {
+    return false;
+  }
+  return value.constructor === Object && Object.getPrototypeOf(value) === Object.prototype;
+}
+var markdown_exports = {};
+__export$1(markdown_exports, {
+  createAtomBlockMarkdownSpec: () => createAtomBlockMarkdownSpec,
+  createBlockMarkdownSpec: () => createBlockMarkdownSpec,
+  createInlineMarkdownSpec: () => createInlineMarkdownSpec,
+  parseAttributes: () => parseAttributes,
+  parseIndentedBlocks: () => parseIndentedBlocks,
+  renderNestedMarkdownContent: () => renderNestedMarkdownContent,
+  serializeAttributes: () => serializeAttributes
+});
+function parseAttributes(attrString) {
+  if (!(attrString == null ? void 0 : attrString.trim())) {
+    return {};
+  }
+  const attributes = {};
+  const quotedStrings = [];
+  const tempString = attrString.replace(/["']([^"']*)["']/g, (match) => {
+    quotedStrings.push(match);
+    return `__QUOTED_${quotedStrings.length - 1}__`;
+  });
+  const classMatches = tempString.match(/(?:^|\s)\.([\w-]+)/g);
+  if (classMatches) {
+    const classes = classMatches.map((match) => match.trim().slice(1));
+    attributes.class = classes.join(" ");
+  }
+  const idMatch = tempString.match(/(?:^|\s)#([\w-]+)/);
+  if (idMatch) {
+    attributes.id = idMatch[1];
+  }
+  const kvRegex = /([a-zA-Z][\w-]*)\s*=\s*(__QUOTED_\d+__)/g;
+  const kvMatches = Array.from(tempString.matchAll(kvRegex));
+  kvMatches.forEach(([, key, quotedRef]) => {
+    var _a;
+    const quotedIndex = parseInt(((_a = quotedRef.match(/__QUOTED_(\d+)__/)) == null ? void 0 : _a[1]) || "0", 10);
+    const quotedValue = quotedStrings[quotedIndex];
+    if (quotedValue) {
+      attributes[key] = quotedValue.slice(1, -1);
+    }
+  });
+  const cleanString = tempString.replace(/(?:^|\s)\.([\w-]+)/g, "").replace(/(?:^|\s)#([\w-]+)/g, "").replace(/([a-zA-Z][\w-]*)\s*=\s*__QUOTED_\d+__/g, "").trim();
+  if (cleanString) {
+    const booleanAttrs = cleanString.split(/\s+/).filter(Boolean);
+    booleanAttrs.forEach((attr) => {
+      if (attr.match(/^[a-zA-Z][\w-]*$/)) {
+        attributes[attr] = true;
+      }
+    });
+  }
+  return attributes;
+}
+function serializeAttributes(attributes) {
+  if (!attributes || Object.keys(attributes).length === 0) {
+    return "";
+  }
+  const parts = [];
+  if (attributes.class) {
+    const classes = String(attributes.class).split(/\s+/).filter(Boolean);
+    classes.forEach((cls) => parts.push(`.${cls}`));
+  }
+  if (attributes.id) {
+    parts.push(`#${attributes.id}`);
+  }
+  Object.entries(attributes).forEach(([key, value]) => {
+    if (key === "class" || key === "id") {
+      return;
+    }
+    if (value === true) {
+      parts.push(key);
+    } else if (value !== false && value != null) {
+      parts.push(`${key}="${String(value)}"`);
+    }
+  });
+  return parts.join(" ");
+}
+function createAtomBlockMarkdownSpec(options) {
+  const {
+    nodeName,
+    name: markdownName,
+    parseAttributes: parseAttributes2 = parseAttributes,
+    serializeAttributes: serializeAttributes2 = serializeAttributes,
+    defaultAttributes = {},
+    requiredAttributes = [],
+    allowedAttributes
+  } = options;
+  const blockName = markdownName || nodeName;
+  const filterAttributes = (attrs) => {
+    if (!allowedAttributes) {
+      return attrs;
+    }
+    const filtered = {};
+    allowedAttributes.forEach((key) => {
+      if (key in attrs) {
+        filtered[key] = attrs[key];
+      }
+    });
+    return filtered;
+  };
+  return {
+    parseMarkdown: (token, h2) => {
+      const attrs = { ...defaultAttributes, ...token.attributes };
+      return h2.createNode(nodeName, attrs, []);
+    },
+    markdownTokenizer: {
+      name: nodeName,
+      level: "block",
+      start(src) {
+        var _a;
+        const regex = new RegExp(`^:::${blockName}(?:\\s|$)`, "m");
+        const index = (_a = src.match(regex)) == null ? void 0 : _a.index;
+        return index !== void 0 ? index : -1;
+      },
+      tokenize(src, _tokens, _lexer) {
+        const regex = new RegExp(`^:::${blockName}(?:\\s+\\{([^}]*)\\})?\\s*:::(?:\\n|$)`);
+        const match = src.match(regex);
+        if (!match) {
+          return void 0;
+        }
+        const attrString = match[1] || "";
+        const attributes = parseAttributes2(attrString);
+        const missingRequired = requiredAttributes.find((required) => !(required in attributes));
+        if (missingRequired) {
+          return void 0;
+        }
+        return {
+          type: nodeName,
+          raw: match[0],
+          attributes
+        };
+      }
+    },
+    renderMarkdown: (node) => {
+      const filteredAttrs = filterAttributes(node.attrs || {});
+      const attrs = serializeAttributes2(filteredAttrs);
+      const attrString = attrs ? ` {${attrs}}` : "";
+      return `:::${blockName}${attrString} :::`;
+    }
+  };
+}
+function createBlockMarkdownSpec(options) {
+  const {
+    nodeName,
+    name: markdownName,
+    getContent,
+    parseAttributes: parseAttributes2 = parseAttributes,
+    serializeAttributes: serializeAttributes2 = serializeAttributes,
+    defaultAttributes = {},
+    content = "block",
+    allowedAttributes
+  } = options;
+  const blockName = markdownName || nodeName;
+  const filterAttributes = (attrs) => {
+    if (!allowedAttributes) {
+      return attrs;
+    }
+    const filtered = {};
+    allowedAttributes.forEach((key) => {
+      if (key in attrs) {
+        filtered[key] = attrs[key];
+      }
+    });
+    return filtered;
+  };
+  return {
+    parseMarkdown: (token, h2) => {
+      let nodeContent;
+      if (getContent) {
+        const contentResult = getContent(token);
+        nodeContent = typeof contentResult === "string" ? [{ type: "text", text: contentResult }] : contentResult;
+      } else if (content === "block") {
+        nodeContent = h2.parseChildren(token.tokens || []);
+      } else {
+        nodeContent = h2.parseInline(token.tokens || []);
+      }
+      const attrs = { ...defaultAttributes, ...token.attributes };
+      return h2.createNode(nodeName, attrs, nodeContent);
+    },
+    markdownTokenizer: {
+      name: nodeName,
+      level: "block",
+      start(src) {
+        var _a;
+        const regex = new RegExp(`^:::${blockName}`, "m");
+        const index = (_a = src.match(regex)) == null ? void 0 : _a.index;
+        return index !== void 0 ? index : -1;
+      },
+      tokenize(src, _tokens, lexer) {
+        var _a;
+        const openingRegex = new RegExp(`^:::${blockName}(?:\\s+\\{([^}]*)\\})?\\s*\\n`);
+        const openingMatch = src.match(openingRegex);
+        if (!openingMatch) {
+          return void 0;
+        }
+        const [openingTag, attrString = ""] = openingMatch;
+        const attributes = parseAttributes2(attrString);
+        let level = 1;
+        const position = openingTag.length;
+        let matchedContent = "";
+        const blockPattern = /^:::([\w-]*)(\s.*)?/gm;
+        const remaining = src.slice(position);
+        blockPattern.lastIndex = 0;
+        for (; ; ) {
+          const match = blockPattern.exec(remaining);
+          if (match === null) {
+            break;
+          }
+          const matchPos = match.index;
+          const blockType = match[1];
+          if ((_a = match[2]) == null ? void 0 : _a.endsWith(":::")) {
+            continue;
+          }
+          if (blockType) {
+            level += 1;
+          } else {
+            level -= 1;
+            if (level === 0) {
+              const rawContent = remaining.slice(0, matchPos);
+              matchedContent = rawContent.trim();
+              const fullMatch = src.slice(0, position + matchPos + match[0].length);
+              let contentTokens = [];
+              if (matchedContent) {
+                if (content === "block") {
+                  contentTokens = lexer.blockTokens(rawContent);
+                  contentTokens.forEach((token) => {
+                    if (token.text && (!token.tokens || token.tokens.length === 0)) {
+                      token.tokens = lexer.inlineTokens(token.text);
+                    }
+                  });
+                  while (contentTokens.length > 0) {
+                    const lastToken = contentTokens[contentTokens.length - 1];
+                    if (lastToken.type === "paragraph" && (!lastToken.text || lastToken.text.trim() === "")) {
+                      contentTokens.pop();
+                    } else {
+                      break;
+                    }
+                  }
+                } else {
+                  contentTokens = lexer.inlineTokens(matchedContent);
+                }
+              }
+              return {
+                type: nodeName,
+                raw: fullMatch,
+                attributes,
+                content: matchedContent,
+                tokens: contentTokens
+              };
+            }
+          }
+        }
+        return void 0;
+      }
+    },
+    renderMarkdown: (node, h2) => {
+      const filteredAttrs = filterAttributes(node.attrs || {});
+      const attrs = serializeAttributes2(filteredAttrs);
+      const attrString = attrs ? ` {${attrs}}` : "";
+      const renderedContent = h2.renderChildren(node.content || [], "\n\n");
+      return `:::${blockName}${attrString}
+
+${renderedContent}
+
+:::`;
+    }
+  };
+}
+function parseShortcodeAttributes(attrString) {
+  if (!attrString.trim()) {
+    return {};
+  }
+  const attributes = {};
+  const regex = /(\w+)=(?:"([^"]*)"|'([^']*)')/g;
+  let match = regex.exec(attrString);
+  while (match !== null) {
+    const [, key, doubleQuoted, singleQuoted] = match;
+    attributes[key] = doubleQuoted || singleQuoted;
+    match = regex.exec(attrString);
+  }
+  return attributes;
+}
+function serializeShortcodeAttributes(attrs) {
+  return Object.entries(attrs).filter(([, value]) => value !== void 0 && value !== null).map(([key, value]) => `${key}="${value}"`).join(" ");
+}
+function createInlineMarkdownSpec(options) {
+  const {
+    nodeName,
+    name: shortcodeName,
+    getContent,
+    parseAttributes: parseAttributes2 = parseShortcodeAttributes,
+    serializeAttributes: serializeAttributes2 = serializeShortcodeAttributes,
+    defaultAttributes = {},
+    selfClosing = false,
+    allowedAttributes
+  } = options;
+  const shortcode = shortcodeName || nodeName;
+  const filterAttributes = (attrs) => {
+    if (!allowedAttributes) {
+      return attrs;
+    }
+    const filtered = {};
+    allowedAttributes.forEach((attr) => {
+      const attrName = typeof attr === "string" ? attr : attr.name;
+      const skipIfDefault = typeof attr === "string" ? void 0 : attr.skipIfDefault;
+      if (attrName in attrs) {
+        const value = attrs[attrName];
+        if (skipIfDefault !== void 0 && value === skipIfDefault) {
+          return;
+        }
+        filtered[attrName] = value;
+      }
+    });
+    return filtered;
+  };
+  const escapedShortcode = shortcode.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return {
+    parseMarkdown: (token, h2) => {
+      const attrs = { ...defaultAttributes, ...token.attributes };
+      if (selfClosing) {
+        return h2.createNode(nodeName, attrs);
+      }
+      const content = getContent ? getContent(token) : token.content || "";
+      if (content) {
+        return h2.createNode(nodeName, attrs, [h2.createTextNode(content)]);
+      }
+      return h2.createNode(nodeName, attrs, []);
+    },
+    markdownTokenizer: {
+      name: nodeName,
+      level: "inline",
+      start(src) {
+        const startPattern = selfClosing ? new RegExp(`\\[${escapedShortcode}\\s*[^\\]]*\\]`) : new RegExp(`\\[${escapedShortcode}\\s*[^\\]]*\\][\\s\\S]*?\\[\\/${escapedShortcode}\\]`);
+        const match = src.match(startPattern);
+        const index = match == null ? void 0 : match.index;
+        return index !== void 0 ? index : -1;
+      },
+      tokenize(src, _tokens, _lexer) {
+        const tokenPattern = selfClosing ? new RegExp(`^\\[${escapedShortcode}\\s*([^\\]]*)\\]`) : new RegExp(
+          `^\\[${escapedShortcode}\\s*([^\\]]*)\\]([\\s\\S]*?)\\[\\/${escapedShortcode}\\]`
+        );
+        const match = src.match(tokenPattern);
+        if (!match) {
+          return void 0;
+        }
+        let content = "";
+        let attrString = "";
+        if (selfClosing) {
+          const [, attrs] = match;
+          attrString = attrs;
+        } else {
+          const [, attrs, contentMatch] = match;
+          attrString = attrs;
+          content = contentMatch || "";
+        }
+        const attributes = parseAttributes2(attrString.trim());
+        return {
+          type: nodeName,
+          raw: match[0],
+          content: content.trim(),
+          attributes
+        };
+      }
+    },
+    renderMarkdown: (node) => {
+      let content = "";
+      if (getContent) {
+        content = getContent(node);
+      } else if (node.content && node.content.length > 0) {
+        content = node.content.filter((child) => child.type === "text").map((child) => child.text).join("");
+      }
+      const filteredAttrs = filterAttributes(node.attrs || {});
+      const attrs = serializeAttributes2(filteredAttrs);
+      const attrString = attrs ? ` ${attrs}` : "";
+      if (selfClosing) {
+        return `[${shortcode}${attrString}]`;
+      }
+      return `[${shortcode}${attrString}]${content}[/${shortcode}]`;
+    }
+  };
+}
+function parseIndentedBlocks(src, config, lexer) {
+  var _a, _b, _c, _d;
+  const lines = src.split("\n");
+  const items = [];
+  let totalRaw = "";
+  let i = 0;
+  const baseIndentSize = config.baseIndentSize || 2;
+  while (i < lines.length) {
+    const currentLine = lines[i];
+    const itemMatch = currentLine.match(config.itemPattern);
+    if (!itemMatch) {
+      if (items.length > 0) {
+        break;
+      } else if (currentLine.trim() === "") {
+        i += 1;
+        totalRaw = `${totalRaw}${currentLine}
+`;
+        continue;
+      } else {
+        return void 0;
+      }
+    }
+    const itemData = config.extractItemData(itemMatch);
+    const { indentLevel, mainContent } = itemData;
+    totalRaw = `${totalRaw}${currentLine}
+`;
+    const itemContent = [mainContent];
+    i += 1;
+    while (i < lines.length) {
+      const nextLine = lines[i];
+      if (nextLine.trim() === "") {
+        const nextNonEmptyIndex = lines.slice(i + 1).findIndex((l) => l.trim() !== "");
+        if (nextNonEmptyIndex === -1) {
+          break;
+        }
+        const nextNonEmpty = lines[i + 1 + nextNonEmptyIndex];
+        const nextIndent2 = ((_b = (_a = nextNonEmpty.match(/^(\s*)/)) == null ? void 0 : _a[1]) == null ? void 0 : _b.length) || 0;
+        if (nextIndent2 > indentLevel) {
+          itemContent.push(nextLine);
+          totalRaw = `${totalRaw}${nextLine}
+`;
+          i += 1;
+          continue;
+        } else {
+          break;
+        }
+      }
+      const nextIndent = ((_d = (_c = nextLine.match(/^(\s*)/)) == null ? void 0 : _c[1]) == null ? void 0 : _d.length) || 0;
+      if (nextIndent > indentLevel) {
+        itemContent.push(nextLine);
+        totalRaw = `${totalRaw}${nextLine}
+`;
+        i += 1;
+      } else {
+        break;
+      }
+    }
+    let nestedTokens;
+    const nestedContent = itemContent.slice(1);
+    if (nestedContent.length > 0) {
+      const dedentedNested = nestedContent.map((nestedLine) => nestedLine.slice(indentLevel + baseIndentSize)).join("\n");
+      if (dedentedNested.trim()) {
+        if (config.customNestedParser) {
+          nestedTokens = config.customNestedParser(dedentedNested);
+        } else {
+          nestedTokens = lexer.blockTokens(dedentedNested);
+        }
+      }
+    }
+    const token = config.createToken(itemData, nestedTokens);
+    items.push(token);
+  }
+  if (items.length === 0) {
+    return void 0;
+  }
+  return {
+    items,
+    raw: totalRaw
+  };
+}
+function renderNestedMarkdownContent(node, h2, prefixOrGenerator, ctx) {
+  if (!node || !Array.isArray(node.content)) {
+    return "";
+  }
+  const prefix = typeof prefixOrGenerator === "function" ? prefixOrGenerator(ctx) : prefixOrGenerator;
+  const [content, ...children] = node.content;
+  const mainContent = h2.renderChildren([content]);
+  let output = `${prefix}${mainContent}`;
+  if (children && children.length > 0) {
+    children.forEach((child, index) => {
+      var _a, _b;
+      const childContent = (_b = (_a = h2.renderChild) == null ? void 0 : _a.call(h2, child, index + 1)) != null ? _b : h2.renderChildren([child]);
+      if (childContent !== void 0 && childContent !== null) {
+        const indentedChild = childContent.split("\n").map((line) => line ? h2.indent(line) : h2.indent("")).join("\n");
+        output += child.type === "paragraph" ? `
+
+${indentedChild}` : `
+${indentedChild}`;
+      }
+    });
+  }
+  return output;
+}
+function mergeDeep(target, source) {
+  const output = { ...target };
+  if (isPlainObject(target) && isPlainObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (isPlainObject(source[key]) && isPlainObject(target[key])) {
+        output[key] = mergeDeep(target[key], source[key]);
+      } else {
+        output[key] = source[key];
+      }
+    });
+  }
+  return output;
+}
+var InputRule = class {
+  constructor(config) {
+    var _a;
+    this.find = config.find;
+    this.handler = config.handler;
+    this.undoable = (_a = config.undoable) != null ? _a : true;
+  }
+};
+var Extendable = class {
+  constructor(config = {}) {
+    this.type = "extendable";
+    this.parent = null;
+    this.child = null;
+    this.name = "";
+    this.config = {
+      name: this.name
+    };
+    this.config = {
+      ...this.config,
+      ...config
+    };
+    this.name = this.config.name;
+  }
+  get options() {
+    return {
+      ...callOrReturn(
+        getExtensionField(this, "addOptions", {
+          name: this.name
+        })
+      )
+    };
+  }
+  get storage() {
+    return {
+      ...callOrReturn(
+        getExtensionField(this, "addStorage", {
+          name: this.name,
+          options: this.options
+        })
+      )
+    };
+  }
+  configure(options = {}) {
+    const extension = this.extend({
+      ...this.config,
+      addOptions: () => {
+        return mergeDeep(this.options, options);
+      }
+    });
+    extension.name = this.name;
+    extension.parent = this.parent;
+    this.child = null;
+    return extension;
+  }
+  extend(extendedConfig = {}) {
+    const extension = new this.constructor({ ...this.config, ...extendedConfig });
+    extension.parent = this;
+    this.child = extension;
+    extension.name = "name" in extendedConfig ? extendedConfig.name : extension.parent.name;
+    return extension;
+  }
+};
+var Mark2 = class _Mark extends Extendable {
+  constructor() {
+    super(...arguments);
+    this.type = "mark";
+  }
+  /**
+   * Create a new Mark instance
+   * @param config - Mark configuration object or a function that returns a configuration object
+   */
+  static create(config = {}) {
+    const resolvedConfig = typeof config === "function" ? config() : config;
+    return new _Mark(resolvedConfig);
+  }
+  static handleExit({ editor, mark }) {
+    const { tr } = editor.state;
+    const currentPos = editor.state.selection.$from;
+    const isAtEnd = currentPos.pos === currentPos.end();
+    if (isAtEnd) {
+      const currentMarks = currentPos.marks();
+      const isInMark = !!currentMarks.find((m) => (m == null ? void 0 : m.type.name) === mark.name);
+      if (!isInMark) {
+        return false;
+      }
+      const removeMark2 = currentMarks.find((m) => (m == null ? void 0 : m.type.name) === mark.name);
+      if (removeMark2) {
+        tr.removeStoredMark(removeMark2);
+      }
+      tr.insertText(" ", currentPos.pos);
+      editor.view.dispatch(tr);
+      return true;
+    }
+    return false;
+  }
+  configure(options) {
+    return super.configure(options);
+  }
+  extend(extendedConfig) {
+    const resolvedConfig = typeof extendedConfig === "function" ? extendedConfig() : extendedConfig;
+    return super.extend(resolvedConfig);
+  }
+};
+var PasteRule = class {
+  constructor(config) {
+    this.find = config.find;
+    this.handler = config.handler;
+  }
+};
+var extensions_exports = {};
+__export$1(extensions_exports, {
+  ClipboardTextSerializer: () => ClipboardTextSerializer,
+  Commands: () => Commands,
+  Delete: () => Delete,
+  Drop: () => Drop,
+  Editable: () => Editable,
+  FocusEvents: () => FocusEvents,
+  Keymap: () => Keymap,
+  Paste: () => Paste,
+  Tabindex: () => Tabindex,
+  TextDirection: () => TextDirection,
+  focusEventsPluginKey: () => focusEventsPluginKey
+});
+var Extension = class _Extension extends Extendable {
+  constructor() {
+    super(...arguments);
+    this.type = "extension";
+  }
+  /**
+   * Create a new Extension instance
+   * @param config - Extension configuration object or a function that returns a configuration object
+   */
+  static create(config = {}) {
+    const resolvedConfig = typeof config === "function" ? config() : config;
+    return new _Extension(resolvedConfig);
+  }
+  configure(options) {
+    return super.configure(options);
+  }
+  extend(extendedConfig) {
+    const resolvedConfig = typeof extendedConfig === "function" ? extendedConfig() : extendedConfig;
+    return super.extend(resolvedConfig);
+  }
+};
+var ClipboardTextSerializer = Extension.create({
+  name: "clipboardTextSerializer",
+  addOptions() {
+    return {
+      blockSeparator: void 0
+    };
+  },
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("clipboardTextSerializer"),
+        props: {
+          clipboardTextSerializer: () => {
+            const { editor } = this;
+            const { state, schema } = editor;
+            const { doc, selection } = state;
+            const textSerializers = getTextSerializersFromSchema(schema);
+            const { blockSeparator } = this.options;
+            const options = {
+              ...blockSeparator !== void 0 ? { blockSeparator } : {},
+              textSerializers
+            };
+            const sortedRanges = [...selection.ranges].sort((a, b) => a.$from.pos - b.$from.pos);
+            return sortedRanges.map(
+              ({ $from, $to }) => getTextBetween(doc, { from: $from.pos, to: $to.pos }, options)
+            ).join(blockSeparator != null ? blockSeparator : "\n\n");
+          }
+        }
+      })
+    ];
+  }
+});
+var Commands = Extension.create({
+  name: "commands",
+  addCommands() {
+    return {
+      ...commands_exports
+    };
+  }
+});
+var Delete = Extension.create({
+  name: "delete",
+  onUpdate({ transaction, appendedTransactions }) {
+    var _a, _b, _c;
+    const callback = () => {
+      var _a2, _b2, _c2, _d;
+      if ((_d = (_c2 = (_b2 = (_a2 = this.editor.options.coreExtensionOptions) == null ? void 0 : _a2.delete) == null ? void 0 : _b2.filterTransaction) == null ? void 0 : _c2.call(_b2, transaction)) != null ? _d : transaction.getMeta("y-sync$")) {
+        return;
+      }
+      const nextTransaction = combineTransactionSteps(transaction.before, [
+        transaction,
+        ...appendedTransactions
+      ]);
+      const changes = getChangedRanges(nextTransaction);
+      changes.forEach((change) => {
+        if (nextTransaction.mapping.mapResult(change.oldRange.from).deletedAfter && nextTransaction.mapping.mapResult(change.oldRange.to).deletedBefore) {
+          nextTransaction.before.nodesBetween(
+            change.oldRange.from,
+            change.oldRange.to,
+            (node, from) => {
+              const to = from + node.nodeSize - 2;
+              const isFullyWithinRange = change.oldRange.from <= from && to <= change.oldRange.to;
+              this.editor.emit("delete", {
+                type: "node",
+                node,
+                from,
+                to,
+                newFrom: nextTransaction.mapping.map(from),
+                newTo: nextTransaction.mapping.map(to),
+                deletedRange: change.oldRange,
+                newRange: change.newRange,
+                partial: !isFullyWithinRange,
+                editor: this.editor,
+                transaction,
+                combinedTransform: nextTransaction
+              });
+            }
+          );
+        }
+      });
+      const mapping = nextTransaction.mapping;
+      nextTransaction.steps.forEach((step, index) => {
+        var _a3, _b3;
+        if (step instanceof RemoveMarkStep) {
+          const newStart = mapping.slice(index).map(step.from, -1);
+          const newEnd = mapping.slice(index).map(step.to);
+          const oldStart = mapping.invert().map(newStart, -1);
+          const oldEnd = mapping.invert().map(newEnd);
+          const foundBeforeMark = newStart > 0 ? (_a3 = nextTransaction.doc.nodeAt(newStart - 1)) == null ? void 0 : _a3.marks.some((mark) => mark.eq(step.mark)) : false;
+          const foundAfterMark = (_b3 = nextTransaction.doc.nodeAt(newEnd)) == null ? void 0 : _b3.marks.some((mark) => mark.eq(step.mark));
+          this.editor.emit("delete", {
+            type: "mark",
+            mark: step.mark,
+            from: step.from,
+            to: step.to,
+            deletedRange: {
+              from: oldStart,
+              to: oldEnd
+            },
+            newRange: {
+              from: newStart,
+              to: newEnd
+            },
+            partial: Boolean(foundAfterMark || foundBeforeMark),
+            editor: this.editor,
+            transaction,
+            combinedTransform: nextTransaction
+          });
+        }
+      });
+    };
+    if ((_c = (_b = (_a = this.editor.options.coreExtensionOptions) == null ? void 0 : _a.delete) == null ? void 0 : _b.async) != null ? _c : true) {
+      setTimeout(callback, 0);
+    } else {
+      callback();
+    }
+  }
+});
+var Drop = Extension.create({
+  name: "drop",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("tiptapDrop"),
+        props: {
+          handleDrop: (_, e, slice, moved) => {
+            this.editor.emit("drop", {
+              editor: this.editor,
+              event: e,
+              slice,
+              moved
+            });
+          }
+        }
+      })
+    ];
+  }
+});
+var Editable = Extension.create({
+  name: "editable",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("editable"),
+        props: {
+          editable: () => this.editor.options.editable
+        }
+      })
+    ];
+  }
+});
+var focusEventsPluginKey = new PluginKey("focusEvents");
+var FocusEvents = Extension.create({
+  name: "focusEvents",
+  addProseMirrorPlugins() {
+    const { editor } = this;
+    return [
+      new Plugin({
+        key: focusEventsPluginKey,
+        props: {
+          handleDOMEvents: {
+            focus: (view, event) => {
+              editor.isFocused = true;
+              const transaction = editor.state.tr.setMeta("focus", { event }).setMeta("addToHistory", false);
+              view.dispatch(transaction);
+              return false;
+            },
+            blur: (view, event) => {
+              editor.isFocused = false;
+              const transaction = editor.state.tr.setMeta("blur", { event }).setMeta("addToHistory", false);
+              view.dispatch(transaction);
+              return false;
+            }
+          }
+        }
+      })
+    ];
+  }
+});
+var Keymap = Extension.create({
+  name: "keymap",
+  addKeyboardShortcuts() {
+    const handleBackspace2 = () => this.editor.commands.first(({ commands }) => [
+      () => commands.undoInputRule(),
+      // maybe convert first text block node to default node
+      () => commands.command(({ tr }) => {
+        const { selection, doc } = tr;
+        const { empty, $anchor } = selection;
+        const { pos, parent } = $anchor;
+        const $parentPos = $anchor.parent.isTextblock && pos > 0 ? tr.doc.resolve(pos - 1) : $anchor;
+        const parentIsIsolating = $parentPos.parent.type.spec.isolating;
+        const parentPos = $anchor.pos - $anchor.parentOffset;
+        const isAtStart = parentIsIsolating && $parentPos.parent.childCount === 1 ? parentPos === $anchor.pos : Selection.atStart(doc).from === pos;
+        if (!empty || !parent.type.isTextblock || parent.textContent.length || !isAtStart || isAtStart && $anchor.parent.type.name === "paragraph") {
+          return false;
+        }
+        return commands.clearNodes();
+      }),
+      () => commands.deleteSelection(),
+      () => commands.joinBackward(),
+      () => commands.selectNodeBackward()
+    ]);
+    const handleDelete2 = () => this.editor.commands.first(({ commands }) => [
+      () => commands.deleteSelection(),
+      () => commands.deleteCurrentNode(),
+      () => commands.joinForward(),
+      () => commands.selectNodeForward()
+    ]);
+    const handleEnter = () => this.editor.commands.first(({ commands }) => [
+      () => commands.newlineInCode(),
+      () => commands.createParagraphNear(),
+      () => commands.liftEmptyBlock(),
+      () => commands.splitBlock()
+    ]);
+    const baseKeymap = {
+      Enter: handleEnter,
+      "Mod-Enter": () => this.editor.commands.exitCode(),
+      Backspace: handleBackspace2,
+      "Mod-Backspace": handleBackspace2,
+      "Shift-Backspace": handleBackspace2,
+      Delete: handleDelete2,
+      "Mod-Delete": handleDelete2,
+      "Mod-a": () => this.editor.commands.selectAll()
+    };
+    const pcKeymap = {
+      ...baseKeymap
+    };
+    const macKeymap = {
+      ...baseKeymap,
+      "Ctrl-h": handleBackspace2,
+      "Alt-Backspace": handleBackspace2,
+      "Ctrl-d": handleDelete2,
+      "Ctrl-Alt-Backspace": handleDelete2,
+      "Alt-Delete": handleDelete2,
+      "Alt-d": handleDelete2,
+      "Ctrl-a": () => this.editor.commands.selectTextblockStart(),
+      "Ctrl-e": () => this.editor.commands.selectTextblockEnd()
+    };
+    if (isiOS() || isMacOS()) {
+      return macKeymap;
+    }
+    return pcKeymap;
+  },
+  addProseMirrorPlugins() {
+    return [
+      // With this plugin we check if the whole document was selected and deleted.
+      // In this case we will additionally call `clearNodes()` to convert e.g. a heading
+      // to a paragraph if necessary.
+      // This is an alternative to ProseMirror's `AllSelection`, which doesn’t work well
+      // with many other commands.
+      new Plugin({
+        key: new PluginKey("clearDocument"),
+        appendTransaction: (transactions, oldState, newState) => {
+          if (transactions.some((tr2) => tr2.getMeta("composition"))) {
+            return;
+          }
+          const docChanges = transactions.some((transaction) => transaction.docChanged) && !oldState.doc.eq(newState.doc);
+          const ignoreTr = transactions.some(
+            (transaction) => transaction.getMeta("preventClearDocument")
+          );
+          if (!docChanges || ignoreTr) {
+            return;
+          }
+          const { empty, from, to } = oldState.selection;
+          const allFrom = Selection.atStart(oldState.doc).from;
+          const allEnd = Selection.atEnd(oldState.doc).to;
+          const allWasSelected = from === allFrom && to === allEnd;
+          if (empty || !allWasSelected) {
+            return;
+          }
+          const isEmpty = isNodeEmpty(newState.doc);
+          if (!isEmpty) {
+            return;
+          }
+          const tr = newState.tr;
+          const state = createChainableState({
+            state: newState,
+            transaction: tr
+          });
+          const { commands } = new CommandManager({
+            editor: this.editor,
+            state
+          });
+          commands.clearNodes();
+          if (!tr.steps.length) {
+            return;
+          }
+          return tr;
+        }
+      })
+    ];
+  }
+});
+var Paste = Extension.create({
+  name: "paste",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("tiptapPaste"),
+        props: {
+          handlePaste: (_view, e, slice) => {
+            this.editor.emit("paste", {
+              editor: this.editor,
+              event: e,
+              slice
+            });
+          }
+        }
+      })
+    ];
+  }
+});
+var Tabindex = Extension.create({
+  name: "tabindex",
+  addOptions() {
+    return {
+      value: void 0
+    };
+  },
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("tabindex"),
+        props: {
+          attributes: () => {
+            var _a;
+            if (!this.editor.isEditable && this.options.value === void 0) {
+              return {};
+            }
+            return { tabindex: (_a = this.options.value) != null ? _a : "0" };
+          }
+        }
+      })
+    ];
+  }
+});
+var TextDirection = Extension.create({
+  name: "textDirection",
+  addOptions() {
+    return {
+      direction: void 0
+    };
+  },
+  addGlobalAttributes() {
+    if (!this.options.direction) {
+      return [];
+    }
+    const { nodeExtensions } = splitExtensions(this.extensions);
+    return [
+      {
+        types: nodeExtensions.filter((extension) => extension.name !== "text").map((extension) => extension.name),
+        attributes: {
+          dir: {
+            default: this.options.direction,
+            parseHTML: (element) => {
+              const dir = element.getAttribute("dir");
+              if (dir && (dir === "ltr" || dir === "rtl" || dir === "auto")) {
+                return dir;
+              }
+              return this.options.direction;
+            },
+            renderHTML: (attributes) => {
+              if (!attributes.dir) {
+                return {};
+              }
+              return {
+                dir: attributes.dir
+              };
+            }
+          }
+        }
+      }
+    ];
+  },
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("textDirection"),
+        props: {
+          attributes: () => {
+            const direction = this.options.direction;
+            if (!direction) {
+              return {};
+            }
+            return {
+              dir: direction
+            };
+          }
+        }
+      })
+    ];
+  }
+});
+function markInputRule(config) {
+  return new InputRule({
+    find: config.find,
+    handler: ({ state, range, match }) => {
+      const attributes = callOrReturn(config.getAttributes, void 0, match);
+      if (attributes === false || attributes === null) {
+        return null;
+      }
+      const { tr } = state;
+      const captureGroup = match[match.length - 1];
+      const fullMatch = match[0];
+      if (captureGroup) {
+        const startSpaces = fullMatch.search(/\S/);
+        const textStart = range.from + fullMatch.indexOf(captureGroup);
+        const textEnd = textStart + captureGroup.length;
+        const excludedMarks = getMarksBetween(range.from, range.to, state.doc).filter((item) => {
+          const excluded = item.mark.type.excluded;
+          return excluded.find((type) => type === config.type && type !== item.mark.type);
+        }).filter((item) => item.to > textStart);
+        if (excludedMarks.length) {
+          return null;
+        }
+        if (textEnd < range.to) {
+          tr.delete(textEnd, range.to);
+        }
+        if (textStart > range.from) {
+          tr.delete(range.from + startSpaces, textStart);
+        }
+        const markEnd = range.from + startSpaces + captureGroup.length;
+        tr.addMark(range.from + startSpaces, markEnd, config.type.create(attributes || {}));
+        tr.removeStoredMark(config.type);
+      }
+    },
+    undoable: config.undoable
+  });
+}
+function nodeInputRule(config) {
+  return new InputRule({
+    find: config.find,
+    handler: ({ state, range, match }) => {
+      const attributes = callOrReturn(config.getAttributes, void 0, match) || {};
+      const { tr } = state;
+      const start = range.from;
+      let end = range.to;
+      const newNode = config.type.create(attributes);
+      if (match[1]) {
+        const offset = match[0].lastIndexOf(match[1]);
+        let matchStart = start + offset;
+        if (matchStart > end) {
+          matchStart = end;
+        } else {
+          end = matchStart + match[1].length;
+        }
+        const lastChar = match[0][match[0].length - 1];
+        tr.insertText(lastChar, start + match[0].length - 1);
+        tr.replaceWith(matchStart, end, newNode);
+      } else if (match[0]) {
+        const insertionStart = config.type.isInline ? start : start - 1;
+        tr.insert(insertionStart, config.type.create(attributes)).delete(
+          tr.mapping.map(start),
+          tr.mapping.map(end)
+        );
+      }
+      tr.scrollIntoView();
+    },
+    undoable: config.undoable
+  });
+}
+function textblockTypeInputRule(config) {
+  return new InputRule({
+    find: config.find,
+    handler: ({ state, range, match }) => {
+      const $start = state.doc.resolve(range.from);
+      const attributes = callOrReturn(config.getAttributes, void 0, match) || {};
+      if (!$start.node(-1).canReplaceWith($start.index(-1), $start.indexAfter(-1), config.type)) {
+        return null;
+      }
+      state.tr.delete(range.from, range.to).setBlockType(range.from, range.from, config.type, attributes);
+    },
+    undoable: config.undoable
+  });
+}
+function wrappingInputRule(config) {
+  return new InputRule({
+    find: config.find,
+    handler: ({ state, range, match, chain }) => {
+      const attributes = callOrReturn(config.getAttributes, void 0, match) || {};
+      const tr = state.tr.delete(range.from, range.to);
+      const $start = tr.doc.resolve(range.from);
+      const blockRange = $start.blockRange();
+      const wrapping = blockRange && findWrapping(blockRange, config.type, attributes);
+      if (!wrapping) {
+        return null;
+      }
+      tr.wrap(blockRange, wrapping);
+      if (config.keepMarks && config.editor) {
+        const { selection, storedMarks } = state;
+        const { splittableMarks } = config.editor.extensionManager;
+        const marks = storedMarks || selection.$to.parentOffset && selection.$from.marks();
+        if (marks) {
+          const filteredMarks = marks.filter((mark) => splittableMarks.includes(mark.type.name));
+          tr.ensureMarks(filteredMarks);
+        }
+      }
+      if (config.keepAttributes) {
+        const nodeType = config.type.name === "bulletList" || config.type.name === "orderedList" ? "listItem" : "taskList";
+        chain().updateAttributes(nodeType, attributes).run();
+      }
+      const before = tr.doc.resolve(range.from - 1).nodeBefore;
+      if (before && before.type === config.type && canJoin(tr.doc, range.from - 1) && (!config.joinPredicate || config.joinPredicate(match, before))) {
+        tr.join(range.from - 1);
+      }
+    },
+    undoable: config.undoable
+  });
+}
+var isTouchEvent = (e) => {
+  return "touches" in e;
+};
+var ResizableNodeView = class {
+  /**
+   * Creates a new ResizableNodeView instance.
+   *
+   * The constructor sets up the resize handles, applies initial sizing from
+   * node attributes, and configures all resize behavior options.
+   *
+   * @param options - Configuration options for the resizable node view
+   */
+  constructor(options) {
+    this.directions = [
+      "bottom-left",
+      "bottom-right",
+      "top-left",
+      "top-right"
+    ];
+    this.minSize = {
+      height: 8,
+      width: 8
+    };
+    this.preserveAspectRatio = false;
+    this.classNames = {
+      container: "",
+      wrapper: "",
+      handle: "",
+      resizing: ""
+    };
+    this.initialWidth = 0;
+    this.initialHeight = 0;
+    this.aspectRatio = 1;
+    this.isResizing = false;
+    this.activeHandle = null;
+    this.startX = 0;
+    this.startY = 0;
+    this.startWidth = 0;
+    this.startHeight = 0;
+    this.isShiftKeyPressed = false;
+    this.lastEditableState = void 0;
+    this.handleMap = /* @__PURE__ */ new Map();
+    this.handleMouseMove = (event) => {
+      if (!this.isResizing || !this.activeHandle) {
+        return;
+      }
+      const deltaX = event.clientX - this.startX;
+      const deltaY = event.clientY - this.startY;
+      this.handleResize(deltaX, deltaY);
+    };
+    this.handleTouchMove = (event) => {
+      if (!this.isResizing || !this.activeHandle) {
+        return;
+      }
+      const touch = event.touches[0];
+      if (!touch) {
+        return;
+      }
+      const deltaX = touch.clientX - this.startX;
+      const deltaY = touch.clientY - this.startY;
+      this.handleResize(deltaX, deltaY);
+    };
+    this.handleMouseUp = () => {
+      if (!this.isResizing) {
+        return;
+      }
+      const finalWidth = this.element.offsetWidth;
+      const finalHeight = this.element.offsetHeight;
+      this.onCommit(finalWidth, finalHeight);
+      this.isResizing = false;
+      this.activeHandle = null;
+      this.container.dataset.resizeState = "false";
+      if (this.classNames.resizing) {
+        this.container.classList.remove(this.classNames.resizing);
+      }
+      document.removeEventListener("mousemove", this.handleMouseMove);
+      document.removeEventListener("mouseup", this.handleMouseUp);
+      document.removeEventListener("keydown", this.handleKeyDown);
+      document.removeEventListener("keyup", this.handleKeyUp);
+    };
+    this.handleKeyDown = (event) => {
+      if (event.key === "Shift") {
+        this.isShiftKeyPressed = true;
+      }
+    };
+    this.handleKeyUp = (event) => {
+      if (event.key === "Shift") {
+        this.isShiftKeyPressed = false;
+      }
+    };
+    var _a, _b, _c, _d, _e, _f;
+    this.node = options.node;
+    this.editor = options.editor;
+    this.element = options.element;
+    this.element.draggable = false;
+    this.contentElement = options.contentElement;
+    this.getPos = options.getPos;
+    this.onResize = options.onResize;
+    this.onCommit = options.onCommit;
+    this.onUpdate = options.onUpdate;
+    if ((_a = options.options) == null ? void 0 : _a.min) {
+      this.minSize = {
+        ...this.minSize,
+        ...options.options.min
+      };
+    }
+    if ((_b = options.options) == null ? void 0 : _b.max) {
+      this.maxSize = options.options.max;
+    }
+    if ((_c = options == null ? void 0 : options.options) == null ? void 0 : _c.directions) {
+      this.directions = options.options.directions;
+    }
+    if ((_d = options.options) == null ? void 0 : _d.preserveAspectRatio) {
+      this.preserveAspectRatio = options.options.preserveAspectRatio;
+    }
+    if ((_e = options.options) == null ? void 0 : _e.className) {
+      this.classNames = {
+        container: options.options.className.container || "",
+        wrapper: options.options.className.wrapper || "",
+        handle: options.options.className.handle || "",
+        resizing: options.options.className.resizing || ""
+      };
+    }
+    if ((_f = options.options) == null ? void 0 : _f.createCustomHandle) {
+      this.createCustomHandle = options.options.createCustomHandle;
+    }
+    this.wrapper = this.createWrapper();
+    this.container = this.createContainer();
+    this.applyInitialSize();
+    this.attachHandles();
+    this.editor.on("update", this.handleEditorUpdate.bind(this));
+  }
+  /**
+   * Returns the top-level DOM node that should be placed in the editor.
+   *
+   * This is required by the ProseMirror NodeView interface. The container
+   * includes the wrapper, handles, and the actual content element.
+   *
+   * @returns The container element to be inserted into the editor
+   */
+  get dom() {
+    return this.container;
+  }
+  get contentDOM() {
+    var _a;
+    return (_a = this.contentElement) != null ? _a : null;
+  }
+  handleEditorUpdate() {
+    const isEditable = this.editor.isEditable;
+    if (isEditable === this.lastEditableState) {
+      return;
+    }
+    this.lastEditableState = isEditable;
+    if (!isEditable) {
+      this.removeHandles();
+    } else if (isEditable && this.handleMap.size === 0) {
+      this.attachHandles();
+    }
+  }
+  /**
+   * Called when the node's content or attributes change.
+   *
+   * Updates the internal node reference. If a custom `onUpdate` callback
+   * was provided, it will be called to handle additional update logic.
+   *
+   * @param node - The new/updated node
+   * @param decorations - Node decorations
+   * @param innerDecorations - Inner decorations
+   * @returns `false` if the node type has changed (requires full rebuild), otherwise the result of `onUpdate` or `true`
+   */
+  update(node, decorations, innerDecorations) {
+    if (node.type !== this.node.type) {
+      return false;
+    }
+    this.node = node;
+    if (this.onUpdate) {
+      return this.onUpdate(node, decorations, innerDecorations);
+    }
+    return true;
+  }
+  /**
+   * Cleanup method called when the node view is being removed.
+   *
+   * Removes all event listeners to prevent memory leaks. This is required
+   * by the ProseMirror NodeView interface. If a resize is active when
+   * destroy is called, it will be properly cancelled.
+   */
+  destroy() {
+    if (this.isResizing) {
+      this.container.dataset.resizeState = "false";
+      if (this.classNames.resizing) {
+        this.container.classList.remove(this.classNames.resizing);
+      }
+      document.removeEventListener("mousemove", this.handleMouseMove);
+      document.removeEventListener("mouseup", this.handleMouseUp);
+      document.removeEventListener("keydown", this.handleKeyDown);
+      document.removeEventListener("keyup", this.handleKeyUp);
+      this.isResizing = false;
+      this.activeHandle = null;
+    }
+    this.editor.off("update", this.handleEditorUpdate.bind(this));
+    this.container.remove();
+  }
+  /**
+   * Creates the outer container element.
+   *
+   * The container is the top-level element returned by the NodeView and
+   * wraps the entire resizable node. It's set up with flexbox to handle
+   * alignment and includes data attributes for styling and identification.
+   *
+   * @returns The container element
+   */
+  createContainer() {
+    const element = document.createElement("div");
+    element.dataset.resizeContainer = "";
+    element.dataset.node = this.node.type.name;
+    element.style.display = this.node.type.isInline ? "inline-flex" : "flex";
+    if (this.classNames.container) {
+      element.className = this.classNames.container;
+    }
+    element.appendChild(this.wrapper);
+    return element;
+  }
+  /**
+   * Creates the wrapper element that contains the content and handles.
+   *
+   * The wrapper uses relative positioning so that resize handles can be
+   * positioned absolutely within it. This is the direct parent of the
+   * content element being made resizable.
+   *
+   * @returns The wrapper element
+   */
+  createWrapper() {
+    const element = document.createElement("div");
+    element.style.position = "relative";
+    element.style.display = "block";
+    element.dataset.resizeWrapper = "";
+    if (this.classNames.wrapper) {
+      element.className = this.classNames.wrapper;
+    }
+    element.appendChild(this.element);
+    return element;
+  }
+  /**
+   * Creates a resize handle element for a specific direction.
+   *
+   * Each handle is absolutely positioned and includes a data attribute
+   * identifying its direction for styling purposes.
+   *
+   * @param direction - The resize direction for this handle
+   * @returns The handle element
+   */
+  createHandle(direction) {
+    const handle = document.createElement("div");
+    handle.dataset.resizeHandle = direction;
+    handle.style.position = "absolute";
+    if (this.classNames.handle) {
+      handle.className = this.classNames.handle;
+    }
+    return handle;
+  }
+  /**
+   * Positions a handle element according to its direction.
+   *
+   * Corner handles (e.g., 'top-left') are positioned at the intersection
+   * of two edges. Edge handles (e.g., 'top') span the full width or height.
+   *
+   * @param handle - The handle element to position
+   * @param direction - The direction determining the position
+   */
+  positionHandle(handle, direction) {
+    const isTop = direction.includes("top");
+    const isBottom = direction.includes("bottom");
+    const isLeft = direction.includes("left");
+    const isRight = direction.includes("right");
+    if (isTop) {
+      handle.style.top = "0";
+    }
+    if (isBottom) {
+      handle.style.bottom = "0";
+    }
+    if (isLeft) {
+      handle.style.left = "0";
+    }
+    if (isRight) {
+      handle.style.right = "0";
+    }
+    if (direction === "top" || direction === "bottom") {
+      handle.style.left = "0";
+      handle.style.right = "0";
+    }
+    if (direction === "left" || direction === "right") {
+      handle.style.top = "0";
+      handle.style.bottom = "0";
+    }
+  }
+  /**
+   * Creates and attaches all resize handles to the wrapper.
+   *
+   * Iterates through the configured directions, creates a handle for each,
+   * positions it, attaches the mousedown listener, and appends it to the DOM.
+   */
+  attachHandles() {
+    this.directions.forEach((direction) => {
+      let handle;
+      if (this.createCustomHandle) {
+        handle = this.createCustomHandle(direction);
+      } else {
+        handle = this.createHandle(direction);
+      }
+      if (!(handle instanceof HTMLElement)) {
+        console.warn(
+          `[ResizableNodeView] createCustomHandle("${direction}") did not return an HTMLElement. Falling back to default handle.`
+        );
+        handle = this.createHandle(direction);
+      }
+      if (!this.createCustomHandle) {
+        this.positionHandle(handle, direction);
+      }
+      handle.addEventListener("mousedown", (event) => this.handleResizeStart(event, direction));
+      handle.addEventListener(
+        "touchstart",
+        (event) => this.handleResizeStart(event, direction)
+      );
+      this.handleMap.set(direction, handle);
+      this.wrapper.appendChild(handle);
+    });
+  }
+  /**
+   * Removes all resize handles from the wrapper.
+   *
+   * Cleans up the handle map and removes each handle element from the DOM.
+   */
+  removeHandles() {
+    this.handleMap.forEach((el) => el.remove());
+    this.handleMap.clear();
+  }
+  /**
+   * Applies initial sizing from node attributes to the element.
+   *
+   * If width/height attributes exist on the node, they're applied to the element.
+   * Otherwise, the element's natural/current dimensions are measured. The aspect
+   * ratio is calculated for later use in aspect-ratio-preserving resizes.
+   */
+  applyInitialSize() {
+    const width = this.node.attrs.width;
+    const height = this.node.attrs.height;
+    if (width) {
+      this.element.style.width = `${width}px`;
+      this.initialWidth = width;
+    } else {
+      this.initialWidth = this.element.offsetWidth;
+    }
+    if (height) {
+      this.element.style.height = `${height}px`;
+      this.initialHeight = height;
+    } else {
+      this.initialHeight = this.element.offsetHeight;
+    }
+    if (this.initialWidth > 0 && this.initialHeight > 0) {
+      this.aspectRatio = this.initialWidth / this.initialHeight;
+    }
+  }
+  /**
+   * Initiates a resize operation when a handle is clicked.
+   *
+   * Captures the starting mouse position and element dimensions, sets up
+   * the resize state, adds the resizing class and state attribute, and
+   * attaches document-level listeners for mouse movement and keyboard input.
+   *
+   * @param event - The mouse down event
+   * @param direction - The direction of the handle being dragged
+   */
+  handleResizeStart(event, direction) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isResizing = true;
+    this.activeHandle = direction;
+    if (isTouchEvent(event)) {
+      this.startX = event.touches[0].clientX;
+      this.startY = event.touches[0].clientY;
+    } else {
+      this.startX = event.clientX;
+      this.startY = event.clientY;
+    }
+    this.startWidth = this.element.offsetWidth;
+    this.startHeight = this.element.offsetHeight;
+    if (this.startWidth > 0 && this.startHeight > 0) {
+      this.aspectRatio = this.startWidth / this.startHeight;
+    }
+    this.getPos();
+    this.container.dataset.resizeState = "true";
+    if (this.classNames.resizing) {
+      this.container.classList.add(this.classNames.resizing);
+    }
+    document.addEventListener("mousemove", this.handleMouseMove);
+    document.addEventListener("touchmove", this.handleTouchMove);
+    document.addEventListener("mouseup", this.handleMouseUp);
+    document.addEventListener("keydown", this.handleKeyDown);
+    document.addEventListener("keyup", this.handleKeyUp);
+  }
+  handleResize(deltaX, deltaY) {
+    if (!this.activeHandle) {
+      return;
+    }
+    const shouldPreserveAspectRatio = this.preserveAspectRatio || this.isShiftKeyPressed;
+    const { width, height } = this.calculateNewDimensions(this.activeHandle, deltaX, deltaY);
+    const constrained = this.applyConstraints(width, height, shouldPreserveAspectRatio);
+    this.element.style.width = `${constrained.width}px`;
+    this.element.style.height = `${constrained.height}px`;
+    if (this.onResize) {
+      this.onResize(constrained.width, constrained.height);
+    }
+  }
+  /**
+   * Calculates new dimensions based on mouse delta and resize direction.
+   *
+   * Takes the starting dimensions and applies the mouse movement delta
+   * according to the handle direction. For corner handles, both dimensions
+   * are affected. For edge handles, only one dimension changes. If aspect
+   * ratio should be preserved, delegates to applyAspectRatio.
+   *
+   * @param direction - The active resize handle direction
+   * @param deltaX - Horizontal mouse movement since resize start
+   * @param deltaY - Vertical mouse movement since resize start
+   * @returns The calculated width and height
+   */
+  calculateNewDimensions(direction, deltaX, deltaY) {
+    let newWidth = this.startWidth;
+    let newHeight = this.startHeight;
+    const isRight = direction.includes("right");
+    const isLeft = direction.includes("left");
+    const isBottom = direction.includes("bottom");
+    const isTop = direction.includes("top");
+    if (isRight) {
+      newWidth = this.startWidth + deltaX;
+    } else if (isLeft) {
+      newWidth = this.startWidth - deltaX;
+    }
+    if (isBottom) {
+      newHeight = this.startHeight + deltaY;
+    } else if (isTop) {
+      newHeight = this.startHeight - deltaY;
+    }
+    if (direction === "right" || direction === "left") {
+      newWidth = this.startWidth + (isRight ? deltaX : -deltaX);
+    }
+    if (direction === "top" || direction === "bottom") {
+      newHeight = this.startHeight + (isBottom ? deltaY : -deltaY);
+    }
+    const shouldPreserveAspectRatio = this.preserveAspectRatio || this.isShiftKeyPressed;
+    if (shouldPreserveAspectRatio) {
+      return this.applyAspectRatio(newWidth, newHeight, direction);
+    }
+    return { width: newWidth, height: newHeight };
+  }
+  /**
+   * Applies min/max constraints to dimensions.
+   *
+   * When aspect ratio is NOT preserved, constraints are applied independently
+   * to width and height. When aspect ratio IS preserved, constraints are
+   * applied while maintaining the aspect ratio—if one dimension hits a limit,
+   * the other is recalculated proportionally.
+   *
+   * This ensures that aspect ratio is never broken when constrained.
+   *
+   * @param width - The unconstrained width
+   * @param height - The unconstrained height
+   * @param preserveAspectRatio - Whether to maintain aspect ratio while constraining
+   * @returns The constrained dimensions
+   */
+  applyConstraints(width, height, preserveAspectRatio) {
+    var _a, _b, _c, _d;
+    if (!preserveAspectRatio) {
+      let constrainedWidth2 = Math.max(this.minSize.width, width);
+      let constrainedHeight2 = Math.max(this.minSize.height, height);
+      if ((_a = this.maxSize) == null ? void 0 : _a.width) {
+        constrainedWidth2 = Math.min(this.maxSize.width, constrainedWidth2);
+      }
+      if ((_b = this.maxSize) == null ? void 0 : _b.height) {
+        constrainedHeight2 = Math.min(this.maxSize.height, constrainedHeight2);
+      }
+      return { width: constrainedWidth2, height: constrainedHeight2 };
+    }
+    let constrainedWidth = width;
+    let constrainedHeight = height;
+    if (constrainedWidth < this.minSize.width) {
+      constrainedWidth = this.minSize.width;
+      constrainedHeight = constrainedWidth / this.aspectRatio;
+    }
+    if (constrainedHeight < this.minSize.height) {
+      constrainedHeight = this.minSize.height;
+      constrainedWidth = constrainedHeight * this.aspectRatio;
+    }
+    if (((_c = this.maxSize) == null ? void 0 : _c.width) && constrainedWidth > this.maxSize.width) {
+      constrainedWidth = this.maxSize.width;
+      constrainedHeight = constrainedWidth / this.aspectRatio;
+    }
+    if (((_d = this.maxSize) == null ? void 0 : _d.height) && constrainedHeight > this.maxSize.height) {
+      constrainedHeight = this.maxSize.height;
+      constrainedWidth = constrainedHeight * this.aspectRatio;
+    }
+    return { width: constrainedWidth, height: constrainedHeight };
+  }
+  /**
+   * Adjusts dimensions to maintain the original aspect ratio.
+   *
+   * For horizontal handles (left/right), uses width as the primary dimension
+   * and calculates height from it. For vertical handles (top/bottom), uses
+   * height as primary and calculates width. For corner handles, uses width
+   * as the primary dimension.
+   *
+   * @param width - The new width
+   * @param height - The new height
+   * @param direction - The active resize direction
+   * @returns Dimensions adjusted to preserve aspect ratio
+   */
+  applyAspectRatio(width, height, direction) {
+    const isHorizontal = direction === "left" || direction === "right";
+    const isVertical = direction === "top" || direction === "bottom";
+    if (isHorizontal) {
+      return {
+        width,
+        height: width / this.aspectRatio
+      };
+    }
+    if (isVertical) {
+      return {
+        width: height * this.aspectRatio,
+        height
+      };
+    }
+    return {
+      width,
+      height: width / this.aspectRatio
+    };
+  }
+};
+var Node3 = class _Node extends Extendable {
+  constructor() {
+    super(...arguments);
+    this.type = "node";
+  }
+  /**
+   * Create a new Node instance
+   * @param config - Node configuration object or a function that returns a configuration object
+   */
+  static create(config = {}) {
+    const resolvedConfig = typeof config === "function" ? config() : config;
+    return new _Node(resolvedConfig);
+  }
+  configure(options) {
+    return super.configure(options);
+  }
+  extend(extendedConfig) {
+    const resolvedConfig = typeof extendedConfig === "function" ? extendedConfig() : extendedConfig;
+    return super.extend(resolvedConfig);
+  }
+};
+function markPasteRule(config) {
+  return new PasteRule({
+    find: config.find,
+    handler: ({ state, range, match, pasteEvent }) => {
+      const attributes = callOrReturn(config.getAttributes, void 0, match, pasteEvent);
+      if (attributes === false || attributes === null) {
+        return null;
+      }
+      const { tr } = state;
+      const captureGroup = match[match.length - 1];
+      const fullMatch = match[0];
+      let markEnd = range.to;
+      if (captureGroup) {
+        const startSpaces = fullMatch.search(/\S/);
+        const textStart = range.from + fullMatch.indexOf(captureGroup);
+        const textEnd = textStart + captureGroup.length;
+        const excludedMarks = getMarksBetween(range.from, range.to, state.doc).filter((item) => {
+          const excluded = item.mark.type.excluded;
+          return excluded.find((type) => type === config.type && type !== item.mark.type);
+        }).filter((item) => item.to > textStart);
+        if (excludedMarks.length) {
+          return null;
+        }
+        if (textEnd < range.to) {
+          tr.delete(textEnd, range.to);
+        }
+        if (textStart > range.from) {
+          tr.delete(range.from + startSpaces, textStart);
+        }
+        markEnd = range.from + startSpaces + captureGroup.length;
+        tr.addMark(range.from + startSpaces, markEnd, config.type.create(attributes || {}));
+        const isMatchAtEndOfText = match.index !== void 0 && match.input !== void 0 && match.index + match[0].length >= match.input.length;
+        if (!isMatchAtEndOfText) {
+          tr.removeStoredMark(config.type);
+        }
+      }
+    }
+  });
+}
+var Document = Node3.create({
+  name: "doc",
+  topNode: true,
+  content: "block+",
+  renderMarkdown: (node, h2) => {
+    if (!node.content) {
+      return "";
+    }
+    return h2.renderChildren(node.content, "\n\n");
+  }
+});
+var index_default$g = Document;
+var EMPTY_PARAGRAPH_MARKDOWN = "&nbsp;";
+var NBSP_CHAR = " ";
+var Paragraph = Node3.create({
+  name: "paragraph",
+  priority: 1e3,
+  addOptions() {
+    return {
+      HTMLAttributes: {}
+    };
+  },
+  group: "block",
+  content: "inline*",
+  parseHTML() {
+    return [{ tag: "p" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["p", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+  parseMarkdown: (token, helpers) => {
+    const tokens = token.tokens || [];
+    if (tokens.length === 1 && tokens[0].type === "image") {
+      return helpers.parseChildren([tokens[0]]);
+    }
+    const content = helpers.parseInline(tokens);
+    const hasExplicitEmptyParagraphMarker = tokens.length === 1 && tokens[0].type === "text" && (tokens[0].raw === EMPTY_PARAGRAPH_MARKDOWN || tokens[0].text === EMPTY_PARAGRAPH_MARKDOWN || tokens[0].raw === NBSP_CHAR || tokens[0].text === NBSP_CHAR);
+    if (hasExplicitEmptyParagraphMarker && content.length === 1 && content[0].type === "text" && (content[0].text === EMPTY_PARAGRAPH_MARKDOWN || content[0].text === NBSP_CHAR)) {
+      return helpers.createNode("paragraph", void 0, []);
+    }
+    return helpers.createNode("paragraph", void 0, content);
+  },
+  renderMarkdown: (node, h2, ctx) => {
+    var _a, _b;
+    if (!node) {
+      return "";
+    }
+    const content = Array.isArray(node.content) ? node.content : [];
+    if (content.length === 0) {
+      const previousContent = Array.isArray((_a = ctx == null ? void 0 : ctx.previousNode) == null ? void 0 : _a.content) ? ctx.previousNode.content : [];
+      const previousNodeIsEmptyParagraph = ((_b = ctx == null ? void 0 : ctx.previousNode) == null ? void 0 : _b.type) === "paragraph" && previousContent.length === 0;
+      return previousNodeIsEmptyParagraph ? EMPTY_PARAGRAPH_MARKDOWN : "";
+    }
+    return h2.renderChildren(content);
+  },
+  addCommands() {
+    return {
+      setParagraph: () => ({ commands }) => {
+        return commands.setNode(this.name);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Alt-0": () => this.editor.commands.setParagraph()
+    };
+  }
+});
+var index_default$f = Paragraph;
+var Text = Node3.create({
+  name: "text",
+  group: "inline",
+  parseMarkdown: (token) => {
+    return {
+      type: "text",
+      text: token.text || ""
+    };
+  },
+  renderMarkdown: (node) => node.text || ""
+});
+var index_default$e = Text;
+var HardBreak = Node3.create({
+  name: "hardBreak",
+  markdownTokenName: "br",
+  addOptions() {
+    return {
+      keepMarks: true,
+      HTMLAttributes: {}
+    };
+  },
+  inline: true,
+  group: "inline",
+  selectable: false,
+  linebreakReplacement: true,
+  parseHTML() {
+    return [{ tag: "br" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["br", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+  },
+  renderText() {
+    return "\n";
+  },
+  renderMarkdown: () => `  
+`,
+  parseMarkdown: () => {
+    return {
+      type: "hardBreak"
+    };
+  },
+  addCommands() {
+    return {
+      setHardBreak: () => ({ commands, chain, state, editor }) => {
+        return commands.first([
+          () => commands.exitCode(),
+          () => commands.command(() => {
+            const { selection, storedMarks } = state;
+            if (selection.$from.parent.type.spec.isolating) {
+              return false;
+            }
+            const { keepMarks } = this.options;
+            const { splittableMarks } = editor.extensionManager;
+            const marks = storedMarks || selection.$to.parentOffset && selection.$from.marks();
+            return chain().insertContent({ type: this.name }).command(({ tr, dispatch }) => {
+              if (dispatch && marks && keepMarks) {
+                const filteredMarks = marks.filter(
+                  (mark) => splittableMarks.includes(mark.type.name)
+                );
+                tr.ensureMarks(filteredMarks);
+              }
+              return true;
+            }).run();
+          })
+        ]);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Enter": () => this.editor.commands.setHardBreak(),
+      "Shift-Enter": () => this.editor.commands.setHardBreak()
+    };
+  }
+});
+var index_default$d = HardBreak;
+var Heading = Node3.create({
+  name: "heading",
+  addOptions() {
+    return {
+      levels: [1, 2, 3, 4, 5, 6],
+      HTMLAttributes: {}
+    };
+  },
+  content: "inline*",
+  group: "block",
+  defining: true,
+  addAttributes() {
+    return {
+      level: {
+        default: 1,
+        rendered: false
+      }
+    };
+  },
+  parseHTML() {
+    return this.options.levels.map((level) => ({
+      tag: `h${level}`,
+      attrs: { level }
+    }));
+  },
+  renderHTML({ node, HTMLAttributes }) {
+    const hasLevel = this.options.levels.includes(node.attrs.level);
+    const level = hasLevel ? node.attrs.level : this.options.levels[0];
+    return [`h${level}`, mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+  parseMarkdown: (token, helpers) => {
+    return helpers.createNode(
+      "heading",
+      { level: token.depth || 1 },
+      helpers.parseInline(token.tokens || [])
+    );
+  },
+  renderMarkdown: (node, h2) => {
+    var _a;
+    const level = ((_a = node.attrs) == null ? void 0 : _a.level) ? parseInt(node.attrs.level, 10) : 1;
+    const headingChars = "#".repeat(level);
+    if (!node.content) {
+      return "";
+    }
+    return `${headingChars} ${h2.renderChildren(node.content)}`;
+  },
+  addCommands() {
+    return {
+      setHeading: (attributes) => ({ commands }) => {
+        if (!this.options.levels.includes(attributes.level)) {
+          return false;
+        }
+        return commands.setNode(this.name, attributes);
+      },
+      toggleHeading: (attributes) => ({ commands }) => {
+        if (!this.options.levels.includes(attributes.level)) {
+          return false;
+        }
+        return commands.toggleNode(this.name, "paragraph", attributes);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return this.options.levels.reduce(
+      (items, level) => ({
+        ...items,
+        [`Mod-Alt-${level}`]: () => this.editor.commands.toggleHeading({ level })
+      }),
+      {}
+    );
+  },
+  addInputRules() {
+    return this.options.levels.map((level) => {
+      return textblockTypeInputRule({
+        find: new RegExp(`^(#{${Math.min(...this.options.levels)},${level}})\\s$`),
+        type: this.type,
+        getAttributes: {
+          level
+        }
+      });
+    });
+  }
+});
+var index_default$c = Heading;
+var h = (tag, attributes) => {
+  if (tag === "slot") {
+    return 0;
+  }
+  if (tag instanceof Function) {
+    return tag(attributes);
+  }
+  const { children, ...rest } = attributes != null ? attributes : {};
+  if (tag === "svg") {
+    throw new Error(
+      "SVG elements are not supported in the JSX syntax, use the array syntax instead"
+    );
+  }
+  return [tag, rest, children];
+};
+var handleBackspace$1 = (editor, type) => {
+  var _a;
+  const { state, view } = editor;
+  const { selection } = state;
+  if (!selection.empty) return false;
+  const { $from } = selection;
+  if ($from.parentOffset !== 0) return false;
+  const parentDepth = $from.depth - 1;
+  if (parentDepth < 0) return false;
+  const parent = $from.node(parentDepth);
+  const index = $from.index(parentDepth);
+  if (index === 0) return false;
+  if (parent.type === type) {
+    return editor.commands.lift(type.name);
+  }
+  const previous = parent.child(index - 1);
+  if (previous.type !== type || !((_a = previous.lastChild) == null ? void 0 : _a.isTextblock)) {
+    return false;
+  }
+  const blockStart = $from.before();
+  const insideBlockquoteEnd = blockStart - 1;
+  const targetPos = insideBlockquoteEnd - 1;
+  const { tr } = state;
+  tr.delete(blockStart, $from.after()).insert(targetPos, $from.parent.content);
+  tr.setSelection(TextSelection.create(tr.doc, targetPos));
+  view.dispatch(tr.scrollIntoView());
+  return true;
+};
+var inputRegex$4 = /^\s*>\s$/;
+var Blockquote = Node3.create({
+  name: "blockquote",
+  addOptions() {
+    return {
+      HTMLAttributes: {}
+    };
+  },
+  content: "block+",
+  group: "block",
+  defining: true,
+  parseHTML() {
+    return [{ tag: "blockquote" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return /* @__PURE__ */ h("blockquote", { ...mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), children: /* @__PURE__ */ h("slot", {}) });
+  },
+  parseMarkdown: (token, helpers) => {
+    var _a;
+    const parseBlockChildren = (_a = helpers.parseBlockChildren) != null ? _a : helpers.parseChildren;
+    return helpers.createNode("blockquote", void 0, parseBlockChildren(token.tokens || []));
+  },
+  renderMarkdown: (node, h2) => {
+    if (!node.content) {
+      return "";
+    }
+    const prefix = ">";
+    const result = [];
+    node.content.forEach((child, index) => {
+      var _a, _b;
+      const childContent = (_b = (_a = h2.renderChild) == null ? void 0 : _a.call(h2, child, index)) != null ? _b : h2.renderChildren([child]);
+      const lines = childContent.split("\n");
+      const linesWithPrefix = lines.map((line) => {
+        if (line.trim() === "") {
+          return prefix;
+        }
+        return `${prefix} ${line}`;
+      });
+      result.push(linesWithPrefix.join("\n"));
+    });
+    return result.join(`
+${prefix}
+`);
+  },
+  addCommands() {
+    return {
+      setBlockquote: () => ({ commands }) => {
+        return commands.wrapIn(this.name);
+      },
+      toggleBlockquote: () => ({ commands }) => {
+        return commands.toggleWrap(this.name);
+      },
+      unsetBlockquote: () => ({ commands }) => {
+        return commands.lift(this.name);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-b": () => this.editor.commands.toggleBlockquote(),
+      Backspace: () => handleBackspace$1(this.editor, this.type)
+    };
+  },
+  addInputRules() {
+    return [
+      wrappingInputRule({
+        find: inputRegex$4,
+        type: this.type
+      })
+    ];
+  }
+});
+var index_default$b = Blockquote;
+var __defProp = Object.defineProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var ListItemName = "listItem";
+var TextStyleName = "textStyle";
+var bulletListInputRegex = /^\s*([-+*])\s$/;
+var BulletList = Node3.create({
+  name: "bulletList",
+  addOptions() {
+    return {
+      itemTypeName: "listItem",
+      HTMLAttributes: {},
+      keepMarks: false,
+      keepAttributes: false
+    };
+  },
+  group: "block list",
+  content() {
+    return `${this.options.itemTypeName}+`;
+  },
+  parseHTML() {
+    return [{ tag: "ul" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["ul", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+  markdownTokenName: "list",
+  parseMarkdown: (token, helpers) => {
+    if (token.type !== "list" || token.ordered) {
+      return [];
+    }
+    return {
+      type: "bulletList",
+      content: token.items ? helpers.parseChildren(token.items) : []
+    };
+  },
+  renderMarkdown: (node, h2) => {
+    if (!node.content) {
+      return "";
+    }
+    return h2.renderChildren(node.content, "\n");
+  },
+  markdownOptions: {
+    indentsContent: true
+  },
+  addCommands() {
+    return {
+      toggleBulletList: () => ({ commands, chain }) => {
+        if (this.options.keepAttributes) {
+          return chain().toggleList(this.name, this.options.itemTypeName, this.options.keepMarks).updateAttributes(ListItemName, this.editor.getAttributes(TextStyleName)).run();
+        }
+        return commands.toggleList(this.name, this.options.itemTypeName, this.options.keepMarks);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-8": () => this.editor.commands.toggleBulletList()
+    };
+  },
+  addInputRules() {
+    let inputRule = wrappingInputRule({
+      find: bulletListInputRegex,
+      type: this.type
+    });
+    if (this.options.keepMarks || this.options.keepAttributes) {
+      inputRule = wrappingInputRule({
+        find: bulletListInputRegex,
+        type: this.type,
+        keepMarks: this.options.keepMarks,
+        keepAttributes: this.options.keepAttributes,
+        getAttributes: () => {
+          return this.editor.getAttributes(TextStyleName);
+        },
+        editor: this.editor
+      });
+    }
+    return [inputRule];
+  }
+});
+var getBranchingNestedListAtCursor = (state, itemName, wrapperNames) => {
+  const { selection } = state;
+  if (!selection.empty) {
+    return null;
+  }
+  const { $from } = selection;
+  if (!$from.parent.isTextblock) {
+    return null;
+  }
+  if ($from.parentOffset !== $from.parent.content.size) {
+    return null;
+  }
+  let listItemDepth = -1;
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    if ($from.node(depth).type.name === itemName) {
+      listItemDepth = depth;
+      break;
+    }
+  }
+  if (listItemDepth < 0) {
+    return null;
+  }
+  const listItem = $from.node(listItemDepth);
+  const indexInListItem = $from.index(listItemDepth);
+  if (indexInListItem + 1 >= listItem.childCount) {
+    return null;
+  }
+  const nextChild = listItem.child(indexInListItem + 1);
+  if (!wrapperNames.includes(nextChild.type.name)) {
+    return null;
+  }
+  const itemType = state.schema.nodes[itemName];
+  let hasBranching = false;
+  nextChild.forEach((child) => {
+    if (child.type === itemType && child.childCount > 1) {
+      hasBranching = true;
+    }
+  });
+  if (!hasBranching) {
+    return null;
+  }
+  const nodeAfter = state.doc.resolve($from.after()).nodeAfter;
+  if (!nodeAfter || !wrapperNames.includes(nodeAfter.type.name)) {
+    return null;
+  }
+  const items = [];
+  nodeAfter.forEach((child) => {
+    items.push(child);
+  });
+  if (items.length === 0) {
+    return null;
+  }
+  return {
+    listItemDepth,
+    nestedList: nodeAfter,
+    nestedListPos: $from.after(),
+    insertPos: $from.after(listItemDepth),
+    items
+  };
+};
+var hoistBranchingNestedList = (state, dispatch, itemName, wrapperNames) => {
+  const context = getBranchingNestedListAtCursor(state, itemName, wrapperNames);
+  if (!context) {
+    return false;
+  }
+  const { selection } = state;
+  const { nestedList, nestedListPos, insertPos, items } = context;
+  const tr = state.tr;
+  tr.delete(nestedListPos, nestedListPos + nestedList.nodeSize);
+  const mappedInsertPos = tr.mapping.map(insertPos);
+  tr.insert(mappedInsertPos, Fragment.from(items));
+  tr.setSelection(selection.map(tr.doc, tr.mapping));
+  if (dispatch) {
+    dispatch(tr);
+  }
+  return true;
+};
+var handleDeleteBranchingNestedList = (editor, itemName, wrapperNames) => {
+  return hoistBranchingNestedList(editor.state, editor.view.dispatch, itemName, wrapperNames);
+};
+var createBranchingListDeleteKeymap = (itemName, wrapperNames) => {
+  return Extension.create({
+    name: `${itemName}BranchingDeleteKeymap`,
+    priority: 101,
+    addKeyboardShortcuts() {
+      const handleDelete2 = () => handleDeleteBranchingNestedList(this.editor, itemName, wrapperNames);
+      return {
+        Delete: handleDelete2,
+        "Mod-Delete": handleDelete2
+      };
+    }
+  });
+};
+var ROMAN_NUMERALS = [
+  [1e3, "m"],
+  [900, "cm"],
+  [500, "d"],
+  [400, "cd"],
+  [100, "c"],
+  [90, "xc"],
+  [50, "l"],
+  [40, "xl"],
+  [10, "x"],
+  [9, "ix"],
+  [5, "v"],
+  [4, "iv"],
+  [1, "i"]
+];
+var ALPHA_NUMERALS = "abcdefghijklmnopqrstuvwxyz";
+var ORDERED_LIST_ALPHA_MARKER_PATTERN = "[a-zA-Z]{1,2}";
+var ORDERED_LIST_MARKER_PATTERN = String.raw`\d+|[ivxlcdmIVXLCDM]+|${ORDERED_LIST_ALPHA_MARKER_PATTERN}`;
+function toRoman(num) {
+  let remaining = num;
+  let result = "";
+  for (const [value, numeral] of ROMAN_NUMERALS) {
+    while (remaining >= value) {
+      result += numeral;
+      remaining -= value;
+    }
+  }
+  return result;
+}
+function toRomanUpper(num) {
+  return toRoman(num).toUpperCase();
+}
+function fromRoman(roman) {
+  const lower = roman.toLowerCase();
+  let index = 0;
+  let result = 0;
+  while (index < lower.length) {
+    let matched = false;
+    for (const [value, numeral] of ROMAN_NUMERALS) {
+      if (lower.startsWith(numeral, index)) {
+        result += value;
+        index += numeral.length;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      return 0;
+    }
+  }
+  return result;
+}
+function isValidRoman(marker) {
+  if (!/^[ivxlcdmIVXLCDM]+$/.test(marker)) {
+    return false;
+  }
+  const value = fromRoman(marker);
+  if (value <= 0) {
+    return false;
+  }
+  const expected = marker === marker.toLowerCase() ? toRoman(value) : toRomanUpper(value);
+  return expected === marker;
+}
+function fromAlpha(marker) {
+  const lower = marker.toLowerCase();
+  if (lower.length === 1) {
+    return lower.charCodeAt(0) - "a".charCodeAt(0) + 1;
+  }
+  if (lower.length === 2) {
+    const first2 = lower.charCodeAt(0) - "a".charCodeAt(0);
+    const second = lower.charCodeAt(1) - "a".charCodeAt(0);
+    return (first2 + 1) * 26 + second + 1;
+  }
+  return 0;
+}
+function toRomanAlpha(num) {
+  if (num <= 26) {
+    return ALPHA_NUMERALS[num - 1];
+  }
+  const first2 = Math.floor((num - 1) / 26) - 1;
+  const second = (num - 1) % 26;
+  if (first2 < 0) {
+    return ALPHA_NUMERALS[second];
+  }
+  return ALPHA_NUMERALS[first2] + ALPHA_NUMERALS[second];
+}
+function detectMarkerType(marker) {
+  if (!marker || /^\d+$/.test(marker)) {
+    return void 0;
+  }
+  if (isValidRoman(marker)) {
+    return marker === marker.toLowerCase() ? "i" : "I";
+  }
+  if (/^[a-z]{1,2}$/.test(marker)) {
+    return "a";
+  }
+  if (/^[A-Z]{1,2}$/.test(marker)) {
+    return "A";
+  }
+  return void 0;
+}
+function markerToStart(marker) {
+  if (/^\d+$/.test(marker)) {
+    return parseInt(marker, 10);
+  }
+  const type = detectMarkerType(marker);
+  if (type === "i" || type === "I") {
+    return fromRoman(marker);
+  }
+  if (type === "a" || type === "A") {
+    const start = fromAlpha(marker);
+    return start > 0 ? start : 1;
+  }
+  const parsed = parseInt(marker, 10);
+  return Number.isNaN(parsed) ? 1 : parsed;
+}
+function startToMarker(type, start) {
+  if (type === "numeric") {
+    return String(start);
+  }
+  switch (type) {
+    case "a":
+      return toRomanAlpha(start);
+    case "A":
+      return toRomanAlpha(start).toUpperCase();
+    case "i":
+      return toRoman(start);
+    case "I":
+      return toRomanUpper(start);
+    default:
+      return String(start);
+  }
+}
+function areOrderedListMarkersSequential(markers) {
+  var _a;
+  if (markers.length === 0) {
+    return false;
+  }
+  const firstType = (_a = detectMarkerType(markers[0])) != null ? _a : "numeric";
+  const firstStart = markerToStart(markers[0]);
+  if (firstStart < 1) {
+    return false;
+  }
+  for (let i = 0; i < markers.length; i++) {
+    const expected = startToMarker(firstType, firstStart + i);
+    if (markers[i] !== expected) {
+      return false;
+    }
+  }
+  return true;
+}
+function parseListMarker(marker) {
+  return {
+    type: detectMarkerType(marker),
+    start: markerToStart(marker)
+  };
+}
+function buildOrderedListAttrsFromMarker(marker) {
+  const { type, start } = parseListMarker(marker);
+  const attrs = {};
+  if (type) {
+    attrs.type = type;
+  }
+  if (start !== 1) {
+    attrs.start = start;
+  }
+  return attrs;
+}
+function getListMarker(type, index, separator = ". ") {
+  const position = index + 1;
+  if (!type || type === "1") {
+    return `${position}${separator}`;
+  }
+  switch (type) {
+    case "a":
+      return `${toRomanAlpha(position)}${separator}`;
+    case "A":
+      return `${toRomanAlpha(position).toUpperCase()}${separator}`;
+    case "i":
+      return `${toRoman(position)}${separator}`;
+    case "I":
+      return `${toRomanUpper(position)}${separator}`;
+    default:
+      return `${position}${separator}`;
+  }
+}
+function isSameLineOrderedListToken(token) {
+  var _a, _b;
+  const nestedToken = (_a = token.tokens) == null ? void 0 : _a[0];
+  return Boolean(
+    token.text && ((_b = token.tokens) == null ? void 0 : _b.length) === 1 && (nestedToken == null ? void 0 : nestedToken.type) === "list" && nestedToken.ordered && nestedToken.raw === token.text
+  );
+}
+function parseSameLineOrderedListText(text, helpers) {
+  if (helpers.tokenizeInline) {
+    return helpers.parseInline(helpers.tokenizeInline(text));
+  }
+  return helpers.parseInline([
+    {
+      type: "text",
+      raw: text,
+      text
+    }
+  ]);
+}
+var ListItem = Node3.create({
+  name: "listItem",
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+      bulletListTypeName: "bulletList",
+      orderedListTypeName: "orderedList"
+    };
+  },
+  content: "paragraph block*",
+  defining: true,
+  parseHTML() {
+    return [
+      {
+        tag: "li"
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["li", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+  markdownTokenName: "list_item",
+  parseMarkdown: (token, helpers) => {
+    var _a;
+    if (token.type !== "list_item") {
+      return [];
+    }
+    const parseBlockChildren = (_a = helpers.parseBlockChildren) != null ? _a : helpers.parseChildren;
+    let content = [];
+    if (token.tokens && token.tokens.length > 0) {
+      if (isSameLineOrderedListToken(token)) {
+        return {
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: parseSameLineOrderedListText(token.text || "", helpers)
+            }
+          ]
+        };
+      }
+      const hasParagraphTokens = token.tokens.some((t) => t.type === "paragraph");
+      if (hasParagraphTokens) {
+        content = parseBlockChildren(token.tokens);
+      } else {
+        const firstToken = token.tokens[0];
+        if (firstToken && firstToken.type === "text" && firstToken.tokens && firstToken.tokens.length > 0) {
+          const inlineContent = helpers.parseInline(firstToken.tokens);
+          content = [
+            {
+              type: "paragraph",
+              content: inlineContent
+            }
+          ];
+          if (token.tokens.length > 1) {
+            const remainingTokens = token.tokens.slice(1);
+            const additionalContent = parseBlockChildren(remainingTokens);
+            content.push(...additionalContent);
+          }
+        } else {
+          content = parseBlockChildren(token.tokens);
+        }
+      }
+    }
+    if (content.length === 0) {
+      content = [
+        {
+          type: "paragraph",
+          content: []
+        }
+      ];
+    }
+    return {
+      type: "listItem",
+      content
+    };
+  },
+  renderMarkdown: (node, h2, ctx) => {
+    return renderNestedMarkdownContent(
+      node,
+      h2,
+      (context) => {
+        var _a, _b, _c, _d;
+        if (context.parentType === "bulletList") {
+          return "- ";
+        }
+        if (context.parentType === "orderedList") {
+          const start = ((_b = (_a = context.meta) == null ? void 0 : _a.parentAttrs) == null ? void 0 : _b.start) || 1;
+          const type = (_d = (_c = context.meta) == null ? void 0 : _c.parentAttrs) == null ? void 0 : _d.type;
+          const index = start - 1 + (context.index || 0);
+          return getListMarker(type, index, ". ");
+        }
+        return "- ";
+      },
+      ctx
+    );
+  },
+  addExtensions() {
+    return [
+      createBranchingListDeleteKeymap(this.name, [
+        this.options.bulletListTypeName,
+        this.options.orderedListTypeName
+      ])
+    ];
+  },
+  addKeyboardShortcuts() {
+    return {
+      Enter: () => this.editor.commands.splitListItem(this.name),
+      Tab: () => this.editor.commands.sinkListItem(this.name),
+      "Shift-Tab": () => this.editor.commands.liftListItem(this.name)
+    };
+  }
+});
+var listHelpers_exports = {};
+__export(listHelpers_exports, {
+  findListItemPos: () => findListItemPos,
+  getNextListDepth: () => getNextListDepth,
+  handleBackspace: () => handleBackspace,
+  handleDelete: () => handleDelete,
+  hasListBefore: () => hasListBefore,
+  hasListItemAfter: () => hasListItemAfter,
+  hasListItemBefore: () => hasListItemBefore,
+  listItemHasSubList: () => listItemHasSubList,
+  nextListIsDeeper: () => nextListIsDeeper,
+  nextListIsHigher: () => nextListIsHigher
+});
+var findListItemPos = (typeOrName, state) => {
+  const { $from } = state.selection;
+  const nodeType = getNodeType(typeOrName, state.schema);
+  let currentNode = null;
+  let currentDepth = $from.depth;
+  let currentPos = $from.pos;
+  let targetDepth = null;
+  while (currentDepth > 0 && targetDepth === null) {
+    currentNode = $from.node(currentDepth);
+    if (currentNode.type === nodeType) {
+      targetDepth = currentDepth;
+    } else {
+      currentDepth -= 1;
+      currentPos -= 1;
+    }
+  }
+  if (targetDepth === null) {
+    return null;
+  }
+  return { $pos: state.doc.resolve(currentPos), depth: targetDepth };
+};
+var getNextListDepth = (typeOrName, state) => {
+  const listItemPos = findListItemPos(typeOrName, state);
+  if (!listItemPos) {
+    return false;
+  }
+  const [, depth] = getNodeAtPosition(state, typeOrName, listItemPos.$pos.pos + 4);
+  return depth;
+};
+var hasListBefore = (editorState, name, parentListTypes) => {
+  const { $anchor } = editorState.selection;
+  const previousNodePos = Math.max(0, $anchor.pos - 2);
+  const previousNode = editorState.doc.resolve(previousNodePos).node();
+  if (!previousNode || !parentListTypes.includes(previousNode.type.name)) {
+    return false;
+  }
+  return true;
+};
+var handleBackspace = (editor, name, parentListTypes) => {
+  if (editor.commands.undoInputRule()) {
+    return true;
+  }
+  if (editor.state.selection.from !== editor.state.selection.to) {
+    return false;
+  }
+  if (!isNodeActive(editor.state, name) && hasListBefore(editor.state, name, parentListTypes)) {
+    const { $anchor } = editor.state.selection;
+    const $listPos = editor.state.doc.resolve($anchor.before() - 1);
+    const listDescendants = [];
+    $listPos.node().descendants((node, pos) => {
+      if (node.type.name === name) {
+        listDescendants.push({ node, pos });
+      }
+    });
+    const lastItem = listDescendants.at(-1);
+    if (!lastItem) {
+      return false;
+    }
+    const $lastItemPos = editor.state.doc.resolve($listPos.start() + lastItem.pos + 1);
+    return editor.chain().cut({ from: $anchor.start() - 1, to: $anchor.end() + 1 }, $lastItemPos.end()).joinForward().run();
+  }
+  if (!isNodeActive(editor.state, name)) {
+    return false;
+  }
+  if (!isAtStartOfNode(editor.state)) {
+    return false;
+  }
+  return editor.chain().liftListItem(name).run();
+};
+var nextListIsDeeper = (typeOrName, state) => {
+  const listDepth = getNextListDepth(typeOrName, state);
+  const listItemPos = findListItemPos(typeOrName, state);
+  if (!listItemPos || !listDepth) {
+    return false;
+  }
+  if (listDepth > listItemPos.depth) {
+    return true;
+  }
+  return false;
+};
+var nextListIsHigher = (typeOrName, state) => {
+  const listDepth = getNextListDepth(typeOrName, state);
+  const listItemPos = findListItemPos(typeOrName, state);
+  if (!listItemPos || !listDepth) {
+    return false;
+  }
+  if (listDepth < listItemPos.depth) {
+    return true;
+  }
+  return false;
+};
+var handleDelete = (editor, name) => {
+  if (!isNodeActive(editor.state, name)) {
+    return false;
+  }
+  if (!isAtEndOfNode(editor.state, name)) {
+    return false;
+  }
+  const { selection } = editor.state;
+  const { $from, $to } = selection;
+  if (!selection.empty && $from.sameParent($to)) {
+    return false;
+  }
+  if (nextListIsDeeper(name, editor.state)) {
+    return editor.chain().focus(editor.state.selection.from + 4).lift(name).joinBackward().run();
+  }
+  if (nextListIsHigher(name, editor.state)) {
+    return editor.chain().joinForward().joinBackward().run();
+  }
+  return editor.commands.joinItemForward();
+};
+var hasListItemAfter = (typeOrName, state) => {
+  var _a;
+  const { $anchor } = state.selection;
+  const $targetPos = state.doc.resolve($anchor.pos - $anchor.parentOffset - 2);
+  if ($targetPos.index() === $targetPos.parent.childCount - 1) {
+    return false;
+  }
+  if (((_a = $targetPos.nodeAfter) == null ? void 0 : _a.type.name) !== typeOrName) {
+    return false;
+  }
+  return true;
+};
+var hasListItemBefore = (typeOrName, state) => {
+  var _a;
+  const { $anchor } = state.selection;
+  const $targetPos = state.doc.resolve($anchor.pos - 2);
+  if ($targetPos.index() === 0) {
+    return false;
+  }
+  if (((_a = $targetPos.nodeBefore) == null ? void 0 : _a.type.name) !== typeOrName) {
+    return false;
+  }
+  return true;
+};
+var listItemHasSubList = (typeOrName, state, node) => {
+  if (!node) {
+    return false;
+  }
+  const nodeType = getNodeType(typeOrName, state.schema);
+  let hasSubList = false;
+  node.descendants((child) => {
+    if (child.type === nodeType) {
+      hasSubList = true;
+    }
+  });
+  return hasSubList;
+};
+var ListKeymap = Extension.create({
+  name: "listKeymap",
+  addOptions() {
+    return {
+      listTypes: [
+        {
+          itemName: "listItem",
+          wrapperNames: ["bulletList", "orderedList"]
+        },
+        {
+          itemName: "taskItem",
+          wrapperNames: ["taskList"]
+        }
+      ]
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      Delete: ({ editor }) => {
+        let handled = false;
+        this.options.listTypes.forEach(({ itemName }) => {
+          if (editor.state.schema.nodes[itemName] === void 0) {
+            return;
+          }
+          if (handleDelete(editor, itemName)) {
+            handled = true;
+          }
+        });
+        return handled;
+      },
+      "Mod-Delete": ({ editor }) => {
+        let handled = false;
+        this.options.listTypes.forEach(({ itemName }) => {
+          if (editor.state.schema.nodes[itemName] === void 0) {
+            return;
+          }
+          if (handleDelete(editor, itemName)) {
+            handled = true;
+          }
+        });
+        return handled;
+      },
+      Backspace: ({ editor }) => {
+        let handled = false;
+        this.options.listTypes.forEach(({ itemName, wrapperNames }) => {
+          if (editor.state.schema.nodes[itemName] === void 0) {
+            return;
+          }
+          if (handleBackspace(editor, itemName, wrapperNames)) {
+            handled = true;
+          }
+        });
+        return handled;
+      },
+      "Mod-Backspace": ({ editor }) => {
+        let handled = false;
+        this.options.listTypes.forEach(({ itemName, wrapperNames }) => {
+          if (editor.state.schema.nodes[itemName] === void 0) {
+            return;
+          }
+          if (handleBackspace(editor, itemName, wrapperNames)) {
+            handled = true;
+          }
+        });
+        return handled;
+      }
+    };
+  }
+});
+var ORDERED_LIST_ITEM_REGEX = new RegExp(
+  `^(\\s*)(${ORDERED_LIST_MARKER_PATTERN})([.)])\\s+(.*)$`
+);
+var ORDERED_LIST_LINE_START_REGEX = new RegExp(
+  `^(\\s*)(${ORDERED_LIST_MARKER_PATTERN})([.)])\\s+`
+);
+var INDENTED_LINE_REGEX = /^\s/;
+var PARAGRAPH_INTERRUPTERS = {
+  heading: /^#{1,6}(?:\s|$)/,
+  bulletItem: /^[-+*]\s+/,
+  codeFence: /^(?:```|~~~)/,
+  thematicBreak: /^(?:(?:-[ \t]*){3,}|(?:_[ \t]*){3,}|(?:\*[ \t]*){3,})$/
+};
+function isOrderedListMarkerLine(line) {
+  return ORDERED_LIST_ITEM_REGEX.test(line.trimStart());
+}
+function isBlockContentLine(line) {
+  const trimmedLine = line.trimStart();
+  return PARAGRAPH_INTERRUPTERS.bulletItem.test(trimmedLine) || isOrderedListMarkerLine(trimmedLine) || PARAGRAPH_INTERRUPTERS.heading.test(trimmedLine) || // dash breaks are excluded: "---" directly below paragraph text is a
+  // setext heading underline, not a thematic break
+  PARAGRAPH_INTERRUPTERS.thematicBreak.test(trimmedLine) && !trimmedLine.startsWith("-") || // oxlint-disable-next-line prefer-string-starts-ends-with
+  /^>\s?/.test(trimmedLine) || PARAGRAPH_INTERRUPTERS.codeFence.test(trimmedLine);
+}
+function interruptsLazyContinuation(line) {
+  return Object.values(PARAGRAPH_INTERRUPTERS).some((pattern) => pattern.test(line));
+}
+function splitItemContent(contentLines) {
+  const paragraphLines = [];
+  const blockLines = [];
+  let reachedBlockBoundary = false;
+  contentLines.forEach((line) => {
+    if (reachedBlockBoundary) {
+      blockLines.push(line);
+      return;
+    }
+    if (line.trim() === "") {
+      reachedBlockBoundary = true;
+      blockLines.push(line);
+      return;
+    }
+    if (paragraphLines.length > 0 && isBlockContentLine(line)) {
+      reachedBlockBoundary = true;
+      blockLines.push(line);
+      return;
+    }
+    paragraphLines.push(line);
+  });
+  return {
+    paragraphLines,
+    blockLines
+  };
+}
+function collectOrderedListItems(lines) {
+  const listItems = [];
+  let currentLineIndex = 0;
+  let consumed = 0;
+  while (currentLineIndex < lines.length) {
+    const line = lines[currentLineIndex];
+    const match = line.match(ORDERED_LIST_ITEM_REGEX);
+    if (!match) {
+      break;
+    }
+    const [, indent, marker, _separator, content] = match;
+    const indentLevel = indent.length;
+    const number = parseInt(marker, 10);
+    const markerType = isNaN(number) ? detectMarkerType(marker) : void 0;
+    const itemNumber = isNaN(number) ? markerToStart(marker) : number;
+    const itemContentLines = [content];
+    let nextLineIndex = currentLineIndex + 1;
+    const itemLines = [line];
+    let sawBlankLine = false;
+    while (nextLineIndex < lines.length) {
+      const nextLine = lines[nextLineIndex];
+      const nextMatch = nextLine.match(ORDERED_LIST_ITEM_REGEX);
+      if (nextMatch) {
+        break;
+      }
+      if (nextLine.trim() === "") {
+        itemLines.push(nextLine);
+        itemContentLines.push("");
+        sawBlankLine = true;
+        nextLineIndex += 1;
+      } else if (nextLine.match(INDENTED_LINE_REGEX)) {
+        const leadingWhitespace = nextLine.length - nextLine.trimStart().length;
+        const contentIndent = indentLevel + marker.length + 1;
+        itemLines.push(nextLine);
+        itemContentLines.push(nextLine.slice(Math.min(leadingWhitespace, contentIndent)));
+        nextLineIndex += 1;
+      } else {
+        if (sawBlankLine || interruptsLazyContinuation(nextLine)) {
+          break;
+        }
+        itemLines.push(nextLine);
+        itemContentLines.push(nextLine);
+        nextLineIndex += 1;
+      }
+    }
+    listItems.push({
+      indent: indentLevel,
+      number: itemNumber,
+      type: markerType,
+      content: itemContentLines.join("\n").trim(),
+      contentLines: itemContentLines,
+      raw: itemLines.join("\n")
+    });
+    consumed = nextLineIndex;
+    currentLineIndex = nextLineIndex;
+  }
+  return [listItems, consumed];
+}
+var PLAIN_TEXT_ORDERED_LIST_LINE_REGEX = new RegExp(
+  `^(${ORDERED_LIST_MARKER_PATTERN})([.)])\\s+(.+)$`
+);
+function parsePlainTextOrderedListPaste(text) {
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length === 0) {
+    return null;
+  }
+  const parsedItems = [];
+  for (const line of lines) {
+    const match = line.trim().match(PLAIN_TEXT_ORDERED_LIST_LINE_REGEX);
+    if (!match) {
+      return null;
+    }
+    parsedItems.push({
+      marker: match[1],
+      content: match[3]
+    });
+  }
+  const markers = parsedItems.map((item) => item.marker);
+  if (!areOrderedListMarkersSequential(markers)) {
+    return null;
+  }
+  const attrs = buildOrderedListAttrsFromMarker(parsedItems[0].marker);
+  return {
+    type: "orderedList",
+    attrs,
+    content: parsedItems.map((item) => ({
+      type: "listItem",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: item.content }]
+        }
+      ]
+    }))
+  };
+}
+function buildNestedStructure(items, baseIndent, lexer) {
+  const result = [];
+  let currentIndex = 0;
+  while (currentIndex < items.length) {
+    const item = items[currentIndex];
+    if (item.indent === baseIndent) {
+      const { paragraphLines, blockLines } = splitItemContent(item.contentLines);
+      const mainText = paragraphLines.join("\n").trim();
+      const tokens = [];
+      if (mainText) {
+        tokens.push({
+          type: "paragraph",
+          raw: mainText,
+          tokens: lexer.inlineTokens(mainText)
+        });
+      }
+      const additionalContent = blockLines.join("\n").trim();
+      if (additionalContent) {
+        const blockTokens = lexer.blockTokens(additionalContent);
+        tokens.push(...blockTokens);
+      }
+      let lookAheadIndex = currentIndex + 1;
+      const nestedItems = [];
+      while (lookAheadIndex < items.length && items[lookAheadIndex].indent > baseIndent) {
+        nestedItems.push(items[lookAheadIndex]);
+        lookAheadIndex += 1;
+      }
+      if (nestedItems.length > 0) {
+        const nextIndent = Math.min(...nestedItems.map((nestedItem) => nestedItem.indent));
+        const nestedListItems = buildNestedStructure(nestedItems, nextIndent, lexer);
+        tokens.push({
+          type: "list",
+          ordered: true,
+          start: nestedItems[0].number,
+          typeMarker: nestedItems[0].type,
+          items: nestedListItems,
+          raw: nestedItems.map((nestedItem) => nestedItem.raw).join("\n")
+        });
+      }
+      result.push({
+        type: "list_item",
+        raw: item.raw,
+        tokens
+      });
+      currentIndex = lookAheadIndex;
+    } else {
+      currentIndex += 1;
+    }
+  }
+  return result;
+}
+function parseListItems(items, helpers) {
+  return items.map((item) => {
+    if (item.type !== "list_item") {
+      return helpers.parseChildren([item])[0];
+    }
+    const content = [];
+    if (item.tokens && item.tokens.length > 0) {
+      item.tokens.forEach((itemToken) => {
+        if (itemToken.type === "paragraph" || itemToken.type === "list" || itemToken.type === "blockquote" || itemToken.type === "code") {
+          content.push(...helpers.parseChildren([itemToken]));
+        } else if (itemToken.type === "text" && itemToken.tokens) {
+          const inlineContent = helpers.parseChildren([itemToken]);
+          content.push({
+            type: "paragraph",
+            content: inlineContent
+          });
+        } else {
+          const parsed = helpers.parseChildren([itemToken]);
+          if (parsed.length > 0) {
+            content.push(...parsed);
+          }
+        }
+      });
+    }
+    return {
+      type: "listItem",
+      content
+    };
+  });
+}
+var ListItemName2 = "listItem";
+var TextStyleName2 = "textStyle";
+var orderedListInputRegex = /^(\d+)\.\s$/;
+function cssListStyleTypeToHtmlType(style) {
+  const match = style.match(/list-style-type\s*:\s*([^;]+)/i);
+  if (!match) {
+    return null;
+  }
+  const cssValue = match[1].trim().toLowerCase();
+  switch (cssValue) {
+    case "upper-roman":
+      return "I";
+    case "lower-roman":
+      return "i";
+    case "upper-alpha":
+    case "upper-latin":
+      return "A";
+    case "lower-alpha":
+    case "lower-latin":
+      return "a";
+    default:
+      return null;
+  }
+}
+var OrderedList = Node3.create({
+  name: "orderedList",
+  addOptions() {
+    return {
+      itemTypeName: "listItem",
+      HTMLAttributes: {},
+      keepMarks: false,
+      keepAttributes: false
+    };
+  },
+  group: "block list",
+  content() {
+    return `${this.options.itemTypeName}+`;
+  },
+  addAttributes() {
+    return {
+      start: {
+        default: 1,
+        parseHTML: (element) => {
+          return element.hasAttribute("start") ? parseInt(element.getAttribute("start") || "", 10) : 1;
+        }
+      },
+      type: {
+        default: null,
+        parseHTML: (element) => {
+          const htmlType = element.getAttribute("type");
+          if (htmlType) {
+            return htmlType;
+          }
+          const style = element.getAttribute("style");
+          if (style) {
+            const mappedFromOl = cssListStyleTypeToHtmlType(style);
+            if (mappedFromOl) {
+              return mappedFromOl;
+            }
+          }
+          const firstLi = element.querySelector("li");
+          if (firstLi) {
+            const liStyle = firstLi.getAttribute("style");
+            if (liStyle) {
+              const mappedFromLi = cssListStyleTypeToHtmlType(liStyle);
+              if (mappedFromLi) {
+                return mappedFromLi;
+              }
+            }
+          }
+          return null;
+        }
+      }
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: "ol"
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    const { start, type, ...attributesWithoutType } = HTMLAttributes;
+    const attrs = mergeAttributes(this.options.HTMLAttributes, attributesWithoutType);
+    if (start !== 1) {
+      attrs.start = start;
+    }
+    if (type && type !== "1") {
+      attrs.type = type;
+    }
+    return ["ol", attrs, 0];
+  },
+  markdownTokenName: "list",
+  parseMarkdown: (token, helpers) => {
+    if (token.type !== "list" || !token.ordered) {
+      return [];
+    }
+    const startValue = token.start || 1;
+    const typeValue = token.typeMarker;
+    const content = token.items ? parseListItems(token.items, helpers) : [];
+    const attrs = {};
+    if (startValue !== 1) {
+      attrs.start = startValue;
+    }
+    if (typeValue) {
+      attrs.type = typeValue;
+    }
+    if (Object.keys(attrs).length > 0) {
+      return {
+        type: "orderedList",
+        attrs,
+        content
+      };
+    }
+    return {
+      type: "orderedList",
+      content
+    };
+  },
+  renderMarkdown: (node, h2) => {
+    if (!node.content) {
+      return "";
+    }
+    return h2.renderChildren(node.content, "\n");
+  },
+  markdownTokenizer: {
+    name: "orderedList",
+    level: "block",
+    start: (src) => {
+      const match = src.match(ORDERED_LIST_LINE_START_REGEX);
+      const index = match == null ? void 0 : match.index;
+      return index !== void 0 ? index : -1;
+    },
+    tokenize: (src, _tokens, lexer) => {
+      var _a, _b;
+      const lines = src.split("\n");
+      const [listItems, consumed] = collectOrderedListItems(lines);
+      if (listItems.length === 0) {
+        return void 0;
+      }
+      const items = buildNestedStructure(listItems, listItems[0].indent, lexer);
+      if (items.length === 0) {
+        return void 0;
+      }
+      const startValue = ((_a = listItems[0]) == null ? void 0 : _a.number) || 1;
+      const typeMarker = (_b = listItems[0]) == null ? void 0 : _b.type;
+      return {
+        type: "list",
+        ordered: true,
+        start: startValue,
+        typeMarker,
+        items,
+        raw: lines.slice(0, consumed).join("\n")
+      };
+    }
+  },
+  markdownOptions: {
+    indentsContent: true
+  },
+  addCommands() {
+    return {
+      toggleOrderedList: () => ({ commands, chain }) => {
+        if (this.options.keepAttributes) {
+          return chain().toggleList(this.name, this.options.itemTypeName, this.options.keepMarks).updateAttributes(ListItemName2, this.editor.getAttributes(TextStyleName2)).run();
+        }
+        return commands.toggleList(this.name, this.options.itemTypeName, this.options.keepMarks);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-7": () => this.editor.commands.toggleOrderedList()
+    };
+  },
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          handlePaste: (view, event) => {
+            var _a, _b;
+            const html = (_a = event.clipboardData) == null ? void 0 : _a.getData("text/html");
+            if (html == null ? void 0 : html.trim()) {
+              return false;
+            }
+            const text = (_b = event.clipboardData) == null ? void 0 : _b.getData("text/plain");
+            if (!text) {
+              return false;
+            }
+            const orderedListContent = parsePlainTextOrderedListPaste(text);
+            if (!orderedListContent) {
+              return false;
+            }
+            try {
+              const orderedListNode = view.state.schema.nodeFromJSON(orderedListContent);
+              const tr = view.state.tr.replaceSelectionWith(orderedListNode);
+              view.dispatch(tr);
+              return true;
+            } catch {
+              return false;
+            }
+          }
+        }
+      })
+    ];
+  },
+  addInputRules() {
+    const joinPredicate = (match, node) => {
+      const hasDefaultType = !node.attrs.type || node.attrs.type === "1";
+      return hasDefaultType && node.childCount + node.attrs.start === +match[1];
+    };
+    let inputRule = wrappingInputRule({
+      find: orderedListInputRegex,
+      type: this.type,
+      getAttributes: (match) => ({ start: +match[1] }),
+      joinPredicate
+    });
+    if (this.options.keepMarks || this.options.keepAttributes) {
+      inputRule = wrappingInputRule({
+        find: orderedListInputRegex,
+        type: this.type,
+        keepMarks: this.options.keepMarks,
+        keepAttributes: this.options.keepAttributes,
+        getAttributes: (match) => ({ start: +match[1], ...this.editor.getAttributes(TextStyleName2) }),
+        joinPredicate,
+        editor: this.editor
+      });
+    }
+    return [inputRule];
+  }
+});
+var inputRegex$3 = /^\s*(\[([( |x])?\])\s$/;
+var TaskItem = Node3.create({
+  name: "taskItem",
+  addOptions() {
+    return {
+      nested: false,
+      HTMLAttributes: {},
+      taskListTypeName: "taskList",
+      a11y: void 0
+    };
+  },
+  content() {
+    return this.options.nested ? "paragraph block*" : "paragraph+";
+  },
+  defining: true,
+  addAttributes() {
+    return {
+      checked: {
+        default: false,
+        keepOnSplit: false,
+        parseHTML: (element) => {
+          const dataChecked = element.getAttribute("data-checked");
+          return dataChecked === "" || dataChecked === "true";
+        },
+        renderHTML: (attributes) => ({
+          "data-checked": attributes.checked
+        })
+      }
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: `li[data-type="${this.name}"]`,
+        priority: 51
+      }
+    ];
+  },
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      "li",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        "data-type": this.name
+      }),
+      [
+        "label",
+        [
+          "input",
+          {
+            type: "checkbox",
+            checked: node.attrs.checked ? "checked" : null
+          }
+        ],
+        ["span"]
+      ],
+      ["div", 0]
+    ];
+  },
+  parseMarkdown: (token, h2) => {
+    const content = [];
+    if (token.tokens && token.tokens.length > 0) {
+      content.push(h2.createNode("paragraph", {}, h2.parseInline(token.tokens)));
+    } else if (token.text) {
+      content.push(h2.createNode("paragraph", {}, [h2.createNode("text", { text: token.text })]));
+    } else {
+      content.push(h2.createNode("paragraph", {}, []));
+    }
+    if (token.nestedTokens && token.nestedTokens.length > 0) {
+      const nestedContent = h2.parseChildren(token.nestedTokens);
+      content.push(...nestedContent);
+    }
+    return h2.createNode("taskItem", { checked: token.checked || false }, content);
+  },
+  renderMarkdown: (node, h2) => {
+    var _a;
+    const checkedChar = ((_a = node.attrs) == null ? void 0 : _a.checked) ? "x" : " ";
+    const prefix = `- [${checkedChar}] `;
+    return renderNestedMarkdownContent(node, h2, prefix);
+  },
+  addExtensions() {
+    if (!this.options.nested) {
+      return [];
+    }
+    return [createBranchingListDeleteKeymap(this.name, [this.options.taskListTypeName])];
+  },
+  addKeyboardShortcuts() {
+    const shortcuts = {
+      Enter: () => this.editor.commands.splitListItem(this.name),
+      "Shift-Tab": () => this.editor.commands.liftListItem(this.name)
+    };
+    if (!this.options.nested) {
+      return shortcuts;
+    }
+    return {
+      ...shortcuts,
+      Tab: () => this.editor.commands.sinkListItem(this.name)
+    };
+  },
+  addNodeView() {
+    return ({ node, HTMLAttributes, getPos, editor }) => {
+      const listItem = document.createElement("li");
+      const checkboxWrapper = document.createElement("label");
+      const checkboxStyler = document.createElement("span");
+      const checkbox = document.createElement("input");
+      const content = document.createElement("div");
+      const updateA11Y = (currentNode) => {
+        var _a, _b;
+        checkbox.ariaLabel = ((_b = (_a = this.options.a11y) == null ? void 0 : _a.checkboxLabel) == null ? void 0 : _b.call(_a, currentNode, checkbox.checked)) || `Task item checkbox for ${currentNode.textContent || "empty task item"}`;
+      };
+      updateA11Y(node);
+      checkboxWrapper.contentEditable = "false";
+      checkbox.type = "checkbox";
+      checkbox.addEventListener("mousedown", (event) => event.preventDefault());
+      checkbox.addEventListener("change", (event) => {
+        if (!editor.isEditable && !this.options.onReadOnlyChecked) {
+          checkbox.checked = !checkbox.checked;
+          return;
+        }
+        const { checked } = event.target;
+        if (editor.isEditable && typeof getPos === "function") {
+          editor.chain().focus(void 0, { scrollIntoView: false }).command(({ tr }) => {
+            const position = getPos();
+            if (typeof position !== "number") {
+              return false;
+            }
+            const currentNode = tr.doc.nodeAt(position);
+            tr.setNodeMarkup(position, void 0, {
+              ...currentNode == null ? void 0 : currentNode.attrs,
+              checked
+            });
+            return true;
+          }).run();
+        }
+        if (!editor.isEditable && this.options.onReadOnlyChecked) {
+          if (!this.options.onReadOnlyChecked(node, checked)) {
+            checkbox.checked = !checkbox.checked;
+          }
+        }
+      });
+      Object.entries(this.options.HTMLAttributes).forEach(([key, value]) => {
+        listItem.setAttribute(key, value);
+      });
+      listItem.dataset.checked = node.attrs.checked;
+      checkbox.checked = node.attrs.checked;
+      checkboxWrapper.append(checkbox, checkboxStyler);
+      listItem.append(checkboxWrapper, content);
+      Object.entries(HTMLAttributes).forEach(([key, value]) => {
+        listItem.setAttribute(key, value);
+      });
+      let prevRenderedAttributeKeys = new Set(Object.keys(HTMLAttributes));
+      return {
+        dom: listItem,
+        contentDOM: content,
+        update: (updatedNode) => {
+          if (updatedNode.type !== this.type) {
+            return false;
+          }
+          listItem.dataset.checked = updatedNode.attrs.checked;
+          checkbox.checked = updatedNode.attrs.checked;
+          updateA11Y(updatedNode);
+          const extensionAttributes = editor.extensionManager.attributes;
+          const newHTMLAttributes = getRenderedAttributes(updatedNode, extensionAttributes);
+          const newKeys = new Set(Object.keys(newHTMLAttributes));
+          const staticAttrs = this.options.HTMLAttributes;
+          prevRenderedAttributeKeys.forEach((key) => {
+            if (!newKeys.has(key)) {
+              if (key in staticAttrs) {
+                listItem.setAttribute(key, staticAttrs[key]);
+              } else {
+                listItem.removeAttribute(key);
+              }
+            }
+          });
+          Object.entries(newHTMLAttributes).forEach(([key, value]) => {
+            if (value === null || value === void 0) {
+              if (key in staticAttrs) {
+                listItem.setAttribute(key, staticAttrs[key]);
+              } else {
+                listItem.removeAttribute(key);
+              }
+            } else {
+              listItem.setAttribute(key, value);
+            }
+          });
+          prevRenderedAttributeKeys = newKeys;
+          return true;
+        }
+      };
+    };
+  },
+  addInputRules() {
+    return [
+      wrappingInputRule({
+        find: inputRegex$3,
+        type: this.type,
+        getAttributes: (match) => ({
+          checked: match[match.length - 1] === "x"
+        })
+      })
+    ];
+  }
+});
+var TaskList = Node3.create({
+  name: "taskList",
+  addOptions() {
+    return {
+      itemTypeName: "taskItem",
+      HTMLAttributes: {}
+    };
+  },
+  group: "block list",
+  content() {
+    return `${this.options.itemTypeName}+`;
+  },
+  parseHTML() {
+    return [
+      {
+        tag: `ul[data-type="${this.name}"]`,
+        priority: 51
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "ul",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, { "data-type": this.name }),
+      0
+    ];
+  },
+  parseMarkdown: (token, h2) => {
+    return h2.createNode("taskList", {}, h2.parseChildren(token.items || []));
+  },
+  renderMarkdown: (node, h2) => {
+    if (!node.content) {
+      return "";
+    }
+    return h2.renderChildren(node.content, "\n");
+  },
+  markdownTokenizer: {
+    name: "taskList",
+    level: "block",
+    start(src) {
+      var _a;
+      const index = (_a = src.match(/^\s*[-+*]\s+\[([ xX])\]\s+/)) == null ? void 0 : _a.index;
+      return index !== void 0 ? index : -1;
+    },
+    tokenize(src, tokens, lexer) {
+      const parseTaskListContent = (content) => {
+        const nestedResult = parseIndentedBlocks(
+          content,
+          {
+            itemPattern: /^(\s*)([-+*])\s+\[([ xX])\]\s+(.*)$/,
+            extractItemData: (match) => ({
+              indentLevel: match[1].length,
+              mainContent: match[4],
+              checked: match[3].toLowerCase() === "x"
+            }),
+            createToken: (data, nestedTokens) => ({
+              type: "taskItem",
+              raw: "",
+              mainContent: data.mainContent,
+              indentLevel: data.indentLevel,
+              checked: data.checked,
+              text: data.mainContent,
+              tokens: lexer.inlineTokens(data.mainContent),
+              nestedTokens
+            }),
+            // Allow recursive nesting
+            customNestedParser: parseTaskListContent
+          },
+          lexer
+        );
+        if (nestedResult) {
+          const taskListToken = {
+            type: "taskList",
+            raw: nestedResult.raw,
+            items: nestedResult.items
+          };
+          const remainder = content.slice(nestedResult.raw.length);
+          if (remainder.trim()) {
+            return [taskListToken, ...lexer.blockTokens(remainder)];
+          }
+          return [taskListToken];
+        }
+        return lexer.blockTokens(content);
+      };
+      const result = parseIndentedBlocks(
+        src,
+        {
+          itemPattern: /^(\s*)([-+*])\s+\[([ xX])\]\s+(.*)$/,
+          extractItemData: (match) => ({
+            indentLevel: match[1].length,
+            mainContent: match[4],
+            checked: match[3].toLowerCase() === "x"
+          }),
+          createToken: (data, nestedTokens) => ({
+            type: "taskItem",
+            raw: "",
+            mainContent: data.mainContent,
+            indentLevel: data.indentLevel,
+            checked: data.checked,
+            text: data.mainContent,
+            tokens: lexer.inlineTokens(data.mainContent),
+            nestedTokens
+          }),
+          // Use the recursive parser for nested content
+          customNestedParser: parseTaskListContent
+        },
+        lexer
+      );
+      if (!result) {
+        return void 0;
+      }
+      return {
+        type: "taskList",
+        raw: result.raw,
+        items: result.items
+      };
+    }
+  },
+  markdownOptions: {
+    indentsContent: true
+  },
+  addCommands() {
+    return {
+      toggleTaskList: () => ({ commands }) => {
+        return commands.toggleList(this.name, this.options.itemTypeName);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-9": () => this.editor.commands.toggleTaskList()
+    };
+  }
+});
+Extension.create({
+  name: "listKit",
+  addExtensions() {
+    const extensions = [];
+    if (this.options.bulletList !== false) {
+      extensions.push(BulletList.configure(this.options.bulletList));
+    }
+    if (this.options.listItem !== false) {
+      extensions.push(ListItem.configure(this.options.listItem));
+    }
+    if (this.options.listKeymap !== false) {
+      extensions.push(ListKeymap.configure(this.options.listKeymap));
+    }
+    if (this.options.orderedList !== false) {
+      extensions.push(OrderedList.configure(this.options.orderedList));
+    }
+    if (this.options.taskItem !== false) {
+      extensions.push(TaskItem.configure(this.options.taskItem));
+    }
+    if (this.options.taskList !== false) {
+      extensions.push(TaskList.configure(this.options.taskList));
+    }
+    return extensions;
+  }
+});
+var index_default$a = BulletList;
+var index_default$9 = OrderedList;
+var index_default$8 = ListItem;
+var index_default$7 = TaskList;
+var index_default$6 = TaskItem;
+var starInputRegex$1 = /(?:^|\s)(\*\*(?!\s+\*\*)((?:[^*]+))\*\*(?!\s+\*\*))$/;
+var starPasteRegex$1 = /(?:^|\s)(\*\*(?!\s+\*\*)((?:[^*]+))\*\*(?!\s+\*\*))/g;
+var underscoreInputRegex$1 = /(?:^|\s)(__(?!\s+__)((?:[^_]+))__(?!\s+__))$/;
+var underscorePasteRegex$1 = /(?:^|\s)(__(?!\s+__)((?:[^_]+))__(?!\s+__))/g;
+var Bold = Mark2.create({
+  name: "bold",
+  addOptions() {
+    return {
+      HTMLAttributes: {}
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: "strong"
+      },
+      {
+        tag: "b",
+        getAttrs: (node) => node.style.fontWeight !== "normal" && null
+      },
+      {
+        style: "font-weight=400",
+        clearMark: (mark) => mark.type.name === this.name
+      },
+      {
+        style: "font-weight",
+        getAttrs: (value) => /^(bold(er)?|[5-9]\d{2,})$/.test(value) && null
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return /* @__PURE__ */ h("strong", { ...mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), children: /* @__PURE__ */ h("slot", {}) });
+  },
+  markdownTokenName: "strong",
+  parseMarkdown: (token, helpers) => {
+    return helpers.applyMark("bold", helpers.parseInline(token.tokens || []));
+  },
+  markdownOptions: {
+    htmlReopen: {
+      open: "<strong>",
+      close: "</strong>"
+    }
+  },
+  renderMarkdown: (node, h2) => {
+    return `**${h2.renderChildren(node)}**`;
+  },
+  addCommands() {
+    return {
+      setBold: () => ({ commands }) => {
+        return commands.setMark(this.name);
+      },
+      toggleBold: () => ({ commands }) => {
+        return commands.toggleMark(this.name);
+      },
+      unsetBold: () => ({ commands }) => {
+        return commands.unsetMark(this.name);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-b": () => this.editor.commands.toggleBold(),
+      "Mod-B": () => this.editor.commands.toggleBold()
+    };
+  },
+  addInputRules() {
+    return [
+      markInputRule({
+        find: starInputRegex$1,
+        type: this.type
+      }),
+      markInputRule({
+        find: underscoreInputRegex$1,
+        type: this.type
+      })
+    ];
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: starPasteRegex$1,
+        type: this.type
+      }),
+      markPasteRule({
+        find: underscorePasteRegex$1,
+        type: this.type
+      })
+    ];
+  }
+});
+var index_default$5 = Bold;
+var starInputRegex = /(?:^|\s)(\*(?!\s+\*)((?:[^*]+))\*(?!\s+\*))$/;
+var starPasteRegex = /(?:^|\s)(\*(?!\s+\*)((?:[^*]+))\*(?!\s+\*))/g;
+var underscoreInputRegex = /(?:^|\s)(_(?!\s+_)((?:[^_]+))_(?!\s+_))$/;
+var underscorePasteRegex = /(?:^|\s)(_(?!\s+_)((?:[^_]+))_(?!\s+_))/g;
+var Italic = Mark2.create({
+  name: "italic",
+  addOptions() {
+    return {
+      HTMLAttributes: {}
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: "em"
+      },
+      {
+        tag: "i",
+        getAttrs: (node) => node.style.fontStyle !== "normal" && null
+      },
+      {
+        style: "font-style=normal",
+        clearMark: (mark) => mark.type.name === this.name
+      },
+      {
+        style: "font-style=italic"
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["em", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+  addCommands() {
+    return {
+      setItalic: () => ({ commands }) => {
+        return commands.setMark(this.name);
+      },
+      toggleItalic: () => ({ commands }) => {
+        return commands.toggleMark(this.name);
+      },
+      unsetItalic: () => ({ commands }) => {
+        return commands.unsetMark(this.name);
+      }
+    };
+  },
+  markdownTokenName: "em",
+  parseMarkdown: (token, helpers) => {
+    return helpers.applyMark("italic", helpers.parseInline(token.tokens || []));
+  },
+  markdownOptions: {
+    htmlReopen: {
+      open: "<em>",
+      close: "</em>"
+    }
+  },
+  renderMarkdown: (node, h2) => {
+    return `*${h2.renderChildren(node)}*`;
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-i": () => this.editor.commands.toggleItalic(),
+      "Mod-I": () => this.editor.commands.toggleItalic()
+    };
+  },
+  addInputRules() {
+    return [
+      markInputRule({
+        find: starInputRegex,
+        type: this.type
+      }),
+      markInputRule({
+        find: underscoreInputRegex,
+        type: this.type
+      })
+    ];
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: starPasteRegex,
+        type: this.type
+      }),
+      markPasteRule({
+        find: underscorePasteRegex,
+        type: this.type
+      })
+    ];
+  }
+});
+var index_default$4 = Italic;
+var Underline = Mark2.create({
+  name: "underline",
+  addOptions() {
+    return {
+      HTMLAttributes: {}
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: "u"
+      },
+      {
+        style: "text-decoration",
+        consuming: false,
+        getAttrs: (style) => style.includes("underline") ? {} : false
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["u", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+  parseMarkdown(token, helpers) {
+    return helpers.applyMark(this.name || "underline", helpers.parseInline(token.tokens || []));
+  },
+  renderMarkdown(node, helpers) {
+    return `++${helpers.renderChildren(node)}++`;
+  },
+  markdownTokenizer: {
+    name: "underline",
+    level: "inline",
+    start(src) {
+      return src.indexOf("++");
+    },
+    tokenize(src, _tokens, lexer) {
+      const rule = /^(\+\+)([\s\S]+?)(\+\+)/;
+      const match = rule.exec(src);
+      if (!match) {
+        return void 0;
+      }
+      const innerContent = match[2].trim();
+      return {
+        type: "underline",
+        raw: match[0],
+        text: innerContent,
+        tokens: lexer.inlineTokens(innerContent)
+      };
+    }
+  },
+  addCommands() {
+    return {
+      setUnderline: () => ({ commands }) => {
+        return commands.setMark(this.name);
+      },
+      toggleUnderline: () => ({ commands }) => {
+        return commands.toggleMark(this.name);
+      },
+      unsetUnderline: () => ({ commands }) => {
+        return commands.unsetMark(this.name);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-u": () => this.editor.commands.toggleUnderline(),
+      "Mod-U": () => this.editor.commands.toggleUnderline()
+    };
+  }
+});
+var index_default$3 = Underline;
+var inputRegex$2 = /(?:^|\s)(~~(?!\s+~~)((?:[^~]+))~~(?!\s+~~))$/;
+var pasteRegex$1 = /(?:^|\s)(~~(?!\s+~~)((?:[^~]+))~~(?!\s+~~))/g;
+var Strike = Mark2.create({
+  name: "strike",
+  addOptions() {
+    return {
+      HTMLAttributes: {}
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: "s"
+      },
+      {
+        tag: "del"
+      },
+      {
+        tag: "strike"
+      },
+      {
+        style: "text-decoration",
+        consuming: false,
+        getAttrs: (style) => style.includes("line-through") ? {} : false
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["s", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+  markdownTokenName: "del",
+  parseMarkdown: (token, helpers) => {
+    return helpers.applyMark("strike", helpers.parseInline(token.tokens || []));
+  },
+  renderMarkdown: (node, h2) => {
+    return `~~${h2.renderChildren(node)}~~`;
+  },
+  addCommands() {
+    return {
+      setStrike: () => ({ commands }) => {
+        return commands.setMark(this.name);
+      },
+      toggleStrike: () => ({ commands }) => {
+        return commands.toggleMark(this.name);
+      },
+      unsetStrike: () => ({ commands }) => {
+        return commands.unsetMark(this.name);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-s": () => this.editor.commands.toggleStrike()
+    };
+  },
+  addInputRules() {
+    return [
+      markInputRule({
+        find: inputRegex$2,
+        type: this.type
+      })
+    ];
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: pasteRegex$1,
+        type: this.type
+      })
+    ];
+  }
+});
+var index_default$2 = Strike;
+var inputRegex$1 = /(?:^|\s)(==(?!\s+==)((?:[^=]+))==(?!\s+==))$/;
+var pasteRegex = /(?:^|\s)(==(?!\s+==)((?:[^=]+))==(?!\s+==))/g;
+var Highlight = Mark2.create({
+  name: "highlight",
+  addOptions() {
+    return {
+      multicolor: false,
+      HTMLAttributes: {}
+    };
+  },
+  addAttributes() {
+    if (!this.options.multicolor) {
+      return {};
+    }
+    return {
+      color: {
+        default: null,
+        // Prefer `data-color` (set by our own `renderHTML`) for lossless
+        // round-trips. Otherwise parse the raw inline `style` attribute so
+        // the original color format (e.g. `#rrggbb`) is preserved instead of
+        // the canonicalized `rgb(...)` value from `element.style.backgroundColor`.
+        parseHTML: (element) => element.getAttribute("data-color") || getStyleProperty(element, "background-color") || element.style.backgroundColor,
+        renderHTML: (attributes) => {
+          if (!attributes.color) {
+            return {};
+          }
+          return {
+            "data-color": attributes.color,
+            style: `background-color: ${attributes.color}; color: inherit`
+          };
+        }
+      }
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: "mark"
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["mark", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+  renderMarkdown: (node, h2) => {
+    return `==${h2.renderChildren(node)}==`;
+  },
+  parseMarkdown: (token, h2) => {
+    return h2.applyMark("highlight", h2.parseInline(token.tokens || []));
+  },
+  markdownTokenizer: {
+    name: "highlight",
+    level: "inline",
+    start: (src) => src.indexOf("=="),
+    tokenize(src, _, h2) {
+      const rule = /^(==)([^=]+)(==)/;
+      const match = rule.exec(src);
+      if (match) {
+        const innerContent = match[2].trim();
+        const children = h2.inlineTokens(innerContent);
+        return {
+          type: "highlight",
+          raw: match[0],
+          text: innerContent,
+          tokens: children
+        };
+      }
+    }
+  },
+  addCommands() {
+    return {
+      setHighlight: (attributes) => ({ commands }) => {
+        return commands.setMark(this.name, attributes);
+      },
+      toggleHighlight: (attributes) => ({ commands }) => {
+        return commands.toggleMark(this.name, attributes);
+      },
+      unsetHighlight: () => ({ commands }) => {
+        return commands.unsetMark(this.name);
+      }
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-h": () => this.editor.commands.toggleHighlight()
+    };
+  },
+  addInputRules() {
+    return [
+      markInputRule({
+        find: inputRegex$1,
+        type: this.type
+      })
+    ];
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: pasteRegex,
+        type: this.type
+      })
+    ];
+  }
+});
+var index_default$1 = Highlight;
+const ColorMark = Mark2.create({
+  name: "color",
+  addAttributes() {
+    return {
+      color: {
+        default: null,
+        parseHTML: (element) => element.style.color || element.getAttribute("data-color"),
+        renderHTML: (attributes) => attributes.color ? { style: `color: ${attributes.color}` } : {}
+      }
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: "span[style*=color]",
+        getAttrs: (element) => element.style.color ? null : false
+      },
+      { tag: "font[color]" }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["span", mergeAttributes(HTMLAttributes), 0];
+  }
+});
+const FontFamilyMark = Mark2.create({
+  name: "fontFamily",
+  addAttributes() {
+    return {
+      fontFamily: {
+        default: null,
+        parseHTML: (element) => element.style.fontFamily,
+        renderHTML: (attributes) => attributes.fontFamily ? { style: `font-family: ${attributes.fontFamily}` } : {}
+      }
+    };
+  },
+  parseHTML() {
+    return [{ tag: "span[style*=font-family]" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["span", mergeAttributes(HTMLAttributes), 0];
+  }
+});
+const FontSizeMark = Mark2.create({
+  name: "fontSize",
+  addAttributes() {
+    return {
+      fontSize: {
+        default: null,
+        parseHTML: (element) => element.style.fontSize,
+        renderHTML: (attributes) => attributes.fontSize ? { style: `font-size: ${attributes.fontSize}` } : {}
+      }
+    };
+  },
+  parseHTML() {
+    return [{ tag: "span[style*=font-size]" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["span", mergeAttributes(HTMLAttributes), 0];
+  }
+});
+var inputRegex = /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/;
+var Image = Node3.create({
+  name: "image",
+  addOptions() {
+    return {
+      inline: false,
+      allowBase64: false,
+      HTMLAttributes: {},
+      resize: false
+    };
+  },
+  inline() {
+    return this.options.inline;
+  },
+  group() {
+    return this.options.inline ? "inline" : "block";
+  },
+  draggable: true,
+  addAttributes() {
+    return {
+      src: {
+        default: null
+      },
+      alt: {
+        default: null
+      },
+      title: {
+        default: null
+      },
+      width: {
+        default: null
+      },
+      height: {
+        default: null
+      }
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: this.options.allowBase64 ? "img[src]" : 'img[src]:not([src^="data:"])'
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["img", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+  },
+  parseMarkdown: (token, helpers) => {
+    return helpers.createNode("image", {
+      src: token.href,
+      title: token.title,
+      alt: token.text
+    });
+  },
+  renderMarkdown: (node) => {
+    var _a, _b, _c, _d, _e, _f;
+    const src = (_b = (_a = node.attrs) == null ? void 0 : _a.src) != null ? _b : "";
+    const alt = (_d = (_c = node.attrs) == null ? void 0 : _c.alt) != null ? _d : "";
+    const title = (_f = (_e = node.attrs) == null ? void 0 : _e.title) != null ? _f : "";
+    return title ? `![${alt}](${src} "${title}")` : `![${alt}](${src})`;
+  },
+  addNodeView() {
+    if (!this.options.resize || !this.options.resize.enabled || typeof document === "undefined") {
+      return null;
+    }
+    const { directions, minWidth, minHeight, alwaysPreserveAspectRatio } = this.options.resize;
+    return ({ node, getPos, HTMLAttributes, editor }) => {
+      const el = document.createElement("img");
+      el.draggable = false;
+      const mergedAttributes = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes);
+      Object.entries(mergedAttributes).forEach(([key, value]) => {
+        if (value != null) {
+          switch (key) {
+            case "width":
+            case "height":
+              break;
+            default:
+              el.setAttribute(key, value);
+              break;
+          }
+        }
+      });
+      if (mergedAttributes.src !== null) {
+        el.src = mergedAttributes.src;
+      }
+      const nodeView = new ResizableNodeView({
+        element: el,
+        editor,
+        node,
+        getPos,
+        onResize: (width, height) => {
+          el.style.width = `${width}px`;
+          el.style.height = `${height}px`;
+        },
+        onCommit: (width, height) => {
+          const pos = getPos();
+          if (pos === void 0) {
+            return;
+          }
+          this.editor.chain().setNodeSelection(pos).updateAttributes(this.name, {
+            width,
+            height
+          }).run();
+        },
+        onUpdate: (updatedNode, _decorations, _innerDecorations) => {
+          if (updatedNode.type !== node.type) {
+            return false;
+          }
+          return true;
+        },
+        options: {
+          directions,
+          min: {
+            width: minWidth,
+            height: minHeight
+          },
+          preserveAspectRatio: alwaysPreserveAspectRatio === true
+        }
+      });
+      const dom = nodeView.dom;
+      dom.style.visibility = "hidden";
+      dom.style.pointerEvents = "none";
+      el.onload = () => {
+        dom.style.visibility = "";
+        dom.style.pointerEvents = "";
+      };
+      return nodeView;
+    };
+  },
+  addCommands() {
+    return {
+      setImage: (options) => ({ commands }) => {
+        return commands.insertContent({
+          type: this.name,
+          attrs: options
+        });
+      }
+    };
+  },
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: inputRegex,
+        type: this.type,
+        getAttributes: (match) => {
+          const [, , alt, src, title] = match;
+          return { src, alt, title };
+        }
+      })
+    ];
+  }
+});
+var index_default = Image;
+const ImageBlock = index_default.extend({
+  name: "image",
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      relPath: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-rel-path"),
+        renderHTML: (attributes) => attributes.relPath ? { "data-rel-path": attributes.relPath } : {}
+      }
+    };
+  }
+});
+const voiceBlockCss = '/* SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.\n   SPDX-License-Identifier: GPL-3.0-or-later */\n\n/* Voice block NodeView styles — self-contained, no references to Summernote assets.\n   All SVG icons inlined as data URIs. Theme colors via CSS variables:\n   --highlightColor (play/seek/progress accent), --color (icon foreground),\n   --backgroundColor (divider/borders). Variables set by themeProvided channel. */\n\n.voiceInfoBox {\n    width: 100%;\n    display: flex;\n    flex-direction: column;\n    margin: 4px 0;\n    user-select: none;\n}\n\n.voicePlayback {\n    height: 42px;\n    width: 100%;\n    display: flex;\n    align-items: center;\n    justify-content: space-between;\n    border-radius: 12px;\n}\n\n.voicePlayback .voiceBtn {\n    width: 24px;\n    height: 24px;\n    border-radius: 50%;\n    background-size: contain;\n    background-repeat: no-repeat;\n    background-color: transparent;\n    cursor: pointer;\n    flex-shrink: 0;\n}\n\n/* Progress bar slider */\n.voicePlayback input[type="range"] {\n    margin-left: 10px;\n    margin-right: 10px;\n    width: 50%;\n    height: 24px;\n    -webkit-appearance: none;\n    appearance: none;\n    cursor: pointer;\n    background: repeating-linear-gradient(to right,\n            #BFC0C0,\n            #BFC0C0 2px,\n            transparent 2px,\n            transparent 3px);\n    background-repeat: no-repeat;\n    background-size: 100% 2px;\n    background-position: center;\n    --progressValue: 0%;\n}\n\n.voicePlayback input[type="range"]::-webkit-slider-runnable-track {\n    width: 100%;\n    height: 2px;\n    background: repeating-linear-gradient(to right,\n            var(--highlightColor, #007AFF),\n            var(--highlightColor, #007AFF) 2px,\n            transparent 2px,\n            transparent 3px);\n    background-repeat: no-repeat;\n    background-size: var(--progressValue);\n    border: none;\n    border-radius: 0;\n}\n\n.voicePlayback input[type="range"]::-webkit-slider-thumb {\n    -webkit-appearance: none;\n    appearance: none;\n    width: 16px;\n    height: 16px;\n    background: rgb(77, 77, 77);\n    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.5),\n        0px -1px 0px 0px rgba(0, 0, 0, 0.2) inset;\n    border-radius: 4px;\n    transform: translateY(-7px);\n    cursor: pointer;\n}\n\n.voicePlayback input[type="range"]:focus {\n    outline: none;\n}\n\n.voicePlayback .left {\n    display: flex;\n    align-items: center;\n    gap: 10px;\n    margin-left: 10px;\n    min-width: 160px;\n}\n\n.voicePlayback .left .title {\n    font-size: 14px;\n    color: var(--color, black);\n    overflow: hidden;\n    text-overflow: ellipsis;\n    white-space: nowrap;\n}\n\n.voicePlayback .right {\n    margin-right: 10px;\n    justify-content: right;\n    align-items: center;\n    display: flex;\n    min-width: 100px;\n}\n\n.voicePlayback .right .timeField {\n    font-size: 12px;\n    display: flex;\n}\n\n/* Voice-to-text loading label */\n.voiceToTextLabel {\n    display: flex;\n    align-items: center;\n    justify-content: center;\n}\n\n.voiceToTextLabel .voiceToTextIcon {\n    width: 18px;\n    height: 18px;\n    -webkit-mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI5IiBmaWxsPSJub25lIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMi41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1kYXNoYXJyYXk9IjQyIDYwIi8+PC9zdmc+") no-repeat center/cover;\n    mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI5IiBmaWxsPSJub25lIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMi41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1kYXNoYXJyYXk9IjQyIDYwIi8+PC9zdmc+") no-repeat center/cover;\n    background-color: var(--highlightColor, #007AFF);\n    animation: rotate 2s linear infinite;\n}\n\n@keyframes rotate {\n    0% { transform: rotate(0deg); }\n    100% { transform: rotate(360deg); }\n}\n\n.voiceToTextLabel .translatingLabel {\n    margin-left: 5px;\n    font-weight: 400;\n    font-size: 12px;\n    color: var(--highlightColor, #007AFF);\n}\n\n/* Translate section below the playback bar */\n.translateHeader {\n    width: calc(100% - 32px);\n    height: 30px;\n    margin-left: 16px;\n    margin-right: 16px;\n    display: flex;\n    flex-direction: row;\n    align-items: center;\n    justify-content: center;\n}\n\n.translateHeader .translateIcon {\n    width: 14px;\n    height: 14px;\n    background-color: var(--color, black);\n    -webkit-mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTZweCIgaGVpZ2h0PSIxNnB4IiB2aWV3Qm94PSIwIDAgMTYgMTYiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC92b2ljZV90b190ZXh0L05vcm1hbDwvdGl0bGU+CiAgICA8ZyBpZD0iRC92b2ljZV90b190ZXh0L05vcm1hbCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IklDT04tLy10ZXh0IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxLCAxKSIgZmlsbD0iIzAwMDAwMCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgPHBhdGggZD0iTTEsOSBMMSwxMS4wMDEgQzEsMTIuMTA1NTY5NSAxLjg5NTQzMDUsMTMuMDAxIDMsMTMuMDAxIEw1LDEzIEw1LDE0IEwzLDE0LjAwMSBDMS4zNDMxNDU3NSwxNC4wMDEgMCwxMi42NTc4NTQyIDAsMTEuMDAxIEwwLDkgTDEsOSBaIE0xMC41MDAxMjY1LDYgQzEwLjgyMjM1MTMsNiAxMS4xMTI4ODE5LDYuMTkyMDYxNDYgMTEuMjI5MDk0MSw2LjQ4NjU1NTcgTDEzLjk2ODAwNDgsMTMuMzg1NDAzMyBDMTQuMDg2ODU4MiwxMy42ODI0NTg0IDEzLjg1OTcxNjEsMTQgMTMuNTMyMjA4OSwxNCBDMTMuMzM2NzYxMSwxNCAxMy4xNjI0NDI4LDEzLjg4MjIwMjMgMTMuMDkzNzcxOSwxMy43MDI5NDQ5IEwxMi4zNDYzMTYxLDEyLjAwMDU1NDYgTDguNjQzMzcyMjMsMTIuMDAwNTU0NiBMNy44OTU5MTYzNywxMy43MDgwNjY2IEM3LjgyNzI0NTUxLDEzLjg4MjIwMjMgNy42NTU1NjgzNywxNCA3LjQ2Mjc2MTc1LDE0IEM3LjEzNzg5NTc3LDE0IDYuOTEzMzk0OSwxMy42ODUwMTkyIDcuMDMyMjQ4MjksMTMuMzkwNTI1IEM3LjAyOTYwNzEsMTMuMzkzMDg1OCA5Ljc3MTE1ODk3LDYuNDg2NTU1NyA5Ljc3MTE1ODk5LDYuNDg2NTU1NyBDOS44ODczNzEyLDYuMTk0NjIyMjcgMTAuMTc3OTAxOCw2IDEwLjUwMDEyNjUsNiBaIE0xMC41MzE4MjA4LDYuOTg1OTE1NDkgTDEwLjQ4NjkyMDYsNi45ODU5MTU0OSBMOC45MzY1NDM5NiwxMS4wMDE3Njc2IEwxMi4wNTg0MjY3LDExLjAwMTc2NzYgTDEwLjUzMTgyMDgsNi45ODU5MTU0OSBaIE00LjUsLTkuOTkyMDA3MjJlLTE2IEM0Ljc3NjE0MjM3LC0xLjA0OTkyNzI1ZS0xNSA1LDAuMjIzODU3NjI1IDUsMC41IEw1LDUuNSBDNSw1Ljc3NjE0MjM3IDQuNzc2MTQyMzcsNiA0LjUsNiBDNC4yMjM4NTc2Myw2IDQsNS43NzYxNDIzNyA0LDUuNSBMNCwwLjUgQzQsMC4yMjM4NTc2MjUgNC4yMjM4NTc2MywtOS40ODQ3NDE5MWUtMTYgNC41LC05Ljk5MjAwNzIyZS0xNiBaIE0xMSwwLjAwMSBDMTIuNjU2ODU0MiwwLjAwMSAxNCwxLjM0NDE0NTc1IDE0LDMuMDAxIEwxNCw1IEwxMyw1IEwxMywzLjAwMSBDMTMsMS44OTY0MzA1IDEyLjEwNDU2OTUsMS4wMDEgMTEsMS4wMDEgTDksMSBMOSwtOS45OTIwMDcyMmUtMTYgTDExLDAuMDAxIFogTTIuNSwxIEMyLjc3NjE0MjM3LDEgMywxLjIyMzg1NzYzIDMsMS41IEwzLDQuNSBDMyw0Ljc3NjE0MjM3IDIuNzc2MTQyMzcsNSAyLjUsNSBDMi4yMjM4NTc2Myw1IDIsNC43NzYxNDIzNyAyLDQuNSBMMiwxLjUgQzIsMS4yMjM4NTc2MyAyLjIyMzg1NzYzLDEgMi41LDEgWiBNNi41LDEgQzYuNzc2MTQyMzcsMSA3LDEuMjIzODU3NjMgNywxLjUgTDcsNC41IEM3LDQuNzc2MTQyMzcgNi43NzYxNDIzNyw1IDYuNSw1IEM2LjIyMzg1NzYzLDUgNiw0Ljc3NjE0MjM3IDYsNC41IEw2LDEuNSBDNiwxLjIyMzg1NzYzIDYuMjIzODU3NjMsMSA2LjUsMSBaIE0wLjUsMiBDMC43NzYxNDIzNzUsMiAxLDIuMjIzODU3NjMgMSwyLjUgTDEsMy41IEMxLDMuNzc2MTQyMzcgMC43NzYxNDIzNzUsNCAwLjUsNCBDMC4yMjM4NTc2MjUsNCAzLjM4MTc2ODc2ZS0xNywzLjc3NjE0MjM3IDAsMy41IEwwLDIuNSBDLTMuMzgxNzY4NzZlLTE3LDIuMjIzODU3NjMgMC4yMjM4NTc2MjUsMiAwLjUsMiBaIE04LjUsMiBDOC43NzYxNDIzNywyIDksMi4yMjM4NTc2MyA5LDIuNSBMOSwzLjUgQzksMy43NzYxNDIzNyA4Ljc3NjE0MjM3LDQgOC41LDQgQzguMjIzODU3NjMsNCA4LDMuNzc2MTQyMzcgOCwzLjUgTDgsMi41IEM4LDIuMjIzODU3NjMgOC4yMjM4NTc2MywyIDguNSwyIFoiIGlkPSLlvaLnirbnu5PlkIgiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==") no-repeat center/cover;\n    mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTZweCIgaGVpZ2h0PSIxNnB4IiB2aWV3Qm94PSIwIDAgMTYgMTYiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC92b2ljZV90b190ZXh0L05vcm1hbDwvdGl0bGU+CiAgICA8ZyBpZD0iRC92b2ljZV90b190ZXh0L05vcm1hbCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IklDT04tLy10ZXh0IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxLCAxKSIgZmlsbD0iIzAwMDAwMCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgPHBhdGggZD0iTTEsOSBMMSwxMS4wMDEgQzEsMTIuMTA1NTY5NSAxLjg5NTQzMDUsMTMuMDAxIDMsMTMuMDAxIEw1LDEzIEw1LDE0IEwzLDE0LjAwMSBDMS4zNDMxNDU3NSwxNC4wMDEgMCwxMi42NTc4NTQyIDAsMTEuMDAxIEwwLDkgTDEsOSBaIE0xMC41MDAxMjY1LDYgQzEwLjgyMjM1MTMsNiAxMS4xMTI4ODE5LDYuMTkyMDYxNDYgMTEuMjI5MDk0MSw2LjQ4NjU1NTcgTDEzLjk2ODAwNDgsMTMuMzg1NDAzMyBDMTQuMDg2ODU4MiwxMy42ODI0NTg0IDEzLjg1OTcxNjEsMTQgMTMuNTMyMjA4OSwxNCBDMTMuMzM2NzYxMSwxNCAxMy4xNjI0NDI4LDEzLjg4MjIwMjMgMTMuMDkzNzcxOSwxMy43MDI5NDQ5IEwxMi4zNDYzMTYxLDEyLjAwMDU1NDYgTDguNjQzMzcyMjMsMTIuMDAwNTU0NiBMNy44OTU5MTYzNywxMy43MDgwNjY2IEM3LjgyNzI0NTUxLDEzLjg4MjIwMjMgNy42NTU1NjgzNywxNCA3LjQ2Mjc2MTc1LDE0IEM3LjEzNzg5NTc3LDE0IDYuOTEzMzk0OSwxMy42ODUwMTkyIDcuMDMyMjQ4MjksMTMuMzkwNTI1IEM3LjAyOTYwNzEsMTMuMzkzMDg1OCA5Ljc3MTE1ODk3LDYuNDg2NTU1NyA5Ljc3MTE1ODk5LDYuNDg2NTU1NyBDOS44ODczNzEyLDYuMTk0NjIyMjcgMTAuMTc3OTAxOCw2IDEwLjUwMDEyNjUsNiBaIE0xMC41MzE4MjA4LDYuOTg1OTE1NDkgTDEwLjQ4NjkyMDYsNi45ODU5MTU0OSBMOC45MzY1NDM5NiwxMS4wMDE3Njc2IEwxMi4wNTg0MjY3LDExLjAwMTc2NzYgTDEwLjUzMTgyMDgsNi45ODU5MTU0OSBaIE00LjUsLTkuOTkyMDA3MjJlLTE2IEM0Ljc3NjE0MjM3LC0xLjA0OTkyNzI1ZS0xNSA1LDAuMjIzODU3NjI1IDUsMC41IEw1LDUuNSBDNSw1Ljc3NjE0MjM3IDQuNzc2MTQyMzcsNiA0LjUsNiBDNC4yMjM4NTc2Myw2IDQsNS43NzYxNDIzNyA0LDUuNSBMNCwwLjUgQzQsMC4yMjM4NTc2MjUgNC4yMjM4NTc2MywtOS40ODQ3NDE5MWUtMTYgNC41LC05Ljk5MjAwNzIyZS0xNiBaIE0xMSwwLjAwMSBDMTIuNjU2ODU0MiwwLjAwMSAxNCwxLjM0NDE0NTc1IDE0LDMuMDAxIEwxNCw1IEwxMyw1IEwxMywzLjAwMSBDMTMsMS44OTY0MzA1IDEyLjEwNDU2OTUsMS4wMDEgMTEsMS4wMDEgTDksMSBMOSwtOS45OTIwMDcyMmUtMTYgTDExLDAuMDAxIFogTTIuNSwxIEMyLjc3NjE0MjM3LDEgMywxLjIyMzg1NzYzIDMsMS41IEwzLDQuNSBDMyw0Ljc3NjE0MjM3IDIuNzc2MTQyMzcsNSAyLjUsNSBDMi4yMjM4NTc2Myw1IDIsNC43NzYxNDIzNyAyLDQuNSBMMiwxLjUgQzIsMS4yMjM4NTc2MyAyLjIyMzg1NzYzLDEgMi41LDEgWiBNNi41LDEgQzYuNzc2MTQyMzcsMSA3LDEuMjIzODU3NjMgNywxLjUgTDcsNC41IEM3LDQuNzc2MTQyMzcgNi43NzYxNDIzNyw1IDYuNSw1IEM2LjIyMzg1NzYzLDUgNiw0Ljc3NjE0MjM3IDYsNC41IEw2LDEuNSBDNiwxLjIyMzg1NzYzIDYuMjIzODU3NjMsMSA2LjUsMSBaIE0wLjUsMiBDMC43NzYxNDIzNzUsMiAxLDIuMjIzODU3NjMgMSwyLjUgTDEsMy41IEMxLDMuNzc2MTQyMzcgMC43NzYxNDIzNzUsNCAwLjUsNCBDMC4yMjM4NTc2MjUsNCAzLjM4MTc2ODc2ZS0xNywzLjc3NjE0MjM3IDAsMy41IEwwLDIuNSBDLTMuMzgxNzY4NzZlLTE3LDIuMjIzODU3NjMgMC4yMjM4NTc2MjUsMiAwLjUsMiBaIE04LjUsMiBDOC43NzYxNDIzNywyIDksMi4yMjM4NTc2MyA5LDIuNSBMOSwzLjUgQzksMy43NzYxNDIzNyA4Ljc3NjE0MjM3LDQgOC41LDQgQzguMjIzODU3NjMsNCA4LDMuNzc2MTQyMzcgOCwzLjUgTDgsMi41IEM4LDIuMjIzODU3NjMgOC4yMjM4NTc2MywyIDguNSwyIFoiIGlkPSLlvaLnirbnu5PlkIgiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==") no-repeat center/cover;\n}\n\n.translateHeader .translateLabel {\n    margin-left: 13px;\n    font-size: 12px;\n}\n\n.translateHeader .foldBtn {\n    margin-left: auto;\n    width: 16px;\n    height: 16px;\n    background-color: var(--color, black);\n    -webkit-mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTZweCIgaGVpZ2h0PSIxNnB4IiB2aWV3Qm94PSIwIDAgMTYgMTYiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC91bmZvbGQvTm9ybWFsPC90aXRsZT4KICAgIDxnIGlkPSJEL3VuZm9sZC9Ob3JtYWwiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSLkuIvmi4nnrq3lpLQtMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNy45NDY3LCA4LjQwNzQpIHNjYWxlKDEsIC0xKSB0cmFuc2xhdGUoLTcuOTQ2NywgLTguNDA3NCl0cmFuc2xhdGUoMi40MjY3LCA1LjI0NzQpIiBmaWxsPSIjMDAwMDAwIiBmaWxsLXJ1bGU9Im5vbnplcm8iPgogICAgICAgICAgICA8ZyBpZD0iRFRLLS/oj5zljZUvLU1lbnVpdGVtLS8tQXJyb3ciIHRyYW5zZm9ybT0idHJhbnNsYXRlKDUuNTIsIDMuMTYpIHNjYWxlKDEsIC0xKSByb3RhdGUoLTI3MCkgdHJhbnNsYXRlKC01LjUyLCAtMy4xNil0cmFuc2xhdGUoMi4zNiwgLTIuMzYpIj4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLjIzNDMxNDU3NSwwLjIzNDMxNDU3NSBDMC41MTIwMjA3MzgsLTAuMDQzMzkxNTg4IDAuOTQzMDk5NzgsLTAuMDc0MjQ3ODI4MyAxLjI1NDg4ODgsMC4xNDE3NDU4NTQgTDEuMzY1Njg1NDIsMC4yMzQzMTQ1NzUgTDYuMDg1Njg1MzcsNC45NTQzMTQ1MiBDNi4zNjMzOTE1NCw1LjIzMjAyMDY5IDYuMzk0MjQ3NzgsNS42NjMwOTk3MyA2LjE3ODI1NDEsNS45NzQ4ODg3NSBMNi4wODU2ODUzNyw2LjA4NTY4NTM3IEwxLjM2NTY4NTQyLDEwLjgwNTY4NTMgQzEuMDUzMjY1OTksMTEuMTE4MTA0OCAwLjU0NjczNDAwOCwxMS4xMTgxMDQ4IDAuMjM0MzE0NTc1LDEwLjgwNTY4NTMgQy0wLjA0MzM5MTU4OCwxMC41Mjc5NzkyIC0wLjA3NDI0NzgyODMsMTAuMDk2OTAwMSAwLjE0MTc0NTg1NCw5Ljc4NTExMTA5IEwwLjIzNDMxNDU3NSw5LjY3NDMxNDQ3IEw0LjM4ODYyMTQ2LDUuNTIgTDAuMjM0MzE0NTc1LDEuMzY1Njg1NDIgQy0wLjA0MzM5MTU4OCwxLjA4Nzk3OTI2IC0wLjA3NDI0NzgyODMsMC42NTY5MDAyMiAwLjE0MTc0NTg1NCwwLjM0NTExMTE5NSBMMC4yMzQzMTQ1NzUsMC4yMzQzMTQ1NzUgWiIgaWQ9IuiPnOWNleeureWktOmAieS4rSI+PC9wYXRoPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=") no-repeat center/cover;\n    mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTZweCIgaGVpZ2h0PSIxNnB4IiB2aWV3Qm94PSIwIDAgMTYgMTYiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC91bmZvbGQvTm9ybWFsPC90aXRsZT4KICAgIDxnIGlkPSJEL3VuZm9sZC9Ob3JtYWwiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSLkuIvmi4nnrq3lpLQtMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNy45NDY3LCA4LjQwNzQpIHNjYWxlKDEsIC0xKSB0cmFuc2xhdGUoLTcuOTQ2NywgLTguNDA3NCl0cmFuc2xhdGUoMi40MjY3LCA1LjI0NzQpIiBmaWxsPSIjMDAwMDAwIiBmaWxsLXJ1bGU9Im5vbnplcm8iPgogICAgICAgICAgICA8ZyBpZD0iRFRLLS/oj5zljZUvLU1lbnVpdGVtLS8tQXJyb3ciIHRyYW5zZm9ybT0idHJhbnNsYXRlKDUuNTIsIDMuMTYpIHNjYWxlKDEsIC0xKSByb3RhdGUoLTI3MCkgdHJhbnNsYXRlKC01LjUyLCAtMy4xNil0cmFuc2xhdGUoMi4zNiwgLTIuMzYpIj4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLjIzNDMxNDU3NSwwLjIzNDMxNDU3NSBDMC41MTIwMjA3MzgsLTAuMDQzMzkxNTg4IDAuOTQzMDk5NzgsLTAuMDc0MjQ3ODI4MyAxLjI1NDg4ODgsMC4xNDE3NDU4NTQgTDEuMzY1Njg1NDIsMC4yMzQzMTQ1NzUgTDYuMDg1Njg1MzcsNC45NTQzMTQ1MiBDNi4zNjMzOTE1NCw1LjIzMjAyMDY5IDYuMzk0MjQ3NzgsNS42NjMwOTk3MyA2LjE3ODI1NDEsNS45NzQ4ODg3NSBMNi4wODU2ODUzNyw2LjA4NTY4NTM3IEwxLjM2NTY4NTQyLDEwLjgwNTY4NTMgQzEuMDUzMjY1OTksMTEuMTE4MTA0OCAwLjU0NjczNDAwOCwxMS4xMTgxMDQ4IDAuMjM0MzE0NTc1LDEwLjgwNTY4NTMgQy0wLjA0MzM5MTU4OCwxMC41Mjc5NzkyIC0wLjA3NDI0NzgyODMsMTAuMDk2OTAwMSAwLjE0MTc0NTg1NCw5Ljc4NTExMTA5IEwwLjIzNDMxNDU3NSw5LjY3NDMxNDQ3IEw0LjM4ODYyMTQ2LDUuNTIgTDAuMjM0MzE0NTc1LDEuMzY1Njg1NDIgQy0wLjA0MzM5MTU4OCwxLjA4Nzk3OTI2IC0wLjA3NDI0NzgyODMsMC42NTY5MDAyMiAwLjE0MTc0NTg1NCwwLjM0NTExMTE5NSBMMC4yMzQzMTQ1NzUsMC4yMzQzMTQ1NzUgWiIgaWQ9IuiPnOWNleeureWktOmAieS4rSI+PC9wYXRoPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=") no-repeat center/cover;\n    cursor: pointer;\n}\n\n.translateHeader.unfold .foldBtn {\n    -webkit-mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTZweCIgaGVpZ2h0PSIxNnB4IiB2aWV3Qm94PSIwIDAgMTYgMTYiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9mb2xkL05vcm1hbDwvdGl0bGU+CiAgICA8ZyBpZD0iRC9mb2xkL05vcm1hbCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IuS4i+aLieeureWktC0yIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyLjQyNjcsIDQuNDMyNikiIGZpbGw9IiMwMDAwMDAiIGZpbGwtcnVsZT0ibm9uemVybyI+CiAgICAgICAgICAgIDxnIGlkPSJEVEstL+iPnOWNlS8tTWVudWl0ZW0tLy1BcnJvdyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNS41MiwgMy4xNikgc2NhbGUoMSwgLTEpIHJvdGF0ZSgtMjcwKSB0cmFuc2xhdGUoLTUuNTIsIC0zLjE2KXRyYW5zbGF0ZSgyLjM2LCAtMi4zNikiPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTAuMjM0MzE0NTc1LDAuMjM0MzE0NTc1IEMwLjUxMjAyMDczOCwtMC4wNDMzOTE1ODggMC45NDMwOTk3OCwtMC4wNzQyNDc4MjgzIDEuMjU0ODg4OCwwLjE0MTc0NTg1NCBMMS4zNjU2ODU0MiwwLjIzNDMxNDU3NSBMNi4wODU2ODUzNyw0Ljk1NDMxNDUyIEM2LjM2MzM5MTU0LDUuMjMyMDIwNjkgNi4zOTQyNDc3OCw1LjY2MzA5OTczIDYuMTc4MjU0MSw1Ljk3NDg4ODc1IEw2LjA4NTY4NTM3LDYuMDg1Njg1MzcgTDEuMzY1Njg1NDIsMTAuODA1Njg1MyBDMS4wNTMyNjU5OSwxMS4xMTgxMDQ4IDAuNTQ2NzM0MDA4LDExLjExODEwNDggMC4yMzQzMTQ1NzUsMTAuODA1Njg1MyBDLTAuMDQzMzkxNTg4LDEwLjUyNzk3OTIgLTAuMDc0MjQ3ODI4MywxMC4wOTY5MDAxIDAuMTQxNzQ1ODU0LDkuNzg1MTExMDkgTDAuMjM0MzE0NTc1LDkuNjc0MzE0NDcgTDQuMzg4NjIxNDYsNS41MiBMMC4yMzQzMTQ1NzUsMS4zNjU2ODU0MiBDLTAuMDQzMzkxNTg4LDEuMDg3OTc5MjYgLTAuMDc0MjQ3ODI4MywwLjY1NjkwMDIyIDAuMTQxNzQ1ODU0LDAuMzQ1MTExMTk1IEwwLjIzNDMxNDU3NSwwLjIzNDMxNDU3NSBaIiBpZD0i6I+c5Y2V566t5aS06YCJ5LitIj48L3BhdGg+CiAgICAgICAgICAgIDwvZz4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==") no-repeat center/cover;\n    mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTZweCIgaGVpZ2h0PSIxNnB4IiB2aWV3Qm94PSIwIDAgMTYgMTYiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9mb2xkL05vcm1hbDwvdGl0bGU+CiAgICA8ZyBpZD0iRC9mb2xkL05vcm1hbCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IuS4i+aLieeureWktC0yIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyLjQyNjcsIDQuNDMyNikiIGZpbGw9IiMwMDAwMDAiIGZpbGwtcnVsZT0ibm9uemVybyI+CiAgICAgICAgICAgIDxnIGlkPSJEVEstL+iPnOWNlS8tTWVudWl0ZW0tLy1BcnJvdyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNS41MiwgMy4xNikgc2NhbGUoMSwgLTEpIHJvdGF0ZSgtMjcwKSB0cmFuc2xhdGUoLTUuNTIsIC0zLjE2KXRyYW5zbGF0ZSgyLjM2LCAtMi4zNikiPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTAuMjM0MzE0NTc1LDAuMjM0MzE0NTc1IEMwLjUxMjAyMDczOCwtMC4wNDMzOTE1ODggMC45NDMwOTk3OCwtMC4wNzQyNDc4MjgzIDEuMjU0ODg4OCwwLjE0MTc0NTg1NCBMMS4zNjU2ODU0MiwwLjIzNDMxNDU3NSBMNi4wODU2ODUzNyw0Ljk1NDMxNDUyIEM2LjM2MzM5MTU0LDUuMjMyMDIwNjkgNi4zOTQyNDc3OCw1LjY2MzA5OTczIDYuMTc4MjU0MSw1Ljk3NDg4ODc1IEw2LjA4NTY4NTM3LDYuMDg1Njg1MzcgTDEuMzY1Njg1NDIsMTAuODA1Njg1MyBDMS4wNTMyNjU5OSwxMS4xMTgxMDQ4IDAuNTQ2NzM0MDA4LDExLjExODEwNDggMC4yMzQzMTQ1NzUsMTAuODA1Njg1MyBDLTAuMDQzMzkxNTg4LDEwLjUyNzk3OTIgLTAuMDc0MjQ3ODI4MywxMC4wOTY5MDAxIDAuMTQxNzQ1ODU0LDkuNzg1MTExMDkgTDAuMjM0MzE0NTc1LDkuNjc0MzE0NDcgTDQuMzg4NjIxNDYsNS41MiBMMC4yMzQzMTQ1NzUsMS4zNjU2ODU0MiBDLTAuMDQzMzkxNTg4LDEuMDg3OTc5MjYgLTAuMDc0MjQ3ODI4MywwLjY1NjkwMDIyIDAuMTQxNzQ1ODU0LDAuMzQ1MTExMTk1IEwwLjIzNDMxNDU3NSwwLjIzNDMxNDU3NSBaIiBpZD0i6I+c5Y2V566t5aS06YCJ5LitIj48L3BhdGg+CiAgICAgICAgICAgIDwvZz4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==") no-repeat center/cover;\n}\n\n.voiceInfoBox .translateText {\n    margin-left: 20px;\n    margin-right: 20px;\n    margin-bottom: 12px;\n    font-size: 14px;\n    text-align: left;\n    white-space: pre-wrap;\n    word-break: break-word;\n    cursor: text;\n    user-select: text;\n    -webkit-user-select: text;\n}\n\n.voiceInfoBox .translateText::selection {\n    background: rgba(0, 129, 255, 0.3);\n    color: inherit;\n}\n\n\n/* Voice-to-text trigger (idle state entry point) */\n.voicePlayback .voiceToTextTrigger {\n    font-size: 12px;\n    color: var(--highlightColor, #007AFF);\n    cursor: pointer;\n    white-space: nowrap;\n}\n\n.voicePlayback.play .voiceToTextTrigger,\n.voicePlayback.pause .voiceToTextTrigger,\n.voicePlayback.voiceToText .voiceToTextTrigger,\n.voicePlayback.unplayable .voiceToTextTrigger {\n    display: none;\n}\n\n/* State control: component visibility by playback state */\n.voicePlayback .progressBar,\n.voicePlayback .timePassed,\n.voicePlayback .voiceToTextLabel {\n    display: none;\n}\n\n.voicePlayback.play .progressBar,\n.voicePlayback.play .timePassed {\n    display: flex;\n}\n\n.voicePlayback.play .voiceToTextLabel {\n    display: none;\n}\n\n.voicePlayback.voiceToText .timeField {\n    display: none;\n}\n\n.voicePlayback.voiceToText .voiceToTextLabel {\n    display: flex;\n}\n\n.voiceInfoBox.containText .voicePlayback {\n    border-radius: 12px 12px 0px 0px;\n}\n\n.voiceInfoBox .translate {\n    display: none;\n}\n\n.voiceInfoBox.containText .translate {\n    display: flex;\n    flex-direction: column;\n    border-radius: 0px 0px 12px 12px;\n    border-top: 1px solid var(--backgroundColor, #e0e0e0);\n}\n\n/* State control: button icons by playback state */\n/* Default play button */\n.voicePlayback .voiceBtn {\n    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXkvTm9ybWFsL0xpZ2h0PC90aXRsZT4KICAgIDxnIGlkPSJEL2F1ZGlvX2ZpbGVfcGxheS9Ob3JtYWwvTGlnaHQiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJJQ09OL2F1ZGlvL2ZpbGUvbm9ybWFsIj4KICAgICAgICAgICAgPHBhdGggZD0iTTEyLDAgQzE4LjYyNzQxNywwIDI0LDUuMzcyNTgzIDI0LDEyIEMyNCwxOC42Mjc0MTcgMTguNjI3NDE3LDI0IDEyLDI0IEM1LjM3MjU4MywyNCAwLDE4LjYyNzQxNyAwLDEyIEMwLDUuMzcyNTgzIDUuMzcyNTgzLDAgMTIsMCBaIiBpZD0i6Lev5b6EIiBmaWxsPSIjRkZGRkZGIj48L3BhdGg+CiAgICAgICAgICAgIDxwYXRoIGQ9Ik0xMC45NTAzNjQyLDcuMjkzNTYwNTkgQzkuODczMjA3OCw2LjU4ODc5NDM0IDksNy4xOTc0OTUyMSA5LDguNjQzMzA3ODYgTDksMTUuMzU2OTQ1MyBDOSwxNi44MDcxNTY0IDkuODc2NzQ4MjksMTcuNDA5MTQyNCAxMC45NTAzNjQyLDE2LjcwNjY5MjYgTDE2LjE5MzQ1OTgsMTMuMjc2MjE4OCBDMTcuMjcwNjE2MiwxMi41NzE0NTI1IDE3LjI2NzA3NTcsMTEuNDI2NDg0MiAxNi4xOTM0NTk4LDEwLjcyNDAzNDQgTDEwLjk1MDM2NDIsNy4yOTM1NjA1OSBaIiBpZD0icGxheSIgZmlsbD0iIzAwNThERSI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+");\n}\n\n.voicePlayback .voiceBtn:hover {\n    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXkvSG92ZXIvTGlnaHQ8L3RpdGxlPgogICAgPGcgaWQ9IkQvYXVkaW9fZmlsZV9wbGF5L0hvdmVyL0xpZ2h0IiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iSUNPTi9hdWRpby9maWxlL25vcm1hbCI+CiAgICAgICAgICAgIDxwYXRoIGQ9Ik0xMiwwIEMxOC42Mjc0MTcsMCAyNCw1LjM3MjU4MyAyNCwxMiBDMjQsMTguNjI3NDE3IDE4LjYyNzQxNywyNCAxMiwyNCBDNS4zNzI1ODMsMjQgMCwxOC42Mjc0MTcgMCwxMiBDMCw1LjM3MjU4MyA1LjM3MjU4MywwIDEyLDAgWiIgaWQ9Iui3r+W+hCIgZmlsbD0iI0U2RTZFNiI+PC9wYXRoPgogICAgICAgICAgICA8cGF0aCBkPSJNMTAuOTUwMzY0Miw3LjI5MzU2MDU5IEM5Ljg3MzIwNzgsNi41ODg3OTQzNCA5LDcuMTk3NDk1MjEgOSw4LjY0MzMwNzg2IEw5LDE1LjM1Njk0NTMgQzksMTYuODA3MTU2NCA5Ljg3Njc0ODI5LDE3LjQwOTE0MjQgMTAuOTUwMzY0MiwxNi43MDY2OTI2IEwxNi4xOTM0NTk4LDEzLjI3NjIxODggQzE3LjI3MDYxNjIsMTIuNTcxNDUyNSAxNy4yNjcwNzU3LDExLjQyNjQ4NDIgMTYuMTkzNDU5OCwxMC43MjQwMzQ0IEwxMC45NTAzNjQyLDcuMjkzNTYwNTkgWiIgaWQ9InBsYXkiIGZpbGw9IiMwMDU4REUiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==");\n}\n\n.voicePlayback .voiceBtn:active {\n    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXkvUHJlc3NlZC9MaWdodDwvdGl0bGU+CiAgICA8ZGVmcz4KICAgICAgICA8bGluZWFyR3JhZGllbnQgeDE9IjUwJSIgeTE9Ii0xLjkyNzYyNDczZS0xMiUiIHgyPSI1MCUiIHkyPSI5OS4yMzc4NzE1JSIgaWQ9ImxpbmVhckdyYWRpZW50LTEiPgogICAgICAgICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjQTlBOUE5IiBzdG9wLW9wYWNpdHk9IjAuNiIgb2Zmc2V0PSIwJSI+PC9zdG9wPgogICAgICAgICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjQ0FDQUNBIiBzdG9wLW9wYWNpdHk9IjAuNSIgb2Zmc2V0PSIxMDAlIj48L3N0b3A+CiAgICAgICAgPC9saW5lYXJHcmFkaWVudD4KICAgIDwvZGVmcz4KICAgIDxnIGlkPSJEL2F1ZGlvX2ZpbGVfcGxheS9QcmVzc2VkL0xpZ2h0IiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iSUNPTi9hdWRpby9maWxlL25vcm1hbCI+CiAgICAgICAgICAgIDxwYXRoIGQ9Ik0xMiwwIEMxOC42Mjc0MTcsMCAyNCw1LjM3MjU4MyAyNCwxMiBDMjQsMTguNjI3NDE3IDE4LjYyNzQxNywyNCAxMiwyNCBDNS4zNzI1ODMsMjQgMCwxOC42Mjc0MTcgMCwxMiBDMCw1LjM3MjU4MyA1LjM3MjU4MywwIDEyLDAgWiIgaWQ9Iui3r+W+hCIgZmlsbD0idXJsKCNsaW5lYXJHcmFkaWVudC0xKSI+PC9wYXRoPgogICAgICAgICAgICA8cGF0aCBkPSJNMTAuOTUwMzY0Miw3LjI5MzU2MDU5IEM5Ljg3MzIwNzgsNi41ODg3OTQzNCA5LDcuMTk3NDk1MjEgOSw4LjY0MzMwNzg2IEw5LDE1LjM1Njk0NTMgQzksMTYuODA3MTU2NCA5Ljg3Njc0ODI5LDE3LjQwOTE0MjQgMTAuOTUwMzY0MiwxNi43MDY2OTI2IEwxNi4xOTM0NTk4LDEzLjI3NjIxODggQzE3LjI3MDYxNjIsMTIuNTcxNDUyNSAxNy4yNjcwNzU3LDExLjQyNjQ4NDIgMTYuMTkzNDU5OCwxMC43MjQwMzQ0IEwxMC45NTAzNjQyLDcuMjkzNTYwNTkgWiIgaWQ9InBsYXkiIGZpbGw9IiMwMDU4REUiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==");\n}\n\n/* Playing state: show pause icon */\n.voicePlayback.play .voiceBtn {\n    background-image: none;\n    background-color: var(--color, black);\n    -webkit-mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXlpbmdfcGF1c2UvTm9ybWFsPC90aXRsZT4KICAgIDxnIGlkPSJEL2F1ZGlvX2ZpbGVfcGxheWluZ19wYXVzZS9Ob3JtYWwiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJJQ09OL2F1ZGlvL2ZpbGUvbm9ybWFsIiBmaWxsPSIjMDAwMDAwIiBmaWxsLXJ1bGU9Im5vbnplcm8iPgogICAgICAgICAgICA8cGF0aCBkPSJNMTIsMCBDMTguNjI3NDE3LDAgMjQsNS4zNzI1ODMgMjQsMTIgQzI0LDE4LjYyNzQxNyAxOC42Mjc0MTcsMjQgMTIsMjQgQzUuMzcyNTgzLDI0IDAsMTguNjI3NDE3IDAsMTIgQzAsNS4zNzI1ODMgNS4zNzI1ODMsMCAxMiwwIFogTTEyLDEgQzUuOTI0ODY3NzUsMSAxLDUuOTI0ODY3NzUgMSwxMiBDMSwxOC4wNzUxMzIyIDUuOTI0ODY3NzUsMjMgMTIsMjMgQzE4LjA3NTEzMjIsMjMgMjMsMTguMDc1MTMyMiAyMywxMiBDMjMsNS45MjQ4Njc3NSAxOC4wNzUxMzIyLDEgMTIsMSBaIE05LjMzMzMzMzMzLDcgQzkuNzAxNTIzMTcsNyAxMCw3LjI5ODQ3NjgzIDEwLDcuNjY2NjY2NjcgTDEwLDE2LjMzMzMzMzMgQzEwLDE2LjcwMTUyMzIgOS43MDE1MjMxNywxNyA5LjMzMzMzMzMzLDE3IEw4LjY2NjY2NjY3LDE3IEM4LjI5ODQ3NjgzLDE3IDgsMTYuNzAxNTIzMiA4LDE2LjMzMzMzMzMgTDgsNy42NjY2NjY2NyBDOCw3LjI5ODQ3NjgzIDguMjk4NDc2ODMsNyA4LjY2NjY2NjY3LDcgTDkuMzMzMzMzMzMsNyBaIE0xNS4zMzMzMzMzLDcgQzE1LjcwMTUyMzIsNyAxNiw3LjI5ODQ3NjgzIDE2LDcuNjY2NjY2NjcgTDE2LDE2LjMzMzMzMzMgQzE2LDE2LjcwMTUyMzIgMTUuNzAxNTIzMiwxNyAxNS4zMzMzMzMzLDE3IEwxNC42NjY2NjY3LDE3IEMxNC4yOTg0NzY4LDE3IDE0LDE2LjcwMTUyMzIgMTQsMTYuMzMzMzMzMyBMMTQsNy42NjY2NjY2NyBDMTQsNy4yOTg0NzY4MyAxNC4yOTg0NzY4LDcgMTQuNjY2NjY2Nyw3IEwxNS4zMzMzMzMzLDcgWiIgaWQ9IuW9oueKtue7k+WQiCI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+") no-repeat center/cover;\n    mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXlpbmdfcGF1c2UvTm9ybWFsPC90aXRsZT4KICAgIDxnIGlkPSJEL2F1ZGlvX2ZpbGVfcGxheWluZ19wYXVzZS9Ob3JtYWwiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJJQ09OL2F1ZGlvL2ZpbGUvbm9ybWFsIiBmaWxsPSIjMDAwMDAwIiBmaWxsLXJ1bGU9Im5vbnplcm8iPgogICAgICAgICAgICA8cGF0aCBkPSJNMTIsMCBDMTguNjI3NDE3LDAgMjQsNS4zNzI1ODMgMjQsMTIgQzI0LDE4LjYyNzQxNyAxOC42Mjc0MTcsMjQgMTIsMjQgQzUuMzcyNTgzLDI0IDAsMTguNjI3NDE3IDAsMTIgQzAsNS4zNzI1ODMgNS4zNzI1ODMsMCAxMiwwIFogTTEyLDEgQzUuOTI0ODY3NzUsMSAxLDUuOTI0ODY3NzUgMSwxMiBDMSwxOC4wNzUxMzIyIDUuOTI0ODY3NzUsMjMgMTIsMjMgQzE4LjA3NTEzMjIsMjMgMjMsMTguMDc1MTMyMiAyMywxMiBDMjMsNS45MjQ4Njc3NSAxOC4wNzUxMzIyLDEgMTIsMSBaIE05LjMzMzMzMzMzLDcgQzkuNzAxNTIzMTcsNyAxMCw3LjI5ODQ3NjgzIDEwLDcuNjY2NjY2NjcgTDEwLDE2LjMzMzMzMzMgQzEwLDE2LjcwMTUyMzIgOS43MDE1MjMxNywxNyA5LjMzMzMzMzMzLDE3IEw4LjY2NjY2NjY3LDE3IEM4LjI5ODQ3NjgzLDE3IDgsMTYuNzAxNTIzMiA4LDE2LjMzMzMzMzMgTDgsNy42NjY2NjY2NyBDOCw3LjI5ODQ3NjgzIDguMjk4NDc2ODMsNyA4LjY2NjY2NjY3LDcgTDkuMzMzMzMzMzMsNyBaIE0xNS4zMzMzMzMzLDcgQzE1LjcwMTUyMzIsNyAxNiw3LjI5ODQ3NjgzIDE2LDcuNjY2NjY2NjcgTDE2LDE2LjMzMzMzMzMgQzE2LDE2LjcwMTUyMzIgMTUuNzAxNTIzMiwxNyAxNS4zMzMzMzMzLDE3IEwxNC42NjY2NjY3LDE3IEMxNC4yOTg0NzY4LDE3IDE0LDE2LjcwMTUyMzIgMTQsMTYuMzMzMzMzMyBMMTQsNy42NjY2NjY2NyBDMTQsNy4yOTg0NzY4MyAxNC4yOTg0NzY4LDcgMTQuNjY2NjY2Nyw3IEwxNS4zMzMzMzMzLDcgWiIgaWQ9IuW9oueKtue7k+WQiCI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+") no-repeat center/cover;\n}\n\n.voicePlayback.play .voiceBtn:hover,\n.voicePlayback.play .voiceBtn:active {\n    background-image: none;\n    background-color: var(--color, black);\n}\n\n/* Paused state: show play icon */\n.voicePlayback.pause .voiceBtn {\n    background-image: none;\n    background-color: var(--color, black);\n    -webkit-mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXlpbmdfcGxheS9Ob3JtYWw8L3RpdGxlPgogICAgPGcgaWQ9IkQvYXVkaW9fZmlsZV9wbGF5aW5nX3BsYXkvTm9ybWFsIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iSUNPTi9hdWRpby9maWxlL25vcm1hbCIgZmlsbD0iIzAwMDAwMCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgPHBhdGggZD0iTTEyLDAgQzE4LjYyNzQxNywwIDI0LDUuMzcyNTgzIDI0LDEyIEMyNCwxOC42Mjc0MTcgMTguNjI3NDE3LDI0IDEyLDI0IEM1LjM3MjU4MywyNCAwLDE4LjYyNzQxNyAwLDEyIEMwLDUuMzcyNTgzIDUuMzcyNTgzLDAgMTIsMCBaIE0xMiwxIEM1LjkyNDg2Nzc1LDEgMSw1LjkyNDg2Nzc1IDEsMTIgQzEsMTguMDc1MTMyMiA1LjkyNDg2Nzc1LDIzIDEyLDIzIEMxOC4wNzUxMzIyLDIzIDIzLDE4LjA3NTEzMjIgMjMsMTIgQzIzLDUuOTI0ODY3NzUgMTguMDc1MTMyMiwxIDEyLDEgWiBNOSw4LjY0MzMwNzg2IEM5LDcuMTk3NDk1MjEgOS44NzMyMDc4LDYuNTg4Nzk0MzQgMTAuOTUwMzY0Miw3LjI5MzU2MDU5IEwxNi4xOTM0NTk4LDEwLjcyNDAzNDQgQzE3LjI2NzA3NTcsMTEuNDI2NDg0MiAxNy4yNzA2MTYyLDEyLjU3MTQ1MjUgMTYuMTkzNDU5OCwxMy4yNzYyMTg4IEwxMC45NTAzNjQyLDE2LjcwNjY5MjYgQzkuODc2NzQ4MjksMTcuNDA5MTQyNCA5LDE2LjgwNzE1NjQgOSwxNS4zNTY5NDUzIFoiIGlkPSLlvaLnirbnu5PlkIgiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==") no-repeat center/cover;\n    mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXlpbmdfcGxheS9Ob3JtYWw8L3RpdGxlPgogICAgPGcgaWQ9IkQvYXVkaW9fZmlsZV9wbGF5aW5nX3BsYXkvTm9ybWFsIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iSUNPTi9hdWRpby9maWxlL25vcm1hbCIgZmlsbD0iIzAwMDAwMCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgPHBhdGggZD0iTTEyLDAgQzE4LjYyNzQxNywwIDI0LDUuMzcyNTgzIDI0LDEyIEMyNCwxOC42Mjc0MTcgMTguNjI3NDE3LDI0IDEyLDI0IEM1LjM3MjU4MywyNCAwLDE4LjYyNzQxNyAwLDEyIEMwLDUuMzcyNTgzIDUuMzcyNTgzLDAgMTIsMCBaIE0xMiwxIEM1LjkyNDg2Nzc1LDEgMSw1LjkyNDg2Nzc1IDEsMTIgQzEsMTguMDc1MTMyMiA1LjkyNDg2Nzc1LDIzIDEyLDIzIEMxOC4wNzUxMzIyLDIzIDIzLDE4LjA3NTEzMjIgMjMsMTIgQzIzLDUuOTI0ODY3NzUgMTguMDc1MTMyMiwxIDEyLDEgWiBNOSw4LjY0MzMwNzg2IEM5LDcuMTk3NDk1MjEgOS44NzMyMDc4LDYuNTg4Nzk0MzQgMTAuOTUwMzY0Miw3LjI5MzU2MDU5IEwxNi4xOTM0NTk4LDEwLjcyNDAzNDQgQzE3LjI2NzA3NTcsMTEuNDI2NDg0MiAxNy4yNzA2MTYyLDEyLjU3MTQ1MjUgMTYuMTkzNDU5OCwxMy4yNzYyMTg4IEwxMC45NTAzNjQyLDE2LjcwNjY5MjYgQzkuODc2NzQ4MjksMTcuNDA5MTQyNCA5LDE2LjgwNzE1NjQgOSwxNS4zNTY5NDUzIFoiIGlkPSLlvaLnirbnu5PlkIgiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==") no-repeat center/cover;\n}\n\n.voicePlayback.pause .voiceBtn:hover,\n.voicePlayback.pause .voiceBtn:active {\n    background-image: none;\n    background-color: var(--color, black);\n}\n\n/* File missing: unplayable state — disable play button, keep text */\n.voicePlayback.unplayable .voiceBtn {\n    background-image: none;\n    background-color: #ccc;\n    -webkit-mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXlpbmdfcGxheS9Ob3JtYWw8L3RpdGxlPgogICAgPGcgaWQ9IkQvYXVkaW9fZmlsZV9wbGF5aW5nX3BsYXkvTm9ybWFsIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iSUNPTi9hdWRpby9maWxlL25vcm1hbCIgZmlsbD0iIzAwMDAwMCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgPHBhdGggZD0iTTEyLDAgQzE4LjYyNzQxNywwIDI0LDUuMzcyNTgzIDI0LDEyIEMyNCwxOC42Mjc0MTcgMTguNjI3NDE3LDI0IDEyLDI0IEM1LjM3MjU4MywyNCAwLDE4LjYyNzQxNyAwLDEyIEMwLDUuMzcyNTgzIDUuMzcyNTgzLDAgMTIsMCBaIE0xMiwxIEM1LjkyNDg2Nzc1LDEgMSw1LjkyNDg2Nzc1IDEsMTIgQzEsMTguMDc1MTMyMiA1LjkyNDg2Nzc1LDIzIDEyLDIzIEMxOC4wNzUxMzIyLDIzIDIzLDE4LjA3NTEzMjIgMjMsMTIgQzIzLDUuOTI0ODY3NzUgMTguMDc1MTMyMiwxIDEyLDEgWiBNOSw4LjY0MzMwNzg2IEM5LDcuMTk3NDk1MjEgOS44NzMyMDc4LDYuNTg4Nzk0MzQgMTAuOTUwMzY0Miw3LjI5MzU2MDU5IEwxNi4xOTM0NTk4LDEwLjcyNDAzNDQgQzE3LjI2NzA3NTcsMTEuNDI2NDg0MiAxNy4yNzA2MTYyLDEyLjU3MTQ1MjUgMTYuMTkzNDU5OCwxMy4yNzYyMTg4IEwxMC45NTAzNjQyLDE2LjcwNjY5MjYgQzkuODc2NzQ4MjksMTcuNDA5MTQyNCA5LDE2LjgwNzE1NjQgOSwxNS4zNTY5NDUzIFoiIGlkPSLlvaLnirbnu5PlkIgiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==") no-repeat center/cover;\n    mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNHB4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+RC9hdWRpb19maWxlX3BsYXlpbmdfcGxheS9Ob3JtYWw8L3RpdGxlPgogICAgPGcgaWQ9IkQvYXVkaW9fZmlsZV9wbGF5aW5nX3BsYXkvTm9ybWFsIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iSUNPTi9hdWRpby9maWxlL25vcm1hbCIgZmlsbD0iIzAwMDAwMCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgPHBhdGggZD0iTTEyLDAgQzE4LjYyNzQxNywwIDI0LDUuMzcyNTgzIDI0LDEyIEMyNCwxOC42Mjc0MTcgMTguNjI3NDE3LDI0IDEyLDI0IEM1LjM3MjU4MywyNCAwLDE4LjYyNzQxNyAwLDEyIEMwLDUuMzcyNTgzIDUuMzcyNTgzLDAgMTIsMCBaIE0xMiwxIEM1LjkyNDg2Nzc1LDEgMSw1LjkyNDg2Nzc1IDEsMTIgQzEsMTguMDc1MTMyMiA1LjkyNDg2Nzc1LDIzIDEyLDIzIEMxOC4wNzUxMzIyLDIzIDIzLDE4LjA3NTEzMjIgMjMsMTIgQzIzLDUuOTI0ODY3NzUgMTguMDc1MTMyMiwxIDEyLDEgWiBNOSw4LjY0MzMwNzg2IEM5LDcuMTk3NDk1MjEgOS44NzMyMDc4LDYuNTg4Nzk0MzQgMTAuOTUwMzY0Miw3LjI5MzU2MDU5IEwxNi4xOTM0NTk4LDEwLjcyNDAzNDQgQzE3LjI2NzA3NTcsMTEuNDI2NDg0MiAxNy4yNzA2MTYyLDEyLjU3MTQ1MjUgMTYuMTkzNDU5OCwxMy4yNzYyMTg4IEwxMC45NTAzNjQyLDE2LjcwNjY5MjYgQzkuODc2NzQ4MjksMTcuNDA5MTQyNCA5LDE2LjgwNzE1NjQgOSwxNS4zNTY5NDUzIFoiIGlkPSLlvaLnirbnu5PlkIgiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==") no-repeat center/cover;\n    cursor: not-allowed;\n    opacity: 0.4;\n}\n\n.voicePlayback.unplayable .progressBar,\n.voicePlayback.unplayable .timeField {\n    display: none;\n}\n\n.voicePlayback.unplayable .voiceToTextLabel {\n    display: none;\n}\n';
+const voiceSubscribers = /* @__PURE__ */ new Map();
+function subscribeVoiceEvents(voiceId, handlers) {
+  if (!voiceSubscribers.has(voiceId)) {
+    voiceSubscribers.set(voiceId, /* @__PURE__ */ new Set());
+  }
+  voiceSubscribers.get(voiceId).add(handlers);
+  return () => {
+    const set = voiceSubscribers.get(voiceId);
+    if (set) {
+      set.delete(handlers);
+      if (set.size === 0) voiceSubscribers.delete(voiceId);
+    }
+  };
+}
+if (typeof document !== "undefined") {
+  const style = document.createElement("style");
+  style.textContent = voiceBlockCss;
+  document.head.appendChild(style);
+}
+function generateVoiceId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = Math.random() * 16 | 0;
+    const v = c === "x" ? r : r & 3 | 8;
+    return v.toString(16);
+  });
+}
+function formatTime(ms) {
+  if (typeof ms !== "number" || ms < 0) ms = 0;
+  const totalSeconds = Math.floor(ms / 1e3);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+function buildVoiceMenuJson(attrs) {
+  return JSON.stringify({
+    type: 2,
+    voiceId: attrs.voiceId,
+    voicePath: attrs.voicePath,
+    voiceSize: attrs.voiceSize,
+    title: attrs.title,
+    createTime: attrs.createTime,
+    text: attrs.text,
+    state: !!attrs.text
+  });
+}
+const VoiceBlock = Node3.create({
+  name: "voiceBlock",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+  addAttributes() {
+    return {
+      voiceId: { default: null },
+      voicePath: { default: null },
+      voiceSize: { default: 0 },
+      createTime: { default: null },
+      title: { default: null },
+      text: { default: null },
+      translateUnfold: { default: true }
+    };
+  },
+  parseHTML() {
+    return [{ tag: 'div[data-type="voice-block"]' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes, { "data-type": "voice-block" })];
+  },
+  addNodeView() {
+    return ({ node, view, getPos, editor }) => {
+      let playing = false;
+      let paused = false;
+      let translating = false;
+      let progress = 0;
+      let duration = node.attrs.voiceSize || 0;
+      let seeking = false;
+      let unplayable = false;
+      let currentNode = node;
+      let destroyed = false;
+      const box = document.createElement("div");
+      box.className = "voiceInfoBox";
+      box.setAttribute("data-type", "voice-block");
+      box.setAttribute("data-voice-meta", buildVoiceMenuJson(node.attrs));
+      const playback = document.createElement("div");
+      playback.className = "voicePlayback";
+      box.appendChild(playback);
+      const left = document.createElement("div");
+      left.className = "left";
+      const voiceBtn = document.createElement("div");
+      voiceBtn.className = "voiceBtn";
+      const titleEl = document.createElement("span");
+      titleEl.className = "title";
+      titleEl.textContent = node.attrs.title || "";
+      left.appendChild(voiceBtn);
+      left.appendChild(titleEl);
+      playback.appendChild(left);
+      const progressBar = document.createElement("input");
+      progressBar.type = "range";
+      progressBar.className = "progressBar";
+      progressBar.min = 0;
+      progressBar.max = Math.max(duration, 1);
+      progressBar.value = 0;
+      playback.appendChild(progressBar);
+      const right = document.createElement("div");
+      right.className = "right";
+      const timeField = document.createElement("div");
+      timeField.className = "timeField";
+      const timePassed = document.createElement("span");
+      timePassed.className = "timePassed";
+      timePassed.textContent = "00:00";
+      const timeTotal = document.createElement("span");
+      timeTotal.className = "timeTotal";
+      timeTotal.textContent = formatTime(duration);
+      timeField.appendChild(timePassed);
+      timeField.appendChild(timeTotal);
+      right.appendChild(timeField);
+      const toTextLabel = document.createElement("div");
+      toTextLabel.className = "voiceToTextLabel";
+      const toTextIcon = document.createElement("div");
+      toTextIcon.className = "voiceToTextIcon";
+      const translatingLabel = document.createElement("span");
+      translatingLabel.className = "translatingLabel";
+      translatingLabel.textContent = "转写中";
+      toTextLabel.appendChild(toTextIcon);
+      toTextLabel.appendChild(translatingLabel);
+      right.appendChild(toTextLabel);
+      const toTextTrigger = document.createElement("div");
+      toTextTrigger.className = "voiceToTextTrigger";
+      toTextTrigger.textContent = "转文字";
+      right.appendChild(toTextTrigger);
+      playback.appendChild(right);
+      const translate = document.createElement("div");
+      translate.className = "translate";
+      const translateHeader = document.createElement("div");
+      translateHeader.className = "translateHeader";
+      const translateIcon = document.createElement("div");
+      translateIcon.className = "translateIcon";
+      const translateLabel = document.createElement("span");
+      translateLabel.className = "translateLabel";
+      translateLabel.textContent = "语音转文字";
+      const foldBtn = document.createElement("div");
+      foldBtn.className = "foldBtn";
+      translateHeader.appendChild(translateIcon);
+      translateHeader.appendChild(translateLabel);
+      translateHeader.appendChild(foldBtn);
+      translate.appendChild(translateHeader);
+      const translateText = document.createElement("div");
+      translateText.className = "translateText";
+      translateText.textContent = node.attrs.text || "";
+      translate.appendChild(translateText);
+      box.appendChild(translate);
+      function refreshState() {
+        playback.classList.toggle("play", playing);
+        playback.classList.toggle("pause", paused);
+        playback.classList.toggle("voiceToText", translating);
+        playback.classList.toggle("unplayable", unplayable);
+        const hasText = !!(currentNode.attrs.text && currentNode.attrs.text.length > 0);
+        box.classList.toggle("containText", hasText);
+        const unfold = currentNode.attrs.translateUnfold !== false;
+        translateHeader.classList.toggle("unfold", unfold);
+        translateText.style.display = hasText && unfold ? "" : "none";
+        const pct = duration > 0 ? Math.min(progress / duration * 100, 100) : 0;
+        progressBar.style.setProperty("--progressValue", pct + "%");
+        timePassed.textContent = formatTime(progress);
+        timeTotal.textContent = formatTime(duration);
+        progressBar.max = Math.max(duration, 1);
+        progressBar.value = Math.min(progress, progressBar.max);
+      }
+      function onVoiceBtnClick() {
+        return;
+      }
+      function onToTextTriggerClick() {
+        return;
+      }
+      function onFoldToggle() {
+        const pos = getPos();
+        if (pos == null || pos < 0) return;
+        view.dispatch(view.state.tr.setNodeMarkup(pos, void 0, {
+          ...currentNode.attrs,
+          translateUnfold: currentNode.attrs.translateUnfold === false ? true : false
+        }));
+      }
+      voiceBtn.addEventListener("click", onVoiceBtnClick);
+      toTextTrigger.addEventListener("click", onToTextTriggerClick);
+      foldBtn.addEventListener("click", onFoldToggle);
+      translateHeader.addEventListener("click", (e) => {
+        if (e.target === foldBtn) return;
+        onFoldToggle();
+      });
+      progressBar.addEventListener("input", () => {
+        seeking = true;
+        progress = Number(progressBar.value);
+        progressBar.style.setProperty(
+          "--progressValue",
+          (duration > 0 ? progress / duration * 100 : 0) + "%"
+        );
+        timePassed.textContent = formatTime(progress);
+      });
+      progressBar.addEventListener("change", () => {
+        seeking = false;
+      });
+      const unsubscribe = subscribeVoiceEvents(node.attrs.voiceId, {
+        onPlaybackStateChanged(state) {
+          if (state === 0) {
+            playing = true;
+            paused = false;
+          } else if (state === 1) {
+            playing = false;
+            paused = true;
+          } else {
+            playing = false;
+            paused = false;
+            progress = 0;
+          }
+          refreshState();
+        },
+        onPositionChanged(ms) {
+          if (seeking) return;
+          progress = ms;
+          refreshState();
+        },
+        onDurationChanged(ms) {
+          duration = ms;
+          refreshState();
+        },
+        onFileError() {
+          unplayable = true;
+          playing = false;
+          paused = false;
+          refreshState();
+        },
+        onToTextStarted() {
+          translating = true;
+          refreshState();
+        },
+        onToTextFailed() {
+          translating = false;
+          refreshState();
+        },
+        onToTextCompleted(text) {
+          translating = false;
+          const pos = getPos();
+          if (pos != null && pos >= 0) {
+            view.dispatch(view.state.tr.setNodeMarkup(pos, void 0, {
+              ...currentNode.attrs,
+              text
+            }));
+          }
+          refreshState();
+        }
+      });
+      refreshState();
+      return {
+        dom: box,
+        update(updatedNode) {
+          if (updatedNode.type.name !== "voiceBlock") return false;
+          currentNode = updatedNode;
+          titleEl.textContent = updatedNode.attrs.title || "";
+          translateText.textContent = updatedNode.attrs.text || "";
+          box.setAttribute("data-voice-meta", buildVoiceMenuJson(updatedNode.attrs));
+          refreshState();
+          return true;
+        },
+        stopEvent(event) {
+          const target = event.target;
+          if (target instanceof HTMLElement) {
+            if (target.closest(".voiceBtn, .progressBar, .voiceToTextTrigger, .foldBtn, .translateHeader, .translateText")) {
+              return true;
+            }
+          }
+          return false;
+        },
+        ignoreMutation() {
+          return true;
+        },
+        selectNode() {
+          box.classList.add("ProseMirror-selectednode");
+        },
+        deselectNode() {
+          box.classList.remove("ProseMirror-selectednode");
+        },
+        destroy() {
+          if (destroyed) return;
+          destroyed = true;
+          unsubscribe();
+          voiceBtn.removeEventListener("click", onVoiceBtnClick);
+          toTextTrigger.removeEventListener("click", onToTextTriggerClick);
+          foldBtn.removeEventListener("click", onFoldToggle);
+        }
+      };
+    };
+  },
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("voiceBlockCopyClear"),
+        props: {
+          transformCopied(slice) {
+            let modified = false;
+            function transformFragment(fragment) {
+              const newNodes = [];
+              for (let i = 0; i < fragment.childCount; i++) {
+                const node = fragment.child(i);
+                if (node.type.name === "voiceBlock") {
+                  modified = true;
+                  newNodes.push(node.type.create({
+                    ...node.attrs,
+                    text: null,
+                    voiceId: generateVoiceId(),
+                    translateUnfold: true
+                  }, node.content, node.marks));
+                } else if (node.content && node.content.size > 0) {
+                  const newContent2 = transformFragment(node.content);
+                  if (newContent2 !== node.content) {
+                    newNodes.push(node.copy(newContent2));
+                  } else {
+                    newNodes.push(node);
+                  }
+                } else {
+                  newNodes.push(node);
+                }
+              }
+              return Fragment.from(newNodes);
+            }
+            const newContent = transformFragment(slice.content);
+            if (!modified) return slice;
+            return new Slice(newContent, slice.openStart, slice.openEnd);
+          }
+        }
+      }),
+      new Plugin({
+        key: new PluginKey("voiceBlockPasteId"),
+        appendTransaction(transactions, oldState, newState) {
+          const isPaste = transactions.some((t) => t.getMeta("paste"));
+          if (!isPaste) return null;
+          const seen = /* @__PURE__ */ new Set();
+          let tr = newState.tr;
+          let modified = false;
+          newState.doc.descendants((node, pos) => {
+            if (node.type.name !== "voiceBlock") return;
+            const id = node.attrs.voiceId;
+            if (seen.has(id)) {
+              const newId = generateVoiceId();
+              tr = tr.setNodeMarkup(pos, void 0, { ...node.attrs, voiceId: newId });
+              modified = true;
+            } else {
+              seen.add(id);
+            }
+          });
+          return modified ? tr : null;
+        }
+      })
+    ];
+  }
+});
+function createTiptapSchemaV1() {
+  return getSchema([
+    index_default$g,
+    index_default$f,
+    index_default$e,
+    index_default$d,
+    index_default$c.configure({ levels: [1, 2, 3, 4, 5, 6] }),
+    index_default$b,
+    index_default$a,
+    index_default$9,
+    index_default$8,
+    index_default$7,
+    index_default$6.configure({ nested: true }),
+    ImageBlock,
+    VoiceBlock,
+    index_default$5,
+    index_default$4,
+    index_default$3,
+    index_default$2,
+    ColorMark,
+    index_default$1.configure({ multicolor: true }),
+    FontFamilyMark,
+    FontSizeMark
+  ]);
+}
+const TIPTAP_FORMAT = "tiptap";
+const TIPTAP_SCHEMA_VERSION = 1;
+const SCHEMA_V1_NODES = Object.freeze([
+  "doc",
+  "paragraph",
+  "text",
+  "hardBreak",
+  "heading",
+  "blockquote",
+  "bulletList",
+  "orderedList",
+  "listItem",
+  "taskList",
+  "taskItem",
+  "image",
+  "voiceBlock"
+]);
+const SCHEMA_V1_MARKS = Object.freeze([
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "color",
+  "highlight",
+  "fontFamily",
+  "fontSize"
+]);
+const MAX_NODE_DEPTH = 100;
+const URL_SCHEME_RE = /^([a-z][a-z0-9+.-]*):/i;
+const URL_SCHEME_OBFUSCATION_RE = /[\u0000-\u0020\u007f\s]/g;
+const URL_NETWORK_PATH_RE = /^(?:\/\/|\\\\)/;
+const SAFE_IMAGE_URL_SCHEMES = /* @__PURE__ */ new Set(["http", "https"]);
+function parseEnvelope(text) {
+  return JSON.parse(text);
+}
+function validateEnvelope(envelope, schema = createTiptapSchemaV1()) {
+  const errors = [];
+  if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+    errors.push(error("", "invalid-envelope", "Envelope must be an object"));
+    return { ok: false, errors };
+  }
+  if (envelope.format !== TIPTAP_FORMAT) {
+    errors.push(error("format", "invalid-format", `format must be ${TIPTAP_FORMAT}`));
+  }
+  if (envelope.schemaVersion !== TIPTAP_SCHEMA_VERSION) {
+    errors.push(error("schemaVersion", "unsupported-schema-version", `schemaVersion must be ${TIPTAP_SCHEMA_VERSION}`));
+  }
+  if (!envelope.content || typeof envelope.content !== "object" || Array.isArray(envelope.content)) {
+    errors.push(error("content", "invalid-content", "content must be a ProseMirror document object"));
+    return { ok: false, errors };
+  }
+  if (envelope.content.type !== "doc") {
+    errors.push(error("content.type", "invalid-root", "content.type must be doc"));
+  }
+  if (envelope.content.type === "doc" && Array.isArray(envelope.content.content) && envelope.content.content.length === 0) {
+    errors.push(error("content.content", "empty-doc-content", "empty documents must be persisted as one empty paragraph"));
+  }
+  walkNode(envelope.content, "content", errors);
+  if (!errors.some((error2) => error2.code === "max-node-depth-exceeded")) {
+    try {
+      schema.nodeFromJSON(envelope.content).check();
+    } catch (err) {
+      errors.push(error("content", "schema-validation-failed", err.message));
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+function walkNode(node, path, errors, depth = 0) {
+  if (depth > MAX_NODE_DEPTH) {
+    errors.push(error(path, "max-node-depth-exceeded", `node depth must not exceed ${MAX_NODE_DEPTH}`));
+    return;
+  }
+  if (!node || typeof node !== "object" || Array.isArray(node)) {
+    errors.push(error(path, "invalid-node", "node must be an object"));
+    return;
+  }
+  if (!SCHEMA_V1_NODES.includes(node.type)) {
+    errors.push(error(`${path}.type`, "unsupported-node", `unsupported node type: ${node.type}`));
+  }
+  if (node.type === "text") {
+    if (typeof node.text !== "string") {
+      errors.push(error(`${path}.text`, "invalid-text", "text node requires string text"));
+    }
+  }
+  if (node.type === "heading") {
+    const level = node.attrs?.level;
+    if (!Number.isInteger(level) || level < 1 || level > 6) {
+      errors.push(error(`${path}.attrs.level`, "invalid-heading-level", "heading level must be 1..6"));
+    }
+  }
+  if (node.type === "image") {
+    const src = node.attrs?.src;
+    if (typeof src !== "string" || src.length === 0) {
+      errors.push(error(`${path}.attrs.src`, "invalid-image-src", "image src is required"));
+    } else if (!isSafeImageSrc(src)) {
+      errors.push(error(`${path}.attrs.src`, "unsafe-image-src", "image src uses an unsafe URL scheme"));
+    }
+    const relPath = node.attrs?.relPath;
+    if (!isSafeImageRelPath(relPath)) {
+      errors.push(error(`${path}.attrs.relPath`, "unsafe-image-relpath", "image relPath must be an images/ relative path without traversal"));
+    }
+  }
+  if (node.type === "voiceBlock") {
+    if (!nonEmptyString(node.attrs?.voiceId)) {
+      errors.push(error(`${path}.attrs.voiceId`, "invalid-voice-id", "voiceId is required"));
+    }
+    if (!nonEmptyString(node.attrs?.voicePath)) {
+      errors.push(error(`${path}.attrs.voicePath`, "invalid-voice-path", "voicePath is required"));
+    }
+    if (typeof node.attrs?.voiceSize !== "number" || node.attrs.voiceSize < 0) {
+      errors.push(error(`${path}.attrs.voiceSize`, "invalid-voice-size", "voiceSize must be a non-negative number"));
+    }
+    if (Object.hasOwn(node.attrs ?? {}, "translating")) {
+      errors.push(error(`${path}.attrs.translating`, "runtime-state-persisted", "translating is runtime state and is not part of Schema V1 persistence"));
+    }
+  }
+  for (let markIndex = 0; markIndex < (node.marks ?? []).length; ++markIndex) {
+    const mark = node.marks[markIndex];
+    const markPath = `${path}.marks[${markIndex}]`;
+    if (!mark || typeof mark !== "object" || Array.isArray(mark)) {
+      errors.push(error(markPath, "invalid-mark", "mark must be an object"));
+      continue;
+    }
+    if (!SCHEMA_V1_MARKS.includes(mark.type)) {
+      errors.push(error(`${markPath}.type`, "unsupported-mark", `unsupported mark type: ${mark.type}`));
+    }
+  }
+  if (node.content !== void 0) {
+    if (!Array.isArray(node.content)) {
+      errors.push(error(`${path}.content`, "invalid-content-array", "node content must be an array"));
+      return;
+    }
+    for (let index = 0; index < node.content.length; ++index) {
+      walkNode(node.content[index], `${path}.content[${index}]`, errors, depth + 1);
+    }
+  }
+}
+function isSafeImageRelPath(relPath) {
+  if (relPath == null || relPath === "") return true;
+  if (typeof relPath !== "string") return false;
+  if (!relPath.startsWith("images/")) return false;
+  if (relPath.split("/").includes("..")) return false;
+  return true;
+}
+function isSafeImageSrc(src) {
+  const trimmed = src.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  const normalized = trimmed.replace(URL_SCHEME_OBFUSCATION_RE, "");
+  if (normalized.length === 0 || URL_NETWORK_PATH_RE.test(normalized)) {
+    return false;
+  }
+  const scheme = normalized.match(URL_SCHEME_RE)?.[1]?.toLowerCase();
+  return !scheme || SAFE_IMAGE_URL_SCHEMES.has(scheme);
+}
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+function error(path, code, message) {
+  return { path, code, message };
+}
+const input = process.argv[2] ? fs.readFileSync(process.argv[2], "utf8") : fs.readFileSync(0, "utf8");
+try {
+  const result = validateEnvelope(parseEnvelope(input));
+  if (!result.ok) {
+    console.error(JSON.stringify(result.errors, null, 2));
+    process.exit(1);
+  }
+  console.log("valid");
+} catch (error2) {
+  console.error(error2.message);
+  process.exit(1);
+}

--- a/web-editor/package.json
+++ b/web-editor/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "test": "node --import ./test/register-css-loader.mjs --test test/*.test.mjs",
-    "build": "vite build",
+    "build": "vite build && vite build --config vite.validate.config.js",
     "build:test": "vite build --mode test",
+    "build:validate": "vite build --config vite.validate.config.js",
     "validate-envelope": "node scripts/validate-envelope.mjs"
   },
   "dependencies": {

--- a/web-editor/vite.validate.config.js
+++ b/web-editor/vite.validate.config.js
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 独立的校验器打包配置：将 scripts/validate-envelope.mjs 打包为
+// dist/validate-envelope.mjs 自包含 ESM bundle，所有 @tiptap/* 与
+// voice-block.css?inline 依赖全部 inline，运行时无需 node_modules。
+// 供 C++ 单元测试（ut_migrationjsonbuilder / ut_migrationnotedataconverter）
+// 通过 `node dist/validate-envelope.mjs <file>` 直接调用，彻底解耦 npm 依赖。
+
+import { defineConfig } from 'vite'
+import { resolve } from 'node:path'
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const spdxBanner = [
+  '/*!',
+  ' * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.',
+  ' * SPDX-License-Identifier: GPL-3.0-or-later',
+  ' *',
+  ' * Bundled runtime: @tiptap/* and ProseMirror (MIT).',
+  ' */',
+].join('\n')
+
+function spdxBannerPlugin() {
+  return {
+    name: 'spdx-banner',
+    // 在产物落盘后注入 banner，绕开 vite 内部 esbuild pipeline：
+    // 在 transform/renderChunk 阶段注入会让 shebang 错位触发语法错误。
+    writeBundle() {
+      const outPath = resolve(__dirname, 'dist/validate-envelope.mjs')
+      const original = readFileSync(outPath, 'utf8')
+      const lines = original.split('\n')
+      // shebang 必须保留在文件第 1 行，banner 紧跟其后
+      if (lines[0]?.startsWith('#!')) {
+        const shebang = lines.shift()
+        writeFileSync(outPath, shebang + '\n' + spdxBanner + '\n' + lines.join('\n'))
+      } else {
+        writeFileSync(outPath, spdxBanner + '\n' + original)
+      }
+    },
+  }
+}
+
+export default defineConfig({
+  configDir: resolve(__dirname),
+  plugins: [spdxBannerPlugin()],
+  build: {
+    outDir: resolve(__dirname, 'dist'),
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, 'scripts/validate-envelope.mjs'),
+      formats: ['es'],
+      fileName: () => 'validate-envelope.mjs',
+    },
+    rollupOptions: {
+      // Node 内置模块由运行时提供，禁止 vite 注入浏览器 polyfill
+      // （否则 process.argv/process.exit 会指向空对象导致 CLI 失效）
+      external: (id) => id.startsWith('node:'),
+      output: {
+        inlineDynamicImports: true,
+        entryFileNames: 'validate-envelope.mjs',
+      },
+    },
+    cssCodeSplit: false,
+    assetsInlineLimit: 100000000,
+    minify: false,
+  },
+})


### PR DESCRIPTION
Three migration UTs (GeneratedEnvelopePassesSchemaValidator, ComparesGoldenJsonAndPassesValidators, ConvertsVoiceBlockGoldenAndPassesV alidators) failed with ERR_MODULE_NOT_FOUND because QProcess invoked the validator via source path that requires web-editor/node_modules.

三条 tiptap 迁移单元测试通过 QProcess 调用源码版校验器，间接依赖
web-editor/node_modules，缺失时报 ERR_MODULE_NOT_FOUND 而失败。

Bundle scripts/validate-envelope.mjs into dist/validate-envelope.mjs via a dedicated vite.validate.config.js (inline @tiptap/*, keep node:* external, inject SPDX banner via writeBundle hook to avoid shebang/esbuild conflict). Update UTs to invoke the self-contained bundle directly.

新增 vite.validate.config.js 把校验器打包为 dist/validate-envelope.mjs 自包含 bundle（@tiptap/* 全部 inline，node:* 保留为外部依赖，SPDX banner 走 writeBundle 钩子注入以避开 shebang 与 esbuild 冲突）；UT 改调 bundle。

Log: 修复3条UT因缺npm依赖失败，改为调用自包含校验bundle
Influence: 测试运行时不再依赖 web-editor/node_modules，全新克隆即可通过；改 schema/validator 源码后需重跑 npm run build:validate 并提交 dist 产物。

## Summary by Sourcery

Bundle the tiptap migration envelope validator into a self-contained dist script and update unit tests and build configuration to use it instead of the source validator that required npm dependencies.

Enhancements:
- Introduce a dedicated Vite config and bundled dist/validate-envelope.mjs validator to remove runtime dependency on web-editor/node_modules.
- Adjust web-editor build scripts to produce and maintain the validator bundle alongside existing builds.

Tests:
- Update migration validator unit tests to locate and invoke the bundled dist/validate-envelope.mjs script, eliminating dependence on npm-installed modules.