### PR TITLE
fix: correct maxNoteId maintenance after cross-folder note move

### DIFF
--- a/src/db/dbvisitor.cpp
+++ b/src/db/dbvisitor.cpp
@@ -833,6 +833,51 @@ bool UpdateNoteFolderIdDbVisitor::prepareSqls()
 }
 
 /**
+ * @brief UpdateFolderMaxNoteIdDbVisitor::UpdateFolderMaxNoteIdDbVisitor
+ * @param db
+ * @param inParam
+ * @param result
+ */
+UpdateFolderMaxNoteIdDbVisitor::UpdateFolderMaxNoteIdDbVisitor(QSqlDatabase &db, const void *inParam, void *result)
+    : DbVisitor(db, inParam, result)
+{
+}
+
+/**
+ * @brief UpdateFolderMaxNoteIdDbVisitor::prepareSqls
+ * @return true 成功
+ *
+ * 移动笔记后把记事本的 max_noteid 写回 DB，避免重启后从 DB 重新加载导致计数器回退。
+ * 参考 AddNoteDbVisitor/DelNoteDbVisitor 的 UPDATE_FOLDER_TIME 模式。
+ */
+bool UpdateFolderMaxNoteIdDbVisitor::prepareSqls()
+{
+    bool fPrepareOK = true;
+    const VNoteFolder *folder = param.newFolder;
+    if (nullptr != folder) {
+        static constexpr char const *UPDATE_FOLDER_MAXNOTEID = "UPDATE %s SET %s=%s, %s='%s' WHERE %s=%s;";
+
+        QDateTime modifyTime = QDateTime::currentDateTime();
+
+        QString updateSql;
+        updateSql.sprintf(UPDATE_FOLDER_MAXNOTEID,
+                          VNoteDbManager::FOLDER_TABLE_NAME,
+                          DBFolder::folderColumnsName[DBFolder::max_noteid].toUtf8().data(),
+                          QString("%1").arg(folder->maxNoteIdRef()).toUtf8().data(),
+                          DBFolder::folderColumnsName[DBFolder::modify_time].toUtf8().data(),
+                          modifyTime.toString(VNOTE_TIME_FMT).toUtf8().data(),
+                          DBFolder::folderColumnsName[DBFolder::folder_id].toUtf8().data(),
+                          QString("%1").arg(folder->id).toUtf8().data());
+
+        m_dbvSqls.append(updateSql);
+    } else {
+        fPrepareOK = false;
+    }
+
+    return fPrepareOK;
+}
+
+/**
  * @brief DelNoteDbVisitor::DelNoteDbVisitor
  * @param db
  * @param inParam

--- a/src/db/dbvisitor.h
+++ b/src/db/dbvisitor.h
@@ -222,6 +222,15 @@ public:
     virtual bool prepareSqls() override;
 };
 
+//更新记事本最大记事项序号（移动笔记后持久化 max_noteid）
+class UpdateFolderMaxNoteIdDbVisitor : public DbVisitor
+{
+public:
+    explicit UpdateFolderMaxNoteIdDbVisitor(QSqlDatabase &db, const void *inParam, void *result);
+
+    virtual bool prepareSqls() override;
+};
+
 //记事项删除
 class DelNoteDbVisitor : public DbVisitor
 {

--- a/src/db/vnotefolderoper.cpp
+++ b/src/db/vnotefolderoper.cpp
@@ -100,6 +100,40 @@ bool VNoteFolderOper::renameVNoteFolder(const QString &folderName)
 }
 
 /**
+ * @brief VNoteFolderOper::updateFolderMaxNoteId
+ * @param maxNoteId 新的最大记事项序号
+ * @return true 成功
+ *
+ * 把记事本的 maxNoteId 写回 DB，用于移动笔记后持久化目标/源记事本的计数器，
+ * 避免重启后从 DB 重新加载导致计数器回退、新建默认名重号。失败时回滚内存值。
+ */
+bool VNoteFolderOper::updateFolderMaxNoteId(qint32 maxNoteId)
+{
+    bool isUpdateOK = true;
+
+    if (nullptr != m_folder) {
+        qint32 oldMaxNoteId = m_folder->maxNoteIdRef();
+        QDateTime oldModifyTime = m_folder->modifyTime;
+
+        m_folder->maxNoteIdRef() = maxNoteId;
+        m_folder->modifyTime = QDateTime::currentDateTime();
+
+        UpdateFolderMaxNoteIdDbVisitor updateFolderVisitor(VNoteDbManager::instance()->getVNoteDb(), m_folder, nullptr);
+
+        if (Q_UNLIKELY(!VNoteDbManager::instance()->updateData(&updateFolderVisitor))) {
+            m_folder->maxNoteIdRef() = oldMaxNoteId;
+            m_folder->modifyTime = oldModifyTime;
+
+            isUpdateOK = false;
+        }
+    } else {
+        isUpdateOK = false;
+    }
+
+    return isUpdateOK;
+}
+
+/**
  * @brief VNoteFolderOper::loadVNoteFolders
  * @return 所有记事本数据
  */

