### PR TITLE
fix(editor): prevent keyboard flash on initial note creation

### DIFF
--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -345,7 +345,6 @@ Item {
             folderListView.currentIndex = 0;
             folderListView.lastCurrentIndex = 0;
             folderListView.contextIndex = 0;
-            root.forceActiveFocus();
             VNoteMainManager.createNoteInFolderId(folderData.folderId);
             if (folderListView.itemAtIndex(folderListView.currentIndex + 1)) {
                 folderListView.itemAtIndex(folderListView.currentIndex + 1).isHovered = false;

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -967,10 +967,12 @@ function playButColor(status) {
 }
 
 function focusEditor() {
+    setEditorInputMethodEnabled(true);
     $('#summernote').summernote('editor.focus')
 }
 
 function blurEditor() {
+    setEditorInputMethodEnabled(true);
     var editable = document.querySelector('.note-editable');
     var activeElement = document.activeElement;
 
@@ -991,23 +993,42 @@ function clearProgrammaticInputMethodSuppress() {
     suppressProgrammaticInputMethodTimers = [];
 }
 
+function setEditorInputMethodEnabled(enabled) {
+    var editable = document.querySelector('.note-editable');
+    if (!editable) {
+        return;
+    }
+
+    if (enabled) {
+        editable.removeAttribute('inputmode');
+    } else {
+        // 程序化 focus 时禁用虚拟键盘请求，保留 contenteditable 的原生光标。
+        editable.setAttribute('inputmode', 'none');
+    }
+}
+
+function hideInputMethod() {
+    if (webobj && webobj.jsCallHideInputMethod) {
+        webobj.jsCallHideInputMethod();
+    }
+}
+
 function hideInputMethodAfterProgrammaticFocus() {
     clearProgrammaticInputMethodSuppress();
 
     // 第一次新建时 Qt/Chromium 拉起输入法可能晚于 editor.focus() 当前事件轮次，
     // 这里仅针对“程序化新建聚焦”做短延迟兜底，保留原生光标，不影响用户点击后的 show。
-    [0, 80, 200].forEach(function (delay) {
-        suppressProgrammaticInputMethodTimers.push(window.setTimeout(function () {
-            if (webobj && webobj.jsCallHideInputMethod) {
-                webobj.jsCallHideInputMethod();
-            }
-        }, delay));
+    [0, 60, 160].forEach(function (delay) {
+        suppressProgrammaticInputMethodTimers.push(window.setTimeout(hideInputMethod, delay));
     });
 }
 
 function focusEditorWithoutInputMethod() {
-    // 保留 Summernote/Chromium 原生光标，不做任何自绘；只抑制这次程序化聚焦带出的软键盘。
-    focusEditor();
+    // 程序化新建聚焦需要原生光标，但不能请求软键盘；inputmode=none 从源头阻止键盘闪现。
+    setEditorInputMethodEnabled(false);
+    hideInputMethod();
+    $('#summernote').summernote('editor.focus')
+    hideInputMethod();
     hideInputMethodAfterProgrammaticFocus();
 }
 
@@ -1032,6 +1053,7 @@ function requestInputMethodByUserClick(event) {
     }
 
     clearProgrammaticInputMethodSuppress();
+    setEditorInputMethodEnabled(true);
     if (inputMethodShowTimer) {
         window.clearTimeout(inputMethodShowTimer);
     }


### PR DESCRIPTION
Remove the folder-list forced focus in the initial notebook creation path so the auto-created note can keep the editor as the final focus target.

Disable the editable area's input method request with inputmode=none before programmatic editor focus, then restore it for normal editor focus and user clicks. This keeps the native caret for new blank notes while preventing the virtual keyboard from flashing during initial-page creation.

修复初始化页面创建笔记时软键盘闪现：去掉自动创建笔记前的列表强制焦点；程序化聚焦前临时禁用编辑区输入法请求，用户点击正文时恢复，保留原生光标且不弹软键盘。

Log: 修复初始化创建笔记软键盘闪现

PMS: TASK-394163

Influence: 初始化页创建空白笔记时不再出现软键盘闪现；新建笔记仍保留原生光标，用户点击正文后软键盘正常弹出。

## Summary by Sourcery

Prevent virtual keyboard flashes during initial blank-note creation while preserving normal editor focus and input behavior.

Bug Fixes:
- Prevent the virtual keyboard from flashing when creating and focusing an initial blank note.
- Preserve the native editor caret while allowing the keyboard to appear normally after user interaction.

Enhancements:
- Keep the editor as the final focus target during automatic note creation instead of forcing focus back to the folder list.