### PR TITLE
fix(webrichtexteditor): clamp edit toolbar Y to keep font dropdown visible

### DIFF
--- a/src/views/webrichtexteditor.cpp
+++ b/src/views/webrichtexteditor.cpp
@@ -709,6 +709,26 @@ void WebRichTextEditor::onShowEditToolbar(const QPoint &pos)
         //窗无口正常显示右键菜单时，菜单左上角坐标=鼠标位置，工具栏显示在右键菜单上方
         menuPoint.setY(menuPoint.y() - 45);
     }
+    //下边界保护：与 X 方向的右边界回退(:702-705)对称，保证工具栏及其字体下拉栏在编辑区
+    //可视范围内完整显示。非最大化时编辑区高度较小，右键靠近底部会导致工具栏偏下，其字体
+    //下拉栏(最大高度 300px，见 assets/web/css/bootstrapCssReset.css .dropdown-fontname)
+    //向下展开后超出可视下边界而显示不全。仅在编辑区有有效可视高度时生效，避免尺寸未知(0)
+    //时误判。
+    if (this->height() > 0) {
+        const int editToolbarHeight = 35;      //工具栏自身高度，与下方 m_editToolbarRect 一致
+        const int fontDropdownMaxHeight = 300; //字体下拉栏最大高度(assets/web/css/bootstrapCssReset.css)
+        int maxMenuY = this->height() - editToolbarHeight - fontDropdownMaxHeight;
+        if (maxMenuY < 0) {
+            //编辑区过矮，无法同时容纳工具栏与下拉栏，退化为只保证工具栏自身不溢出可视下边界
+            maxMenuY = this->height() - editToolbarHeight;
+        }
+        if (maxMenuY < 0) {
+            maxMenuY = 0;
+        }
+        if (menuPoint.y() > maxMenuY) {
+            menuPoint.setY(maxMenuY);
+        }
+    }
     //记录编辑工具栏的坐标位置
     m_editToolbarRect = QRect(menuPoint, QPoint(menuPoint.x() + 290 + 85, menuPoint.y() + 35));
     emit JsContent::instance()->calllJsShowEditToolbar(menuPoint.x(), menuPoint.y());


### PR DESCRIPTION
## 根因分析

`WebRichTextEditor::onShowEditToolbar()`（`src/views/webrichtexteditor.cpp`）的工具栏 Y 坐标方位判定只有"离顶 < 100px 就放下方"的顶部保护，缺少与 X 方向对称的"可视下边界"保护：

- X 方向已有 `this->width()` 右边界回退（:702–705）；
- Y 方向 `if (menuPoint.y() < 100)`（:706）是硬编码魔数，算出的 `menuPoint.y()` 从未与 `this->height()` 比较/回退，直接在 :714 原样下发；
- 字体下拉栏（Bootstrap `.dropdown-menu`，默认 `top:100%` 向下展开，`max-height: 300px`，见 `assets/web/css/bootstrapCssReset.css`）从工具栏下沿向下展开。

非最大化（编辑区高度较小）+ 右键靠近页面底部时，工具栏被摆到偏下位置，其字体下拉栏向下展开后超出可视下边界 → 显示不全。Web 端 `AirPopover.prototype.rightUpdate`（`summernote_v9_2.js:7282–7305`）同样只兜 X 不兜 Y，未能纠正。

## 修复方案

在 `onShowEditToolbar` 的 Y 方位判定之后、`m_editToolbarRect` 赋值之前，新增与 X 方向对称的下边界保护，**门控在 `this->height() > 0`**（仅当编辑区有有效可视高度时生效）：以 `this->height() - 工具栏高度(35) - 字体下拉栏最大高度(300)` 为安全上限 `maxMenuY`，超出则将工具栏上移到 `maxMenuY`；编辑区过矮时退化为只保证工具栏自身不溢出（`maxMenuY = this->height() - 35`，再兜底为 0）。常量均与现有代码/CSS 一致（35 来自既有 `m_editToolbarRect`，300 来自 `.dropdown-fontname { max-height: 300px }`）。

Web 端 `rightUpdate` 评估结论：**不修改**。下边界保护应在拥有视口几何信息的一层（C++ `this->height()` 即视口高度）完成；Web 端 `$(document).height()` 是文档高度（长笔记可远大于视口），二次 clamp 会失效或与 C++ 不一致，故不在 Web 端重复。

## 改动安全评估

低风险：仅在一个函数内新增边界检查（local clamp + early guard），不改函数签名、不删公开成员、不触碰 Web 端；唯一运行时调用者 `contextMenuEvent:590`（TxtMenu 分支）受益且入参语义不变。已有单测 `UT_WebRichTextEditor_onShowEditToolbar_001` 运行在未 `show()` 的 widget（`height()==0`）上，走 `height()>0` 门控跳过的路径，**单测无需修改、继续通过**（遵循"不主动写/改 UT"原则，已在分析中标注）。

## 关联

- PMS: https://pms.uniontech.com/bug-view-373573.html
- 根因分析报告 + 改动安全评估：见本 Issue 附件（`analysis-report.md`、`change-safety.md`）

## Summary by Sourcery

Bug Fixes:
- Prevent the font dropdown menu from being partially hidden when the context menu is invoked near the bottom of a non-maximized editor window.