### PR TITLE
fix(editor): update text colors to match 1070 palette

### DIFF
--- a/assets/web/css/bootstrapCssReset.css
+++ b/assets/web/css/bootstrapCssReset.css
@@ -166,7 +166,7 @@
  }
 
  .colorFont {
-     color: rgba(65, 77, 104, 1);
+     color: #000000;
      margin: 3px;
      font-size: 12px;
  }

--- a/assets/web/css/dark.css
+++ b/assets/web/css/dark.css
@@ -1,21 +1,21 @@
 body {
-    color: rgba(192, 198, 212, 1) !important;
+    color: #EFEFEF !important;
 }
 
 u {
-    border-bottom: 1px solid rgba(192, 198, 212, 1) !important;
+    border-bottom: 1px solid #EFEFEF !important;
 }
 
 strike {
-    text-decoration-color: rgba(192, 198, 212, 1) !important;
+    text-decoration-color: #EFEFEF !important;
 }
 
 strike[style="text-decoration-line: underline;"] {
-    border-bottom: 1px solid rgba(192, 198, 212, 1) !important;
+    border-bottom: 1px solid #EFEFEF !important;
 }
 
 .title, .time {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .li {
@@ -23,7 +23,7 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .minute {
-    color: rgba(109, 124, 136, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .note-popover .popover-content {
@@ -31,7 +31,7 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .tooltip-inner {
-    color: rgba(192, 198, 212, 1);
+    color: rgba(255, 255, 255, 0.7);
     background-color: rgba(42, 42, 42, 1) !important;
     border: 1px solid rgba(0, 0, 0, 0.30);
 }
@@ -45,15 +45,15 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .colorFont {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .dropdown-fontsize li a {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .dropdown-fontname li a {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .wifi-symbol .first {
@@ -85,7 +85,7 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .dropdown-fontsize>li>a, .dropdown-fontname>li>a {
-    color: rgba(197, 207, 224, 1)
+    color: rgba(255, 255, 255, 0.7)
 }
 
 .icon-forecolor .path1 {
@@ -129,5 +129,5 @@ body::-webkit-scrollbar-thumb:active,
 }
 
 .translate>div {
-    color: rgba(192, 198, 212, 1) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
 }

--- a/assets/web/index.css
+++ b/assets/web/index.css
@@ -3,7 +3,7 @@ body {
     line-height: 1.72;
     font-family: 'Helvetica';
     background-color: transparent;
-    color: rgba(65, 77, 104, 1);
+    color: #000000;
     word-wrap: break-word;
 }
 
@@ -98,7 +98,7 @@ body {
 }
 
 .time {
-    color: rgba(65, 77, 104, 1);
+    color: #000000;
     font-size: 12px !important;
     line-height: 12px;
 }
@@ -134,7 +134,7 @@ body {
 
 .translate>div {
     text-align: center;
-    color: rgba(65, 77, 104, 1) !important;
+    color: #000000 !important;
 }
 
 .icon {
@@ -230,14 +230,14 @@ body {
 
 u {
     text-decoration-color: transparent !important;
-    border-bottom: 1px solid rgba(65, 77, 104, 1);
+    border-bottom: 1px solid #000000;
 }
 
 strike {
-    text-decoration-color: rgba(65, 77, 104, 1);
+    text-decoration-color: #000000;
 }
 
 strike[style="text-decoration-line: underline;"] {
     text-decoration-color: transparent !important;
-    border-bottom: 1px solid rgba(65, 77, 104, 1);
+    border-bottom: 1px solid #000000;
 }

--- a/assets/web/index.js
+++ b/assets/web/index.js
@@ -997,9 +997,9 @@ function changeColor(flag, activeColor, disableColor, backgroundColor) {
     }, function () {
         $('.dropdown-fontsize>li>a').css('background-color', 'transparent');
         if (flag == 1) {
-            $('.dropdown-fontsize>li>a').css('color', "black");
+            $('.dropdown-fontsize>li>a').css('color', "#000000");
         } else {
-            $('.dropdown-fontsize>li>a').css('color', "rgba(197,207,224,1)");
+            $('.dropdown-fontsize>li>a').css('color', "rgba(255, 255, 255, 0.7)");
         }
     })
     $('.dropdown-fontname>li>a').hover(function (e) {
@@ -1007,16 +1007,16 @@ function changeColor(flag, activeColor, disableColor, backgroundColor) {
     }, function () {
         $('.dropdown-fontname>li>a').css('background-color', 'transparent');
         if (flag == 1) {
-            $('.dropdown-fontname>li>a').css('color', "black");
+            $('.dropdown-fontname>li>a').css('color', "#000000");
         } else {
-            $('.dropdown-fontname>li>a').css('color', "rgba(197,207,224,1)");
+            $('.dropdown-fontname>li>a').css('color', "rgba(255, 255, 255, 0.7)");
         }
     })
     $('body').css('background-color', global_themeColor)
     if (flag == 1) {
         $('#dark').remove()
-        $('.dropdown-fontsize>li>a').css('color', "black");
-        $('.dropdown-fontname>li>a').css('color', "black");
+        $('.dropdown-fontsize>li>a').css('color', "#000000");
+        $('.dropdown-fontname>li>a').css('color', "#000000");
     } else if (flag == 2 && !$('#dark').length) {
         $("head").append("<link>");
         var css = $("head").children(":last");


### PR DESCRIPTION
## 修复说明

**PMS Bug**: https://pms.uniontech.com/bug-view-244985.html

### 根因

1070 系统文字色板更新后，语音记事本富文本编辑器中多处文字颜色仍使用旧硬编码色值，未同步到新色板。

### 修复内容

- **浅色主题**：编辑区文字、tips、下拉菜单、语音控件文字颜色从 `rgba(65, 77, 104, 1)` 改为 `#000000`
- **深色主题**：编辑区默认文字颜色改为 `#EFEFEF`（色板第一排右数第二个）
- **深色主题**：tips、下拉菜单、语音控件文字颜色从 `rgba(192, 198, 212, 1)` / `rgba(197, 207, 224, 1)` 改为 `rgba(255, 255, 255, 0.7)`（即 #ffffff 70%）
- 同步更新 `index.js` 中 `changeColor()` 函数的下拉字体颜色

### 涉及文件

- `assets/web/index.css` — 浅色主题文字色值
- `assets/web/css/dark.css` — 深色主题文字色值
- `assets/web/css/bootstrapCssReset.css` — 下拉菜单标签文字色值
- `assets/web/index.js` — 主题切换时下拉字体颜色

## Summary by Sourcery

Align editor text colors with the updated 1070 design palette for both light and dark themes.

Bug Fixes:
- Correct text, tooltip, and dropdown font colors in the rich text editor to match the latest 1070 system palette for light and dark themes.

Enhancements:
- Standardize hardcoded color values in CSS and JavaScript for light/dark theme switching in the editor.