### PR TITLE
fix(editor): prevent virtual keyboard from opening on startup

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -303,7 +303,6 @@ function setFontList(fontList, initFont) {
 // 初始化summernote
 function initSummernote() {
     $('#summernote').summernote({
-        focus: true,
         disableDragAndDrop: true,
         lang: 'zh-CN',
         // 浮动工具栏


### PR DESCRIPTION
Remove Summernote's global initialization focus so opening an existing note does not request editor focus and unintentionally show the virtual keyboard. Keep the explicit post-load focus flow for newly created blank notes.

修复启动语音记事本时软键盘自动弹出：移除 Summernote 初始化阶段的
全局焦点；新建空白笔记仍在内容加载完成后显式聚焦。

Log: 修复启动语音记事本时软键盘自动弹出
PMS: TASK-394163
Influence: 打开已有笔记不再自动拉起软键盘；点击输入区时按正常行为显示，
          新建空白笔记仍能自动获得输入光标。

## Summary by Sourcery

Bug Fixes:
- Prevent the virtual keyboard from opening automatically on startup by disabling Summernote's global initialization focus.