### PR TITLE
fix(editor): update toolbar icon colors to match 1070 palette

### DIFF
--- a/assets/web/css/bootstrapCssReset.css
+++ b/assets/web/css/bootstrapCssReset.css
@@ -133,7 +133,7 @@
  }
 
  .note-icon-caret {
-     color: rgba(65, 77, 104, 1)
+     color: #000000
  }
 
  .dropdown-menu {
@@ -224,7 +224,7 @@
  }
 
  .btn-default {
-     color: rgb(83, 96, 118);
+     color: #000000;
  }
 
  .btn-default:hover {

--- a/assets/web/css/dark.css
+++ b/assets/web/css/dark.css
@@ -37,7 +37,7 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .btn-default {
-    color: rgba(197, 207, 224, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .dropdown-menu {
@@ -89,7 +89,7 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .icon-forecolor .path1 {
-    color: rgba(192, 198, 212, 1);
+    color: rgba(255, 255, 255, 0.7);
 }
 
 .icon-backcolor .path5 {

--- a/assets/web/css/style.css
+++ b/assets/web/css/style.css
@@ -118,7 +118,7 @@
 }
 
 .icon-forecolor .path1 {
-  color: #414D68;
+  color: #000000;
 }
 
 .icon-forecolor .path3:before {


### PR DESCRIPTION
## 修复说明

**PMS Bug**: https://pms.uniontech.com/bug-view-244973.html

### 根因

1070 系统所有按钮图标颜色修改后，语音记事本富文本工具栏中未使用 DTK 的按钮图标颜色仍为旧硬编码色值，需同步更改。

### 修复内容

- **浅色主题**：工具栏按钮图标颜色从 `rgb(83, 96, 118)` / `rgba(65, 77, 104, 1)` / `#414D68` 改为 `#000000`（100%）
- **深色主题**：工具栏按钮图标颜色从 `rgba(197, 207, 224, 1)` / `rgba(192, 198, 212, 1)` 改为 `rgba(255, 255, 255, 0.7)`（即 #ffffff 70%）

### 涉及文件

- `assets/web/css/style.css` — 前景色图标色值
- `assets/web/css/bootstrapCssReset.css` — 工具栏按钮图标、下拉箭头图标色值
- `assets/web/css/dark.css` — 深色主题工具栏按钮图标、前景色图标色值

## Summary by Sourcery

Align rich text editor toolbar icon colors with the 1070 system palette for both light and dark themes.

Bug Fixes:
- Update toolbar button and caret icon colors in light theme to use solid black instead of outdated hard-coded blue-gray values.
- Adjust dark theme toolbar and forecolor icon colors to use semi-transparent white to match updated system button icon styling.