--- a/src/db/vnotefolderoper.h
+++ b/src/db/vnotefolderoper.h
@@ -40,6 +40,8 @@ public:
     bool deleteVNoteFolder(VNoteFolder *folder);
     //重命名记事本
     bool renameVNoteFolder(const QString &folderName);
+    //更新记事本最大记事项序号（移动笔记后持久化 max_noteid）
+    bool updateFolderMaxNoteId(qint32 maxNoteId);
 
 protected:
     VNoteFolder *m_folder {nullptr};

--- a/src/db/vnoteitemoper.cpp
+++ b/src/db/vnoteitemoper.cpp
@@ -220,6 +220,31 @@ QString VNoteItemOper::getDefaultNoteName(qint64 folderId)
 }
 
 /**
+ * @brief VNoteItemOper::parseDefaultNoteSeq
+ * @param noteTitle 笔记标题
+ * @return 默认名后缀序号；非默认名或不匹配返回 0（不参与序号竞争）
+ *
+ * 与 getDefaultNoteName 互逆：默认名 = tr("Text") + 序号（见 getDefaultNoteName）。
+ * 已重命名为非「默认前缀+数字」形态的笔记返回 0，不计入 maxNoteId 推进，
+ * 其自定义名不会与后续默认「文本N」名冲突。
+ */
+qint32 VNoteItemOper::parseDefaultNoteSeq(const QString &noteTitle)
+{
+    static const QString defaultPrefix = DApplication::translate("DefaultName", "Text");
+
+    if (noteTitle.startsWith(defaultPrefix)) {
+        const QString rest = noteTitle.mid(defaultPrefix.size());
+        bool ok = false;
+        qint32 seq = rest.toInt(&ok);
+        if (ok && seq > 0) {
+            return seq;
+        }
+    }
+
+    return 0;
+}
+
+/**
  * @brief VNoteItemOper::getDefaultVoiceName
  * @return 语音项名称
  */

--- a/src/db/vnoteitemoper.h
+++ b/src/db/vnoteitemoper.h
@@ -27,6 +27,8 @@ public:
     VNOTE_ITEMS_MAP *getFolderNotes(qint64 folderId);
     //生成默认名称
     QString getDefaultNoteName(qint64 folderId);
+    //解析默认名称后缀序号（默认名「文本N」→N，非默认名/不匹配返回 0，不参与序号竞争）
+    static qint32 parseDefaultNoteSeq(const QString &noteTitle);
     //生成默认语音名称
     QString getDefaultVoiceName() const;
     //删除记事项

--- a/src/views/leftview.cpp
+++ b/src/views/leftview.cpp
@@ -18,6 +18,7 @@
 #include "common/setting.h"
 #include "widgets/vnoterightmenu.h"
 #include "db/vnoteitemoper.h"
