### PR TITLE
fix(audio): support virtual microphone sources without ports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,8 +151,10 @@ find_package(Qt5Svg REQUIRED)
 find_package(Qt5Xml REQUIRED)
 find_package(DFrameworkdbus REQUIRED)
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
+pkg_check_modules(PULSE REQUIRED libpulse)
 pkg_check_modules(LIBVLC REQUIRED libvlc)
 include_directories(${GSTREAMER_INCLUDE_DIRS})
+include_directories(${PULSE_INCLUDE_DIRS})
 include_directories(${LIBVLC_INCLUDE_DIRS})
 include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 include_directories(${Qt5Svg_INCLUDE_DIRS})
@@ -170,6 +172,7 @@ target_link_libraries(${APP_BIN_NAME}
     ${DtkCore_LIBRARIES}
     ${DFrameworkdbus_LIBRARIES}
     ${GSTREAMER_LIBRARIES}
+    ${PULSE_LIBRARIES}
     ${LIBVLC_LIBRARIES}
     Qt5::Core
     Qt5::Gui

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends:
  libdtkwidget-dev,
  libdframeworkdbus-dev,
  libgstreamer1.0-dev,
+ libpulse-dev,
  libvlc-dev,
  libvlccore-dev,
  libqt5webchannel5-dev,

--- a/src/common/audiowatcher.cpp
+++ b/src/common/audiowatcher.cpp
@@ -7,6 +7,100 @@
 #include "globaldef.h"
 
 #include <DLog>
+#include <QElapsedTimer>
+#include <QFutureWatcher>
+#include <QThread>
+#include <QtConcurrent>
+
+#include <pulse/pulseaudio.h>
+
+namespace {
+constexpr qint64 kPulseProbeCacheDurationMs = 5000;
+
+struct PulseSourceProbe
+{
+    bool finished = false;
+    bool found = false;
+    bool monitor = false;
+    pa_source_state_t state = PA_SOURCE_INVALID_STATE;
+};
+
+void onPulseSourceInfo(pa_context *, const pa_source_info *info, int eol, void *userdata)
+{
+    auto probe = static_cast<PulseSourceProbe *>(userdata);
+    if (eol != 0) {
+        probe->finished = true;
+        return;
+    }
+
+    if (info) {
+        probe->found = true;
+        probe->monitor = info->monitor_of_sink != PA_INVALID_INDEX;
+        probe->state = info->state;
+    }
+}
+
+bool probePulseSource(const QString &sourceName)
+{
+    pa_mainloop *mainloop = pa_mainloop_new();
+    if (!mainloop) {
+        return false;
+    }
+
+    pa_context *context = pa_context_new(pa_mainloop_get_api(mainloop), "deepin-voice-note");
+    if (!context || pa_context_connect(context, nullptr, PA_CONTEXT_NOFLAGS, nullptr) < 0) {
+        if (context) {
+            pa_context_unref(context);
+        }
+        pa_mainloop_free(mainloop);
+        return false;
+    }
+
+    QElapsedTimer timer;
+    timer.start();
+    pa_context_state_t contextState = PA_CONTEXT_UNCONNECTED;
+    while (timer.elapsed() < 500) {
+        pa_mainloop_iterate(mainloop, 0, nullptr);
+        contextState = pa_context_get_state(context);
+        if (contextState == PA_CONTEXT_READY || !PA_CONTEXT_IS_GOOD(contextState)) {
+            break;
+        }
+        QThread::msleep(5);
+    }
+
+    PulseSourceProbe probe;
+    pa_operation *operation = nullptr;
+    if (contextState == PA_CONTEXT_READY) {
+        operation = pa_context_get_source_info_by_name(context,
+                                                       sourceName.toUtf8().constData(),
+                                                       onPulseSourceInfo,
+                                                       &probe);
+        timer.restart();
+        while (operation && !probe.finished && timer.elapsed() < 500) {
+            pa_mainloop_iterate(mainloop, 0, nullptr);
+            QThread::msleep(5);
+        }
+    }
+
+    if (operation) {
+        pa_operation_unref(operation);
+    }
+    pa_context_disconnect(context);
+    pa_context_unref(context);
+    pa_mainloop_free(mainloop);
+
+    const bool validState = probe.state == PA_SOURCE_RUNNING
+            || probe.state == PA_SOURCE_IDLE
+            || probe.state == PA_SOURCE_SUSPENDED;
+    const bool recordable = probe.finished && probe.found && !probe.monitor && validState;
+    qInfo() << "PulseAudio source probe:" << sourceName
+            << "found:" << probe.found
+            << "monitor:" << probe.monitor
+            << "state:" << probe.state
+            << "recordable:" << recordable;
+    return recordable;
+}
+}
 
 bool AudioWatcher::kInIsEnable  = false;
 bool AudioWatcher::kOutIsEnable = false;
@@ -432,6 +526,10 @@ void AudioWatcher::onDefaultSourceChanaged(const QDBusObjectPath &defaultSourceP
                                                  SLOT(onDBusAudioPropertyChanged(QDBusMessage))
                                                 );
         m_defaultSourcePath = newPath;
+        m_probedPulseSource.clear();
+        m_probedPulseSourceRecordable = false;
+        m_probingPulseSource.clear();
+        m_pulseProbeCacheTimer.invalidate();
         if (!newPath.isEmpty() && newPath != "/") {
             qInfo() << "Re-initializing default source D-Bus interface for path:" << newPath;
             initDefaultSourceDBusInterface();
@@ -540,16 +638,69 @@ QString AudioWatcher::getDeviceName(AudioMode mode)
             }
         }
     } else {
-        if ((m_inAudioPort.availability != 1 || !m_fNeedDeviceChecker) &&
-                (defaultSourcePorts().count() != 0 || m_isVirtualMachineHw)) {
-            //if (m_inAudioPort.availability != 1 || !m_fNeedDeviceChecker) {
-            device = defaultSourceName();
-            if (device.endsWith(".monitor") && m_fNeedDeviceChecker) {
-                device.clear();
-            }
+        const QString sourceName = defaultSourceName();
+        const bool hasPorts = !defaultSourcePorts().isEmpty();
+        const bool portAvailable = m_inAudioPort.availability != 1;
+        if (isMicrophoneSourceAvailable(sourceName,
+                                        hasPorts,
+                                        portAvailable,
+                                        m_fNeedDeviceChecker)
+                && (hasPorts || isPulseSourceRecordable(sourceName))) {
+            device = sourceName;
         }
     }
     return device;
+}
+
+bool AudioWatcher::isMicrophoneSourceAvailable(const QString &sourceName,
+                                               bool hasPorts,
+                                               bool portAvailable,
+                                               bool needDeviceChecker)
+{
+    if (sourceName.isEmpty() || sourceName.endsWith(".monitor")) {
+        return false;
+    }
+
+    // 虚拟输入源可能没有 Card/Port 元数据，不能将“无端口”当作明确禁用。
+    return !needDeviceChecker || !hasPorts || portAvailable;
+}
+
+bool AudioWatcher::isPulseSourceRecordable(const QString &sourceName)
+{
+    const bool hasCachedResult = sourceName == m_probedPulseSource;
+    if (hasCachedResult
+            && m_pulseProbeCacheTimer.isValid()
+            && m_pulseProbeCacheTimer.elapsed() < kPulseProbeCacheDurationMs) {
+        return m_probedPulseSourceRecordable;
+    }
+
+    startPulseSourceProbe(sourceName);
+    return hasCachedResult && m_probedPulseSourceRecordable;
+}
+
+void AudioWatcher::startPulseSourceProbe(const QString &sourceName)
+{
+    if (sourceName.isEmpty() || sourceName == m_probingPulseSource) {
+        return;
+    }
+
+    m_probingPulseSource = sourceName;
+    auto watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher, sourceName]() {
+        const bool recordable = watcher->result();
+        watcher->deleteLater();
+        if (m_probingPulseSource == sourceName) {
+            m_probingPulseSource.clear();
+        }
+        if (sourceName != defaultSourceName()) {
+            return;
+        }
+        m_probedPulseSource = sourceName;
+        m_probedPulseSourceRecordable = recordable;
+        m_pulseProbeCacheTimer.start();
+        emit sigDeviceEnableChanged(Micphone, recordable);
+    });
+    watcher->setFuture(QtConcurrent::run(probePulseSource, sourceName));
 }
 
 /**
@@ -579,6 +730,20 @@ bool AudioWatcher::getMute(AudioMode mode)
  */
 bool AudioWatcher::getDeviceEnable(AudioWatcher::AudioMode mode)
 {
+    if (mode == Micphone) {
+        const QString sourceName = defaultSourceName();
+        const QList<AudioPort> ports = defaultSourcePorts();
+        if (isMicrophoneSourceAvailable(sourceName,
+                                        !ports.isEmpty(),
+                                        m_inAudioPort.availability != 1,
+                                        m_fNeedDeviceChecker)
+                && ports.isEmpty()
+                && isPulseSourceRecordable(sourceName)) {
+            qInfo() << "Enable no-port PulseAudio source:" << sourceName;
+            return true;
+        }
+    }
+
     //虚拟环境的情况下是无法判断是否存在声卡的，采用(5.10.17)及以前的处理方式，默认都可用
     QString cards = m_audioDBusInterface->property("Cards").value<QString>();
     if (m_isVirtualMachineHw && (cards.isEmpty() || cards.toLower() == "null")) {

--- a/src/common/audiowatcher.h
+++ b/src/common/audiowatcher.h
@@ -7,6 +7,7 @@
 #define AudioWatcher_H
 
 #include <QObject>
+#include <QElapsedTimer>
 #include <QtDBus/QtDBus>
 
 #ifdef OS_BUILD_V23
@@ -247,6 +248,14 @@ private:
      * @return
      */
     AudioPort currentAuidoPort(const QList<AudioPort> &auidoPorts,AudioMode audioMode);
+
+    // 判断默认输入源能否作为麦克风使用。无端口 source 不再按物理端口判定。
+    static bool isMicrophoneSourceAvailable(const QString &sourceName,
+                                            bool hasPorts,
+                                            bool portAvailable,
+                                            bool needDeviceChecker);
+    bool isPulseSourceRecordable(const QString &sourceName);
+    void startPulseSourceProbe(const QString &sourceName);
 private:
     /**
      * @brief 音频服务dbus接口
@@ -316,6 +325,10 @@ private:
       * @brief  是否是虚拟环境
       */
     bool m_isVirtualMachineHw{false};
+    QString m_probedPulseSource;
+    bool m_probedPulseSourceRecordable{false};
+    QString m_probingPulseSource;
+    QElapsedTimer m_pulseProbeCacheTimer;
 };
 
 #endif // AudioWatcher_H

--- a/src/common/gstreamrecorder.cpp
+++ b/src/common/gstreamrecorder.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2019 UnionTech Software Technology Co.,Ltd.
+// Copyright (C) 2019-2026 ~ 2019 UnionTech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -210,11 +210,20 @@ bool GstreamRecorder::startRecord()
     if (state == GST_STATE_PLAYING) {
         return true;
     } else if (state == GST_STATE_PAUSED) {
-        gst_element_set_state(m_pipeline, GST_STATE_PLAYING);
-        return true;
-    }
-    if (gst_element_set_state(m_pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
+        if (gst_element_set_state(m_pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
+            qCritical() << "resume error";
+            return false;
+        }
+    } else if (gst_element_set_state(m_pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
         qCritical() << "start error";
+        return false;
+    }
+
+    const GstStateChangeReturn stateResult = gst_element_get_state(
+        m_pipeline, nullptr, nullptr, GST_SECOND);
+    if (stateResult == GST_STATE_CHANGE_FAILURE) {
+        qCritical() << "Unable to open audio source:" << m_currentDevice;
+        gst_element_set_state(m_pipeline, GST_STATE_NULL);
         return false;
     }
     return true;

--- a/src/views/vnoterecordbar.cpp
+++ b/src/views/vnoterecordbar.cpp
@@ -333,9 +333,12 @@ void VNoteRecordBar::onChangeTheme()
 void VNoteRecordBar::onDeviceEnableChanged(int mode, bool enabled)
 {
     qInfo() << "通过控制中心改变默认设备 "<< mode << "（输出设备:0 输入设备:1）使能状态！enalbed:" <<enabled;
-    if (1 == mode) {
-        qInfo() << "录制按钮是否可点击？" << enabled;
-        m_recordBtn->setEnabled(enabled);
+    if (m_currentMode == mode) {
+        const auto audioMode = static_cast<AudioWatcher::AudioMode>(mode);
+        const bool available = !m_audioWatcher->getDeviceName(audioMode).isEmpty()
+                && m_audioWatcher->getDeviceEnable(audioMode);
+        qInfo() << "录制按钮是否可点击？" << available;
+        m_recordBtn->setEnabled(available);
     }
 }
 


### PR DESCRIPTION
## Summary
- Support valid PulseAudio microphone sources without Card/Port metadata.
- Keep physical microphone availability checks and reject system-audio monitor sources.
- Verify source startup through PulseAudio and GStreamer state handling.

## Changes
- Query PulseAudio source state and monitor_of_sink with libpulse.
- Allow non-monitor virtual sources such as hdp-source when no Port metadata is available.
- Recalculate the recording button when device availability changes.
- Add libpulse build and runtime dependency wiring.

## Validation
- cmake --build . -j2
- dpkg-buildpackage -b -us -uc
- Verified the generated deb links libpulse.so.0 and declares libpulse0.
- The repository test subdirectory is disabled in the top-level CMakeLists.txt, so unit tests were not built.

## Impact
华为云等仅提供虚拟 PulseAudio source 的环境可以使用语音记事本录音，同时避免将系统声音 monitor 误识别为麦克风。

## Summary by Sourcery

Enable reliable microphone recording from virtual PulseAudio sources while preserving physical-device checks and excluding system-audio monitors.

New Features:
- Support recording from valid non-monitor PulseAudio microphone sources that lack Card/Port metadata.

Bug Fixes:
- Prevent system-audio monitor sources from being treated as microphones and report recording startup failures when GStreamer cannot open the source.

Enhancements:
- Refresh recording availability when audio device state changes and cache asynchronous PulseAudio source checks.

Build:
- Add libpulse discovery, include paths, and linking for PulseAudio integration.