### PR TITLE
fix(editor): set rich text toolbar icon colors to 1070 spec [PMS 244973]

### DIFF
--- a/assets/web/css/bootstrapCssReset.css
+++ b/assets/web/css/bootstrapCssReset.css
@@ -133,7 +133,7 @@
  }
 
  .note-icon-caret {
-     color: rgba(65, 77, 104, 1)
+     color: #000000
  }
 
  .dropdown-menu {
@@ -166,7 +166,7 @@
  }
 
  .colorFont {
-     color: rgba(65, 77, 104, 1);
+     color: #000000;
      margin: 3px;
      font-size: 12px;
  }
@@ -224,7 +224,7 @@
  }
 
  .btn-default {
-     color: rgb(83, 96, 118);
+     color: #000000;
  }
 
  .btn-default:hover {

--- a/assets/web/css/dark.css
+++ b/assets/web/css/dark.css
@@ -37,7 +37,11 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .btn-default {
-    color: rgba(197, 207, 224, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
+}
+
+.note-icon-caret {
+    color: rgba(255, 255, 255, 0.7);
 }
 
 .dropdown-menu {
@@ -45,15 +49,15 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .colorFont {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .dropdown-fontsize li a {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .dropdown-fontname li a {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .wifi-symbol .first {
@@ -85,11 +89,11 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .dropdown-fontsize>li>a, .dropdown-fontname>li>a {
-    color: rgba(197, 207, 224, 1)
+    color: rgba(255, 255, 255, 0.7)
 }
 
 .icon-forecolor .path1 {
-    color: rgba(192, 198, 212, 1);
+    color: rgba(255, 255, 255, 0.7);
 }
 
 .icon-backcolor .path5 {

--- a/assets/web/css/style.css
+++ b/assets/web/css/style.css
@@ -118,7 +118,7 @@
 }
 
 .icon-forecolor .path1 {
-  color: #414D68;
+  color: #000000;
 }
 
 .icon-forecolor .path3:before {

--- a/assets/web/index.js
+++ b/assets/web/index.js
@@ -999,7 +999,7 @@ function changeColor(flag, activeColor, disableColor, backgroundColor) {
         if (flag == 1) {
             $('.dropdown-fontsize>li>a').css('color', "black");
         } else {
-            $('.dropdown-fontsize>li>a').css('color', "rgba(197,207,224,1)");
+            $('.dropdown-fontsize>li>a').css('color', "rgba(255,255,255,0.7)");
         }
     })
     $('.dropdown-fontname>li>a').hover(function (e) {
@@ -1009,7 +1009,7 @@ function changeColor(flag, activeColor, disableColor, backgroundColor) {
         if (flag == 1) {
             $('.dropdown-fontname>li>a').css('color', "black");
         } else {
-            $('.dropdown-fontname>li>a').css('color', "rgba(197,207,224,1)");
+            $('.dropdown-fontname>li>a').css('color', "rgba(255,255,255,0.7)");
         }
     })
     $('body').css('background-color', global_themeColor)


### PR DESCRIPTION
# fix(editor): set rich text toolbar icon colors to 1070 spec [PMS 244973]

## 根因分析

富文本编辑器（Web/Summernote）的工具栏图标为字体图标，颜色由 CSS `color` 硬编码、**未走 DTK 主题**，与 1070 目标色（浅色 `#000000`、深色 `rgba(255,255,255,0.7)`）不符。结论级别：**强根因**。

关键证据：
- `assets/web/css/bootstrapCssReset.css:226-227` `.btn-default { color: rgb(83,96,118) }` —— 浅色工具栏主按钮图标色（应为 `#000000`）。
- `assets/web/css/dark.css:39-41` `.btn-default { color: rgba(197,207,224,1) !important }` —— 深色主按钮图标色（应为 `rgba(255,255,255,0.7)`），dark.css 由 `index.js` 动态注入、最后加载且带 `!important` 覆盖浅色。
- `assets/web/css/dark.css` 原本**无** `.note-icon-caret` 覆盖 —— 深色下拉箭头继承浅色 `rgba(65,77,104,1)`，近乎不可见（既有缺陷）。

## 修复方案

按 1070 目标色统一工具栏字体图标颜色，范围严格限定为「富文本工具栏按钮图标」，不含正文文字色与 SVG 语音图标（保持语义色不变）：

- **浅色 → `#000000`**（`bootstrapCssReset.css` 的 `.btn-default` / `.note-icon-caret` / `.colorFont`，`style.css` 的 `.icon-forecolor .path1`）。
- **深色 → `rgba(255,255,255,0.7)`**（`dark.css` 的 `.btn-default` / `.colorFont` / `.dropdown-fontsize li a` / `.dropdown-fontname li a` / `.dropdown-fontsize>li>a, .dropdown-fontname>li>a` / `.icon-forecolor .path1`，`index.js` 中字号/字体下拉项的深色 JS 色值）。
- **新增** `dark.css` 的 `.note-icon-caret { color: rgba(255,255,255,0.7) }`，修复深色下拉箭头不可见缺陷。

## 改动安全评估

**低风险**。改动仅为 CSS/JS 颜色字面量替换 + 1 条新增小 CSS 规则，不涉及函数签名、控制逻辑、资源管理或外部调用者；`.note-btn` 工具栏图标通过 CSS `color` 继承，无运行时逻辑变更。基线锁定 master `7f2da022`，全仓搜索无既有 1070 相关提交（未发现后续修复）。

## 改动清单

| 文件 | 改动 |
|------|------|
| `assets/web/css/bootstrapCssReset.css` | `.btn-default`/`.note-icon-caret`/`.colorFont` color → `#000000`（3 处） |
| `assets/web/css/style.css` | `.icon-forecolor .path1` color → `#000000`（1 处） |
| `assets/web/css/dark.css` | 6 处 color → `rgba(255,255,255,0.7)` + 新增 `.note-icon-caret` 规则 |
| `assets/web/index.js` | 深色字号/字体下拉项 color → `rgba(255,255,255,0.7)`（2 处） |

不纳入：`assets/web/css/index.css`（死代码，未被 `index.html` 加载）、SVG 语音图标（`play.svg`/`pause.svg`/`play_voice1-7.svg`，保持语义色）、正文/列表文字色、装饰子笔 `.path5`/`.path2`、hover 态。

## Summary by Sourcery

Align rich text editor toolbar icon colors with the 1070 design specification for both light and dark themes.

Enhancements:
- Standardize light-theme toolbar and caret icon colors to pure black for improved visual consistency.
- Standardize dark-theme toolbar, dropdown, and caret icon colors to semi-transparent white for better readability and alignment with design guidelines.
- Update JavaScript-driven dropdown font size/name colors in dark mode to use the new semi-transparent white spec.