### PR TITLE
fix: resolve context menu not showing on first right-click in note editor

### DIFF
--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -376,26 +376,32 @@ Item {
                         req.accepted = true;
                         return;
                     }
-                    // 仅当菜单是文本类型时，我们才在QML层根据上下文标记(editFlags)更新状态
-                    // 这是为了精确修复Qt5下文本菜单状态不更新的问题
-                    if (handler.menuTypeFromJs === WebEngineHandler.TxtMenu) {
-                        var flags = req.editFlags
-                        ActionManager.resetCtxMenu(ActionManager.TxtCtxMenu, false) // false表示禁用全部，然后逐一启用
-                        ActionManager.enableAction(ActionManager.TxtSelectAll, (flags & 1) !== 0)
-                        ActionManager.enableAction(ActionManager.TxtCopy, (flags & 2) !== 0)
-                        ActionManager.enableAction(ActionManager.TxtCut, (flags & 4) !== 0)
-                        ActionManager.enableAction(ActionManager.TxtPaste, (flags & 8) !== 0)
-                        ActionManager.enableAction(ActionManager.TxtDelete, (flags & 16) !== 0)
-                        // 只有能复制时，才能朗读
-                        ActionManager.enableAction(ActionManager.TxtSpeech, (flags & 2) !== 0)
-                        // 只有能粘贴时，才能听写
-                        ActionManager.enableAction(ActionManager.TxtDictation, (flags & 8) !== 0)
-                    }
-
-                    // 对于所有菜单类型，都调用C++的处理器
-                    // C++将处理特殊逻辑(如解析语音路径)并最终弹出菜单
-                    handler.onContextMenuRequested(req)
-
+                    // 异步获取 JS 侧菜单类型并同步设置 menuType，再交给 C++ 处理器。
+                    // 不能直接依赖 menuType：它由 QWebChannel 异步设置的
+                    // jsCallPopupMenu 写入，首次右键时仍为默认值 MaxMenu，会导致
+                    // C++ switch 落入 default 不弹任何菜单（BUG-350743）。
+                    // 参照同文件 Tiptap 路径的已验证模式：先 runJavaScript 取类型，
+                    // 回调中 onSaveMenuParam 后再 onContextMenuRequested。
+                    webView.runJavaScript(
+                        "(function(){"
+                        + "if(typeof isRangeVoice!=='function')"
+                        + "  return JSON.stringify({type:2,json:''});"
+                        + "try{var i=isRangeVoice();"
+                        + "  return JSON.stringify({type:i.flag,json:i.info||''});}"
+                        + "catch(e){return JSON.stringify({type:2,json:''});}"
+                        + "})()",
+                        function(result) {
+                            var info = null;
+                            try { info = JSON.parse(result); } catch(e) {}
+                            if (!info) {
+                                handler.onSaveMenuParam(2, "");
+                            } else {
+                                handler.onSaveMenuParam(info.type, info.json);
+                            }
+                            // C++ 处理器根据 menuType 处理特殊逻辑（语音路径解析、
+                            // editFlags 更新等）并最终弹出菜单
+                            handler.onContextMenuRequested(req);
+                        });
                     // 阻止默认菜单弹出
                     req.accepted = true;
                 }


### PR DESCRIPTION
## 根因分析

语音记事本新建笔记后右键无响应，根因为**异步竞态条件**：

- 右键菜单类型（文本/语音/图片）由 `WebEngineHandler::menuType` 决定，该值通过 QWebChannel 异步链路（JS `rightClick` → `jsCallPopupMenu` → `onSaveMenuParam`）设置
- QWebChannel 消息传递经 IPC + 事件循环队列，执行时机**晚于** QtWebEngine 原生 `onContextMenuRequested` 信号
- 首次右键时 `menuType` 仍为默认值 `MaxMenu`，C++ `switch(menuType)` 落入 `default: break;` 不弹任何菜单

关键证据：
- `web_engine_handler.h:134` — `Menu menuType { MaxMenu };`，switch 无对应 case
- `WebEngineView.qml:381` — `handler.menuTypeFromJs` 在 C++ 类中未定义，条件恒 false，editFlags 更新为死代码
- `WebEngineView.qml:518-542` — 同文件 Tiptap 路径已用正确模式处理此问题

## 修复方案

参照同文件 Tiptap 调试编辑器路径的已验证模式，在主编辑器（Summernote）的 `onContextMenuRequested` 中：
1. 先通过 `runJavaScript` 调用已有的 `isRangeVoice()` 异步获取菜单类型
2. 在回调中同步设置 `handler.onSaveMenuParam(type, json)`
3. 然后调用 `handler.onContextMenuRequested(req)`

确保 C++ 处理器使用正确的 `menuType`，消除对 QWebChannel 异步时序的依赖。同时移除引用未定义属性 `menuTypeFromJs` 的死代码。

改动范围：仅 `src/gui/mainwindow/WebEngineView.qml` 的 `onContextMenuRequested` 处理器（+26/-20 行）。

## 改动安全评估

**低风险**：仅替换 QML 信号处理器内部逻辑（局部作用域），不修改 C++ 函数签名，不影响单元测试，采用同文件已验证模式。

## Summary by Sourcery

Fix first-click context-menu handling in the note editor by synchronizing the JavaScript menu type with native menu processing.

Bug Fixes:
- Ensure the note editor’s context menu appears on the first right-click by resolving the menu type before invoking the native context-menu handler.

Enhancements:
- Remove unused menu-type-dependent edit-action logic from the QML context-menu handler.