### PR TITLE
fix(migration): reload note data after migration entry

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -119,6 +119,18 @@ void VNoteMainManager::initData()
     qInfo() << "Data initialization finished";
 }
 
+void VNoteMainManager::reloadAfterMigration()
+{
+    qInfo() << "Reloading UI data after migration";
+    m_currentFolderIndex = -1;
+    m_currentNoteId = -1;
+    m_currentHasTop = 0;
+    m_noteItems.clear();
+    if (m_richTextManager)
+        m_richTextManager->initData(nullptr, QString());
+    VNoteDataManager::instance()->reloadAllData();
+}
+
 void VNoteMainManager::initConnections()
 {
     qInfo() << "Initializing connections";

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -79,6 +79,7 @@ public:
     Q_INVOKABLE QString getSavedTextPath();
     Q_INVOKABLE QString getSavedVoicePath();
     Q_INVOKABLE void saveUserSelectedPath(const QString &path, const SaveAsType type);
+    Q_INVOKABLE void reloadAfterMigration();
 
     /**
      * @brief 获取当前笔记 ID

--- a/src/common/migrationviewcontroller.cpp
+++ b/src/common/migrationviewcontroller.cpp
@@ -81,6 +81,7 @@ void MigrationViewController::enterApp()
     setReportPath(QString());
     setMigrationActive(false);
     releaseOrchestrator();
+    emit appEntered();
 }
 
 void MigrationViewController::onProgressChanged(const MigrationOrchestrator::ProgressSnapshot &snapshot)

--- a/src/common/migrationviewcontroller.h
+++ b/src/common/migrationviewcontroller.h
@@ -73,6 +73,7 @@ signals:
     void backupPathChanged();
     void reportPathChanged();
     void cancellingChanged();
+    void appEntered();
 
 private:
     explicit MigrationViewController(QObject *parent = nullptr);

--- a/src/common/vnotedatamanager.cpp
+++ b/src/common/vnotedatamanager.cpp
@@ -439,7 +439,7 @@ void VNoteDataManager::reqNoteDefIcons()
 void VNoteDataManager::reqNoteFolders()
 {
     qDebug() << "Requesting note folders";
-    if (m_pNotesLoadThread == nullptr) {
+    if (m_pForldesLoadThread == nullptr) {
         m_pForldesLoadThread = new LoadFolderWorker();
         m_pForldesLoadThread->setAutoDelete(true);
 
@@ -471,6 +471,14 @@ void VNoteDataManager::reqNoteItems()
     } else {
         qDebug() << "Note items load already in progress";
     }
+}
+
+void VNoteDataManager::reloadAllData()
+{
+    qInfo() << "Reloading all note data";
+    m_fDataState = DataState::DataNotLoaded;
+    reqNoteFolders();
+    reqNoteItems();
 }
 
 /**

--- a/src/common/vnotedatamanager.h
+++ b/src/common/vnotedatamanager.h
@@ -36,6 +36,8 @@ public:
     void reqNoteFolders();
     //加载记事项数据
     void reqNoteItems();
+    // 迁移完成后重新从数据库加载全部数据
+    void reloadAllData();
 signals:
     //记事本数据加载完成
     void noteFoldersLoaded();

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -280,6 +280,22 @@ ApplicationWindow {
     }
 
     Connections {
+        target: MigrationViewController
+
+        function onAppEntered() {
+            folderListView.model.clear();
+            itemListView.model.clear();
+            itemListView.selectedNoteItem = [];
+            itemListView.selectSize = 0;
+            itemListView.changeCurrentIndex(-1);
+            label.text = "";
+            initRect.visible = false;
+            webEngineView.webVisible = false;
+            VNoteMainManager.reloadAfterMigration();
+        }
+    }
+
+    Connections {
         function handleFinishedFolderLoad(foldersData) {
             for (var i = 0; i < foldersData.length; i++) {
                 folderListView.model.append({


### PR DESCRIPTION
Reload folders and notes after migration terminal view is dismissed.

迁移终态页放行后重新加载记事本和笔记数据。

Log: 修复首次迁移后 Tiptap 笔记内容不显示

PMS: TASK-393985

Influence: 首次迁移完成点击进入应用后会刷新数据缓存和列表，确保迁移后的

Tiptap 内容立即加载，无需重启应用。

## Summary by Sourcery

Refresh application note data after dismissing the migration completion view.

Bug Fixes:
- Reload note folders, notes, and rich-text data when entering the app after migration so migrated Tiptap content appears immediately without restarting.

Enhancements:
- Reset the active note and folder UI state before repopulating data after migration.