### PR TITLE
fix(editor): align virtual keyboard behavior for new notes

### DIFF
--- a/src/common/jscontent.cpp
+++ b/src/common/jscontent.cpp
@@ -19,6 +19,8 @@
 #include <QImage>
 #include <QDebug>
 #include <QApplication>
+#include <QGuiApplication>
+#include <QInputMethod>
 // 条件编译：Qt5 需要包含 functional 头文件
 #ifdef USE_QT5
 #include <functional>
@@ -36,6 +38,20 @@ JsContent *JsContent::instance()
     // qInfo() << "JsContent instance requested";
     static JsContent _instance;
     return &_instance;
+}
+
+void JsContent::jsCallShowInputMethod()
+{
+    if (QGuiApplication::inputMethod()) {
+        QGuiApplication::inputMethod()->show();
+    }
+}
+
+void JsContent::jsCallHideInputMethod()
+{
+    if (QGuiApplication::inputMethod()) {
+        QGuiApplication::inputMethod()->hide();
+    }
 }
 
 /**

--- a/src/common/jscontent.h
+++ b/src/common/jscontent.h
@@ -47,6 +47,11 @@ public:
     // 提供前端 AppData 基准路径：file://{AppData}/
     Q_INVOKABLE QString jsCallGetAppDataPath();
 
+    // 用户点击编辑区时请求显示/重新显示软键盘。
+    Q_INVOKABLE void jsCallShowInputMethod();
+    // 新建笔记程序化聚焦后隐藏软键盘，保留原生光标。
+    Q_INVOKABLE void jsCallHideInputMethod();
+
 signals:
     void callJsInitData(const QString &jsonData); //调用web前端，设置json格式数据
     void callJsSetHtml(const QString &html); //调用web前端，设置html格式数据

--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -345,11 +345,11 @@ Item {
             folderListView.currentIndex = 0;
             folderListView.lastCurrentIndex = 0;
             folderListView.contextIndex = 0;
+            root.forceActiveFocus();
             VNoteMainManager.createNoteInFolderId(folderData.folderId);
             if (folderListView.itemAtIndex(folderListView.currentIndex + 1)) {
                 folderListView.itemAtIndex(folderListView.currentIndex + 1).isHovered = false;
             }
-            root.forceActiveFocus();
         }
     }
 

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -552,6 +552,13 @@ ApplicationWindow {
         visible: !(needHideSearch && search.visible) || leftBgArea.visible
         z: 100
 
+        onPressedChanged: {
+            if (pressed) {
+                forceActiveFocus();
+                webEngineView.leaveEditorInputState();
+            }
+        }
+
         onClicked: {
             toggleTwoColumnMode();
         }

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -127,6 +127,16 @@ Item {
         webView.forceActiveFocus();
     }
 
+    function leaveEditorInputState() {
+        if (!webView) {
+            Webobj.jsCallHideInputMethod();
+            return;
+        }
+        webView.runJavaScript("if (typeof blurEditor === 'function') blurEditor();", function() {
+            Webobj.jsCallHideInputMethod();
+        })
+    }
+
     function showJsContextMenu() {
         // 仅在编辑区可见时尝试弹出；是否在编辑器内由JS自行判断
         if (webVisible) {

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -271,7 +271,7 @@ new QWebChannel(qt.webChannelTransport,
         webobj.callJsHideEditToolbar.connect(hideRightMenu);
         webobj.callJsClipboardDataChanged.connect(shearPlateChange);
         webobj.callJsSetVoicePlayBtnEnable.connect(playButColor);
-        webobj.callJsFocusEditor.connect(focusEditor);
+        webobj.callJsFocusEditor.connect(focusEditorWithoutInputMethod);
         webobj.callJsSetFontList.connect(setFontList);
 
         webobj.callJsVoicePlayProgressChanged.connect(updateProgressBar);
@@ -969,6 +969,83 @@ function playButColor(status) {
 function focusEditor() {
     $('#summernote').summernote('editor.focus')
 }
+
+function blurEditor() {
+    var editable = document.querySelector('.note-editable');
+    var activeElement = document.activeElement;
+
+    if (activeElement && activeElement.blur) {
+        activeElement.blur();
+    }
+    if (editable && editable.blur) {
+        editable.blur();
+    }
+}
+
+var suppressProgrammaticInputMethodTimers = [];
+
+function clearProgrammaticInputMethodSuppress() {
+    suppressProgrammaticInputMethodTimers.forEach(function (timer) {
+        window.clearTimeout(timer);
+    });
+    suppressProgrammaticInputMethodTimers = [];
+}
+
+function hideInputMethodAfterProgrammaticFocus() {
+    clearProgrammaticInputMethodSuppress();
+
+    // 第一次新建时 Qt/Chromium 拉起输入法可能晚于 editor.focus() 当前事件轮次，
+    // 这里仅针对“程序化新建聚焦”做短延迟兜底，保留原生光标，不影响用户点击后的 show。
+    [0, 80, 200].forEach(function (delay) {
+        suppressProgrammaticInputMethodTimers.push(window.setTimeout(function () {
+            if (webobj && webobj.jsCallHideInputMethod) {
+                webobj.jsCallHideInputMethod();
+            }
+        }, delay));
+    });
+}
+
+function focusEditorWithoutInputMethod() {
+    // 保留 Summernote/Chromium 原生光标，不做任何自绘；只抑制这次程序化聚焦带出的软键盘。
+    focusEditor();
+    hideInputMethodAfterProgrammaticFocus();
+}
+
+var inputMethodShowTimer = null;
+
+function shouldRequestInputMethodByUserClick(event) {
+    var nativeEvent = event.originalEvent || event;
+    if ((event.type === 'mouseup' || event.type === 'pointerup')
+        && typeof nativeEvent.button === 'number'
+        && nativeEvent.button !== 0) {
+        return false;
+    }
+
+    // 语音块、图片和其它可点击控件不属于正文输入点，避免误弹软键盘。
+    var nonTextTarget = $(event.target).closest('.voiceBox, img, button, a, input, textarea, select');
+    return nonTextTarget.length === 0;
+}
+
+function requestInputMethodByUserClick(event) {
+    if (!shouldRequestInputMethodByUserClick(event)) {
+        return;
+    }
+
+    clearProgrammaticInputMethodSuppress();
+    if (inputMethodShowTimer) {
+        window.clearTimeout(inputMethodShowTimer);
+    }
+    inputMethodShowTimer = window.setTimeout(function () {
+        inputMethodShowTimer = null;
+        if (webobj && webobj.jsCallShowInputMethod) {
+            webobj.jsCallShowInputMethod();
+        }
+    }, 0);
+}
+
+// 编辑区可能已经保持焦点；软键盘被用户收起后，再次点击不会触发新的 focus 事件，
+// 因此这里按“用户点击正文文本区域”重新请求输入法显示，不改变光标位置。
+$(document).on('pointerup mouseup touchend', '.note-editable', requestInputMethodByUserClick);
 
 //录音插入数据
 function insertVoiceItem(text) {


### PR DESCRIPTION
Keep the native Summernote caret when a blank note is created, but suppress the virtual keyboard triggered by programmatic editor focus. Re-show the input method only when the user clicks the editable text area so hiding and clicking again works consistently.

Move the folder-list focus in the initial notebook creation path before the automatic note creation, so the WebEngine editor remains the final focus target and the blank note shows the native caret.

修复新建空白笔记的软键盘和光标行为：程序化聚焦保留原生光标但隐藏软键盘；用户点击正文时重新显示软键盘；初始化页创建记事本后自动新建笔记时避免文件夹列表最终抢焦点导致无光标。

Log: 修复新建笔记光标及软键盘行为不一致问题

PMS: TASK-394163

Influence: 新建空白笔记保持原生光标且不自动弹出软键盘；隐藏软键盘后再次点击正文可重新弹出；初始化页创建后的空白笔记光标行为与普通新建保持一致。

## Summary by Sourcery

Align blank-note editor focus and virtual keyboard behavior across programmatic creation and user interaction.

Bug Fixes:
- Ensure newly created blank notes retain the native editor caret without automatically opening the virtual keyboard.
- Allow the virtual keyboard to reappear when users click the editable note body after dismissing it.
- Make blank-note focus behavior consistent when a notebook is created during initialization.

Enhancements:
- Improve editor focus transitions when leaving the editing area and avoid requesting the keyboard for non-text controls.