### PR TITLE
test(at): stabilize voice note AT suite assertions

### DIFF
--- a/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1.suite.yaml
@@ -36,4 +36,4 @@ suites:
   - action: assert_element
     selector:
       name: 确定
-      role: push button
+      role: button

--- a/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1.suite.yaml
@@ -30,4 +30,4 @@ suites:
   - action: assert_element
     selector:
       name: 确定
-      role: push button
+      role: button

--- a/tests/at/yaml/记事本条目(#115181)_case_1625233_s1/记事本条目(#115181)_case_1625233_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目(#115181)_case_1625233_s1/记事本条目(#115181)_case_1625233_s1.suite.yaml
@@ -28,12 +28,14 @@ suites:
       role: label
     items:
     - 重命名
+  - action: keyboard_hot_key
+    key: ctrl+a
   - action: keyboard_type
-    text: test2
+    text: 测试记事本A
   - action: keyboard_press
     key: enter
   assert_steps:
   - action: assert_element
     selector:
-      name: test2
+      name: 测试记事本A
       role: label

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634853_s1/记事本条目管理(#115129)_case_1634853_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634853_s1/记事本条目管理(#115129)_case_1634853_s1.suite.yaml
@@ -28,12 +28,14 @@ suites:
       role: label
     items:
     - 重命名
+  - action: keyboard_hot_key
+    key: ctrl+a
   - action: keyboard_type
-    text: test
+    text: 正常命名测试
   - action: keyboard_press
     key: enter
   assert_steps:
   - action: assert_element
     selector:
-      name: test
+      name: 正常命名测试
       role: label


### PR DESCRIPTION
Fix AT selector role mismatch and rename flow expectations.

修正AT元素角色匹配和重命名流程期望值。

Log: 修复语音记事本AT用例断言

Influence: 修复4条AT用例执行失败问题，tests/at/yaml全量50条通过。

## Summary by Sourcery

Stabilize voice note accessibility test suites by correcting selector roles and aligning flow expectations so previously failing cases now pass.

Bug Fixes:
- Fix role mismatches in AT selectors that caused four voice note test cases to fail.

Tests:
- Update voice note AT suite expectations to restore full pass of the tests/at/yaml suite.