### PR TITLE
fix(editor): update dark theme text colors to 1070 spec (PMS 244985)

### DIFF
--- a/assets/web/css/dark.css
+++ b/assets/web/css/dark.css
@@ -1,21 +1,26 @@
 body {
-    color: rgba(192, 198, 212, 1) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
+}
+
+.note-editable {
+    color: rgba(239, 239, 239, 1) !important;
+    background-color: transparent !important;
 }
 
 u {
-    border-bottom: 1px solid rgba(192, 198, 212, 1) !important;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.7) !important;
 }
 
 strike {
-    text-decoration-color: rgba(192, 198, 212, 1) !important;
+    text-decoration-color: rgba(255, 255, 255, 0.7) !important;
 }
 
 strike[style="text-decoration-line: underline;"] {
-    border-bottom: 1px solid rgba(192, 198, 212, 1) !important;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.7) !important;
 }
 
 .title, .time {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .li {
@@ -31,13 +36,13 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .tooltip-inner {
-    color: rgba(192, 198, 212, 1);
+    color: rgba(255, 255, 255, 0.7);
     background-color: rgba(42, 42, 42, 1) !important;
     border: 1px solid rgba(0, 0, 0, 0.30);
 }
 
 .btn-default {
-    color: rgba(197, 207, 224, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .dropdown-menu {
@@ -45,15 +50,15 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .colorFont {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .dropdown-fontsize li a {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .dropdown-fontname li a {
-    color: rgba(192, 198, 212, 1) !important
+    color: rgba(255, 255, 255, 0.7) !important
 }
 
 .wifi-symbol .first {
@@ -85,11 +90,11 @@ strike[style="text-decoration-line: underline;"] {
 }
 
 .dropdown-fontsize>li>a, .dropdown-fontname>li>a {
-    color: rgba(197, 207, 224, 1)
+    color: rgba(255, 255, 255, 0.7)
 }
 
 .icon-forecolor .path1 {
-    color: rgba(192, 198, 212, 1);
+    color: rgba(255, 255, 255, 0.7);
 }
 
 .icon-backcolor .path5 {
@@ -129,5 +134,24 @@ body::-webkit-scrollbar-thumb:active,
 }
 
 .translate>div {
-    color: rgba(192, 198, 212, 1) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
+}
+
+/* 深色主题 Web 右键菜单覆盖（浅色侧 index.css 已为 #000，此处补深色覆盖） */
+.context-menu-wrap {
+    background: rgba(42, 42, 42, 0.98) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+}
+
+.context-menu-wrap ul.list {
+    border-top: 2px solid rgba(255, 255, 255, 0.1) !important;
+}
+
+.context-menu-wrap .context-li {
+    color: rgba(255, 255, 255, 0.7) !important;
+}
+
+.context-menu-wrap .disabled-li,
+.context-menu-wrap .disabled-li:hover {
+    color: rgba(255, 255, 255, 0.3) !important;
 }

--- a/assets/web/index.js
+++ b/assets/web/index.js
@@ -999,7 +999,7 @@ function changeColor(flag, activeColor, disableColor, backgroundColor) {
         if (flag == 1) {
             $('.dropdown-fontsize>li>a').css('color', "black");
         } else {
-            $('.dropdown-fontsize>li>a').css('color', "rgba(197,207,224,1)");
+            $('.dropdown-fontsize>li>a').css('color', "rgba(255,255,255,0.7)");
         }
     })
     $('.dropdown-fontname>li>a').hover(function (e) {
@@ -1009,7 +1009,7 @@ function changeColor(flag, activeColor, disableColor, backgroundColor) {
         if (flag == 1) {
             $('.dropdown-fontname>li>a').css('color', "black");
         } else {
-            $('.dropdown-fontname>li>a').css('color', "rgba(197,207,224,1)");
+            $('.dropdown-fontname>li>a').css('color', "rgba(255,255,255,0.7)");
         }
     })
     $('body').css('background-color', global_themeColor)


### PR DESCRIPTION
## 根因分析（PMS 244985 — 【专业版1070】1070文字颜色修改）

语音记事本富文本编辑器为 `QWebEngineView` + summernote，深色主题经 C++ `onThemeChanged` → JS `changeColor(flag)` 动态加载 `dark.css`。根因有二：

1. **深色编辑区默认色（核心缺陷）**：`dark.css` 仅用 `!important` 覆盖了 `body` 色，**未对 `.note-editable` 设任何规则**；而 `summernote.css` 把 `.note-editable` 硬编码 `color:#000; background-color:#fff`（元素自带声明不继承父级 `body` 的 `!important`）。故深色主题下编辑区文字实际渲染为 `#000`（黑），与 1070 规范目标 `#EFEFEF` 不符。
2. **深色主题文字**：`dark.css` 中 `body`/`.title,.time`/`.tooltip-inner`/`.btn-default`/`.colorFont`/`.dropdown-fontsize|fontname li a`/`.icon-forecolor .path1`/`.translate>div` 及 `u`/`strike` 装饰线硬编码为 `#C0C6D4`/`#C5CFE0`，目标为 `#FFFFFF 70%`（`rgba(255,255,255,0.7)`）；`index.js` 深色下拉 hover-out 亦置 `#C5CFE0`。Web 右键菜单 `.context-menu-wrap .context-li`（`index.css:288`）`color:#000` 无 dark 覆盖，深色下仍黑。

关键证据：`dark.css:1-3`（无 `.note-editable` 覆盖）+ `summernote.css`（`.note-editable color:#000`）+ `dark.css:18/34/40/48/52/56/88/92/132`（`#C0C6D4`/`#C5CFE0`）+ `index.js:1002/1012`（`#C5CFE0`）+ `index.css:288`（`.context-li #000` 无 dark 覆盖）。

根因复核已通过（CSS 级联静态推导确认）。

## 修复方案

- **T2 深色编辑区默认色**：`dark.css` 新增 `.note-editable { color: rgba(239,239,239,1) !important; background-color: transparent !important; }`。背景用 `transparent` 使编辑区透出已由 `page()->setBackgroundColor(dp.base())`（`webrichtexteditor.cpp:63/692`）+ `body background-color`（`index.js:1015`）设置的深色主题背景，避免硬编码可能与系统主题不一致的深色值。
- **T1 深色主题文字**：`dark.css` 中 13 处 `#C0C6D4`/`#C5CFE0` 文字/装饰色 → `rgba(255,255,255,0.7)`；`index.js:1002/1012` 深色下拉 hover-out `#C5CFE0` → `rgba(255,255,255,0.7)`。
- **Web 右键菜单深色**：`dark.css` 新增 `.context-menu-wrap` 深色覆盖（背景 `rgba(42,42,42,0.98)` + `.context-li` 文字 `rgba(255,255,255,0.7)` + `.disabled-li` `rgba(255,255,255,0.3)`），浅色侧 `#000` 不动。
- **不动项**：浅色编辑区/菜单文字（已 `#000` = T3/T4 合规）、C++ 原生右键菜单（DPalette 自动适配）、语音控件（无文字色硬编码）、色板色值（已含 `#EFEFEF`/`#000000`）。

## 改动安全评估

低风险。改动均为 CSS 色值替换 + 新增深色覆盖规则，无函数签名/逻辑/调用链变更。`dark.css`/`index.css` 自 2021–2023 以来色值稳定，无近期色值修复会被本次改动撤销。

## 修复范围确认项（PMS 截图缺失，保守处理）

PMS 244985 附件截图因专业版访问受限未能抓取，以下 5 项按 1070 规范色值保守推进：
1. `.set-tips`（`index.css:441` 蓝底白字横条）——判断为通知 banner 非常规文字，**未改**，保持 `rgba(255,255,255,1)`；
2. T1 选择器集合——已核对 `dark.css` 全部文字色值，`#C0C6D4`/`#C5CFE0` 全覆盖；`.minute`（`rgba(109,124,136,1)`）为次要/静音时间色，**未改**（保守，保留视觉层级）；
3. 语音控件——无文字色硬编码（DPalette 自动），**未改**；
4. 深色编辑区背景——用 `transparent` 透出 `dp.base()` 深色背景（与 `webrichtexteditor.cpp:63/692` 协调）；
5. 工具栏默认 `foreColor`（`#414D68`）——属色板"当前选中色"非编辑区默认文字色，**未改**。

## ⚠️ 与并行修复 PMS 244973 的重叠说明

本仓库存在并行分支 `agent/pms-bug-bot/caa94cdf` 的提交 `5a45f66d`（PMS 244973 "set rich text toolbar icon colors to 1070 spec"），已将以下选择器改为相同目标色 `rgba(255,255,255,0.7)`：`dark.css` 的 `.btn-default`/`.colorFont`/`.dropdown-fontsize li a`/`.dropdown-fontname li a`/`.dropdown-fontsize>li>a`/`.icon-forecolor .path1`、`index.js:1002/1012`，并额外处理 `.note-icon-caret`（工具栏下拉箭头）及浅色侧工具栏图标色。

本 PR 为自包含（基于锁定基线 `7f2da022`，不依赖 244973 合入），重叠选择器目标值一致无冲突。本 PR 相对 244973 的**独有改动**：`.note-editable`（T2 编辑区默认色 `#EFEFEF` + 透明背景）、`body`、`.title,.time`、`.tooltip-inner`、`.translate>div`、`u`/`strike` 装饰线、`.context-menu-wrap` Web 右键菜单深色覆盖。若 244973 先合入，本 PR 重叠部分自动变为 no-op，独有部分正常合入。

## 改动文件

- `assets/web/css/dark.css` — 13 处深色文字色值 → `rgba(255,255,255,0.7)`；新增 `.note-editable`（T2）+ `.context-menu-wrap` 深色覆盖
- `assets/web/index.js` — 2 处深色下拉 hover-out `#C5CFE0` → `rgba(255,255,255,0.7)`

> 项目存在已有测试 `tests/`，建议自行运行验证。

## Summary by Sourcery

Align the rich text editor dark theme with 1070 design spec by updating default text colors and contextual menu styling.

New Features:
- Define a dedicated dark-theme default text color for the editor content area that respects the page background.
- Add dark-theme styling for the web right-click context menu, including normal and disabled item states.

Bug Fixes:
- Fix dark-theme editor content rendering with incorrect black text by overriding summernote defaults with the specified light text color.

Enhancements:
- Standardize various dark-theme UI text and decoration colors to use 70% white for better consistency and readability.