+#include "db/vnotefolderoper.h"
 
 #include <DApplication>
 #include <DWindowManagerHelper>
@@ -557,10 +558,18 @@ bool LeftView::doNoteMove(const QModelIndexList &src, const QModelIndex &dst)
         VNoteItem *tmpData = static_cast<VNoteItem *>(StandardItemCommon::getStandardItemData(src[0]));
         if (selectFolder && tmpData->folderId != selectFolder->id) {
             VNoteItemOper noteOper;
-            VNOTE_ITEMS_MAP *srcNotes = noteOper.getFolderNotes(tmpData->folderId);
+            //移动后会改变 tmpData->folderId，提前记录源记事本 id，用于全部移出时定位源记事本
+            const qint64 srcFolderId = tmpData->folderId;
+            VNOTE_ITEMS_MAP *srcNotes = noteOper.getFolderNotes(srcFolderId);
             VNOTE_ITEMS_MAP *destNotes = noteOper.getFolderNotes(selectFolder->id);
+            //统计被拖笔记中默认名「文本N」的最大序号，用于推进目标记事本 maxNoteId
+            qint32 maxMovedSeq = 0;
             for (auto it : src) {
                 tmpData = static_cast<VNoteItem *>(StandardItemCommon::getStandardItemData(it));
+                const qint32 seq = VNoteItemOper::parseDefaultNoteSeq(tmpData->noteTitle);
+                if (seq > maxMovedSeq) {
+                    maxMovedSeq = seq;
+                }
                 //更新内存数据
                 srcNotes->lock.lockForWrite();
                 srcNotes->folderNotes.remove(tmpData->noteId);
@@ -574,12 +583,18 @@ bool LeftView::doNoteMove(const QModelIndexList &src, const QModelIndex &dst)
                 noteOper.updateFolderId(tmpData);
             }
 
-            //全部移除后重置当前记事本maxid
+            //目标记事本 maxNoteId 取「原值」与「被拖笔记最大序号+1」的较大者，避免新建默认名重号；
+            //并同步持久化，防止重启后计数器回退。序号来自默认名后缀，不是全局 noteId。
+            const qint32 newDestMaxNoteId = qMax(selectFolder->maxNoteIdRef(), maxMovedSeq + 1);
+            VNoteFolderOper(selectFolder).updateFolderMaxNoteId(newDestMaxNoteId);
+
+            //源记事本笔记全部移出时重置 maxNoteId 为 0（清空语义，与 deleteNote 一致），
+            //通过被拖笔记的 srcFolderId 定位源记事本，避免依赖 currentIndex() 的隐式假设。
             if (src.count() == m_notesNumberOfCurrentFolder) {
-                VNoteFolder *folder = reinterpret_cast<VNoteFolder *>(StandardItemCommon::getStandardItemData(currentIndex()));
-                folder->maxNoteIdRef() = 0;
-            } else {
-                selectFolder->maxNoteIdRef() += src.size();
+                VNoteFolder *srcFolder = VNoteFolderOper().getFolder(srcFolderId);
+                if (nullptr != srcFolder) {
+                    VNoteFolderOper(srcFolder).updateFolderMaxNoteId(0);
+                }
             }
             return true;
         }


### PR DESCRIPTION
## 根因分析

跨记事本拖拽（或右键"移动"）笔记后，在目标记事本新建笔记，默认名「文本N」会与刚拖入的笔记重号。

根因在 `LeftView::doNoteMove()`（`src/views/leftview.cpp`）：移动笔记后对**目标记事本 `maxNoteId`** 计数器的维护存在逻辑缺陷且未持久化，两个分支都错：

