### PR TITLE
fix: record in mono to avoid silent right earphone on mono mic

### DIFF
--- a/src/common/gstreamrecorder.cpp
+++ b/src/common/gstreamrecorder.cpp
@@ -6,7 +6,7 @@
 #include "gstreamrecorder.h"
 #include <DLog>
 
-static const QString mp3Encoder = "capsfilter caps=audio/x-raw,rate=44100,channels=2 ! lamemp3enc name=enc target=1 cbr=true bitrate=192";
+static const QString mp3Encoder = "capsfilter caps=audio/x-raw,rate=44100,channels=1 ! lamemp3enc name=enc target=1 cbr=true bitrate=192";
 
 /**
  * @brief bufferProbe
@@ -392,8 +392,10 @@ void GstreamRecorder::initFormat()
 {
     //未压缩数据
     m_format.setCodec("audio/pcm");
-    //通道，采样率
-    m_format.setChannelCount(2);
+    //通道，采样率——强制单声道：audioconvert 将输入源降混为 mono，
+    //避免双孔耳机麦克风经 PulseAudio 以 2 声道（右声道静音）暴露时
+    //编码出右声道静音的 MP3，确保回放左右耳机均有声
+    m_format.setChannelCount(1);
     m_format.setSampleRate(44100);
     //lamemp3enc 编码器插件格式为S16LE
     m_format.setByteOrder(QAudioFormat::LittleEndian);


### PR DESCRIPTION
## 根因分析

**PMS 250059：【1070第四轮】双孔耳机录音后右耳机无声**（根因已通过独立复核，强根因）

录音管线声道数硬编码为立体声（`src/common/gstreamrecorder.cpp`）。双孔耳机麦克风为 mono 输入，经 PulseAudio 立体声 profile 映射后 pulsesrc 提供「2 声道、右声道静音」数据；capsfilter 强制 `channels=2` 使 audioconvert 2→2 直通保留右静音，lamemp3enc 编码出右声道静音的 MP3，回放右耳机无声。

**关键证据：**
- `gstreamrecorder.cpp:9` — `capsfilter caps=audio/x-raw,rate=44100,channels=2` 编码器入口强制立体声
- `gstreamrecorder.cpp:396` — `initFormat()` 中 `m_format.setChannelCount(2)` 固定 2 声道
- 根因复核已明确：若 pulsesrc 真输出 mono，原 `channels=2` 上混为 L=R=M 两耳均有声、不会触发本 bug；触发前提是 pulsesrc 提供 2 声道（右静音）数据

## 修复方案（返工：显式声道处理 — reviewer 选项 B）

前次提交仅删除 `channels=2` 不约束声道，GStreamer 协商优先选 2→2 直通，编码器仍收到 2ch 右静音，症状依旧（reviewer 阻塞项）。本次改为**显式强制单声道**：

- `gstreamrecorder.cpp:9` — capsfilter `channels=2` → `channels=1`：强制编码器入口为单声道，audioconvert 必须将输入源（含 2ch 右静音源）降混为 mono，无 2→2 直通可能。
- `gstreamrecorder.cpp` `initFormat()` — `setChannelCount(2)` → `setChannelCount(1)`：QAudioBuffer/波形显示声道与编码产物一致（mono）。

**修复效果（按 GStreamer 协商语义确定性推导）：**
- 2ch 右静音源（根因场景）：audioconvert 被迫 2→1 降混 → mono MP3 → 回放居中，左右耳机均有声 ✓
- 真 mono 源：1→1 直通 → mono MP3 → 双耳均有声 ✓
- 真立体声源：2→1 降混 → mono MP3（语音记事本场景下 mono 为预期产物，可接受）

**为何本次确定修复症状**：capsfilter 固定 `channels=1` 是硬约束，audioconvert 必须降混以满足 caps，不存在「协商选 2→2 直通」的歧义路径；产物为 mono MP3，播放器居中输出，双耳均有声。前次「不约束声道靠协商」的方案因 2→2 直通优先而失效，本次以硬约束消除该歧义。

## 关于 reviewer 要求的设备证据

本运行环境为沙箱，无目标双孔耳机硬件与 PulseAudio 源，无法在此产出「目标设备实际协商 caps + 录音产物 ffprobe 声道数 + 双耳回放验证」的实机证据。本次修复的正确性由 GStreamer caps 协商语义确定性保证（capsfilter `channels=1` 强制 audioconvert 降混，无歧义）。实机验证（ffprobe 落盘 MP3 声道数 + 双耳回放）留待流程的「人工复测」阶段（zhangjiarui）在目标设备执行。

## 改动安全评估

**风险等级：低风险。** 仅改 `gstreamrecorder.cpp` 两处常量（capsfilter channels、initFormat channelCount），无方法签名变更、无新增成员/方法、无跨线程写入。`VNoteRecordWidget` 等调用者签名不变。已核查下游无立体声假设：`vnwaveform.cpp:142` 按 `channelCount()` 自适应（mono 时循环一次，正常），`metadataparser` 无声道引用，全 src 无 `channelCount()==2` 假设。UT 文件不受影响（无签名变更）。修改的关键行来自原始功能提交（2020-08-06），非此前 bug 修复产物，无回归风险。

## Diff 概览

```
 src/common/gstreamrecorder.cpp | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```
仅 `gstreamrecorder.cpp` 一个文件，`.h` 无改动。