- else 分支 `selectFolder->maxNoteIdRef() += src.size()` 按"移动条数"递增；`maxNoteId` 语义是"已用最大序号/下次命名基准"（`getDefaultNoteName` 用它作「文本N」后缀），与条数无关，无法越过被拖笔记的实际序号 → 重号。
- if 分支（源全部移出）仅重置源 `maxNoteId=0`，**目标完全不更新**。
- 持久化缺口：移动走的 `UpdateNoteFolderIdDbVisitor` 只 `UPDATE note.folder_id`，不写 `vnote_folder_tbl.max_noteid`；而创建/删除路径都正确持久化了 `max_noteid`，移动路径是唯一遗漏 → 重启后计数器回退、重号复现。

关键证据：
- `src/views/leftview.cpp:582`（旧）`selectFolder->maxNoteIdRef() += src.size();` — 按条数递增，语义错误。
- `src/db/vnoteitemoper.cpp:215-216` — `getDefaultNoteName` 用 per-folder `maxNoteId` 作后缀（**非全局 noteId**），决定重号机理与修复方向。
- `src/db/dbvisitor.cpp:815-828`（旧）移动路径不写 `max_noteid`，对比 `:643`/`:865` 创建/删除路径写，证伪"故意不持久化"，移动是遗漏。

## 修复方案

1. 目标记事本 `maxNoteId = max(原值, 被拖笔记最大序号 + 1)`，序号从默认名 `note_title` 后缀解析（`VNoteItemOper::parseDefaultNoteSeq`，与 `getDefaultNoteName` 共用同一翻译前缀，locale 无关；已重命名/不匹配「文本N」的笔记返回 0 不参与序号竞争）。**序号是名称后缀，不是全局 `noteId`**——按 noteId 实现会跳号空洞。
2. if/else 统一：无论是否全部移出，目标都按上式更新 + 持久化。
3. 源记事本仅"全部移出"时重置 `maxNoteId=0`（清空语义，与 `deleteNote` 一致），并通过被拖笔记的 `folderId` 定位源记事本，去掉原 `currentIndex()` 隐式假设。
4. 新增 `UpdateFolderMaxNoteIdDbVisitor` + `VNoteFolderOper::updateFolderMaxNoteId()`，把受影响记事本的 `max_noteid` 写回 DB（SQL 模式参考 `AddNoteDbVisitor`/`DelNoteDbVisitor` 的 `UPDATE_FOLDER_TIME`），失败回滚内存值。

## 改动安全评估

低-中风险，无高风险触发项：无函数签名变更、无公开成员变更、无公开函数删除；`doNoteMove` 的 3 个调用方（拖拽 `onDropNote`、右键 `NoteMove`、多选 `Move`）均以原签名调用，仅内部行为由"错误维护"变为"正确维护 + 持久化"，无合法调用方依赖旧的错误行为。blame 确认被改代码是原始逻辑（非此前 bug 修复产物），不存在撤销历史修复的回归风险。新增持久化 SQL 失败时回滚内存，笔记移动本身不受影响，最坏退化为原现象（不丢数据）。

## 关联

- Multica 子 Issue：WS-1134（bug-fix-373649）
- PMS：BUG-373649 — https://pms.uniontech.com/bug-view-373649.html

## 回归建议（供 reviewer / 人工复测）

- 跨记事本拖 1 个 / 多个不同序号笔记到目标；
- 源记事本全部移出 / 部分移出；
- 源/目标为空或满的边界；
- 拖入已重命名的笔记（非「文本N」格式）；
- 拖入后新建笔记默认名不重复且递增；
- 重启后 `maxNoteId` 不回退。

## Summary by Sourcery

Fix folder note-number tracking when moving notes across folders and persist the corrected counters.

Bug Fixes:
- Correct per-folder default note numbering after moving notes between folders, preventing duplicate default names for moved notes and newly created notes.
- Persist updated folder note-number counters after moves so numbering remains correct across application restarts.

Enhancements:
- Reset the source folder counter when all of its notes are moved and handle moved notes with custom titles without advancing the default-name sequence.