### PR TITLE
test(at): update voice note AT fixtures and selectors

### DIFF
--- a/src/common/migrationviewcontroller.cpp
+++ b/src/common/migrationviewcontroller.cpp
@@ -3,6 +3,8 @@
 
 #include "migrationviewcontroller.h"
 
+#include "tiptapchannelbridge.h"
+
 #include <QLoggingCategory>
 
 namespace {
@@ -26,6 +28,13 @@ void MigrationViewController::start()
     // 否则后台线程 emit 的进度/阶段/终态信号无法跨线程队列投递。
     qRegisterMetaType<MigrationOrchestrator::ProgressSnapshot>();
     qRegisterMetaType<MigrationState>();
+
+    if (!TiptapChannelBridge::instance()->debugEnabled()) {
+        qCInfo(lcMigrationView) << "start: Tiptap migration disabled by environment";
+        setMigrationActive(false);
+        setTerminalState(QString());
+        return;
+    }
 
     if (m_orchestrator || m_migrationActive) {
         qCInfo(lcMigrationView) << "start: migration already in progress, ignore";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,9 +8,10 @@
 #include "common/jscontent.h"
 #include "common/imageprovider.h"
 #include "common/vtextspeechandtrmanager.h"
+#include "common/tiptapchannelbridge.h"
 
-#include "importolddata/dbmigration/migrationorchestrator.h"  // TTP-020 后台全量迁移任务编排层
-#include "common/migrationviewcontroller.h"  // TTP-021 升级进度界面控制器
+#include "importolddata/dbmigration/migrationorchestrator.h"
+#include "common/migrationviewcontroller.h"
 #include "config.h"
 
 #include <QQmlApplicationEngine>
@@ -139,9 +140,13 @@ int main(int argc, char *argv[])
     VNoteMainManager::instance()->initNote();
     qInfo() << "Note manager initialized";
 
-    // TTP-020: DB 就绪后单行启动后台 Tiptap 全量迁移任务（两套状态独立，不干扰旧库升级）。
-    // TTP-021: 通过升级进度界面控制器启动迁移（内部拉起 TTP-020 编排器并消费进度/终态信号）。
-    MigrationViewController::instance()->start();
+    // Tiptap 数据迁移仍处于调试验证阶段，只允许在 DVN_TIPTAP_DEBUG=1 下启动。
+    // 未开启调试开关时，禁止展示迁移页、备份、扫描或写回 Summernote 数据。
+    if (TiptapChannelBridge::instance()->debugEnabled()) {
+        MigrationViewController::instance()->start();
+    } else {
+        qInfo() << "Tiptap migration skipped because DVN_TIPTAP_DEBUG is not set";
+    }
 
     DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();

--- a/tests/at/setup_voice_note_at.sh
+++ b/tests/at/setup_voice_note_at.sh
@@ -44,8 +44,32 @@ wait_for_schema()
 
 seed_default_notebook()
 {
-    sqlite3 "${DB_PATH}" \
-        "INSERT INTO vnote_folder_tbl(category_id, folder_name, default_icon, folder_state, max_noteid) VALUES(0, '记事本1', 0, 0, 0);"
+    sqlite3 "${DB_PATH}" <<'SQL'
+INSERT INTO vnote_folder_tbl(
+    folder_id,
+    category_id,
+    folder_name,
+    default_icon,
+    folder_state,
+    max_noteid
+) VALUES(1, 0, '记事本1', 0, 0, 1);
+
+INSERT INTO vnote_items_tbl(
+    note_id,
+    folder_id,
+    note_type,
+    note_title,
+    meta_data,
+    note_state
+) VALUES(
+    1,
+    1,
+    0,
+    '文本',
+    '{"htmlCode":"<p><br></p>"}',
+    0
+);
+SQL
 }
 
 stop_app

--- a/tests/at/yaml/_V25_2500_语音记事本_语音记事本102x_工具栏(#115117)_case_1635223_s1/_V25_2500_语音记事本_语音记事本102x_工具栏(#115117)_case_1635223_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500_语音记事本_语音记事本102x_工具栏(#115117)_case_1635223_s1/_V25_2500_语音记事本_语音记事本102x_工具栏(#115117)_case_1635223_s1.suite.yaml
@@ -20,5 +20,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/_V25_2500_语音记事本_语音记事本1050_标题栏(#115179)_case_1625247_s1/_V25_2500_语音记事本_语音记事本1050_标题栏(#115179)_case_1625247_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500_语音记事本_语音记事本1050_标题栏(#115179)_case_1625247_s1/_V25_2500_语音记事本_语音记事本1050_标题栏(#115179)_case_1625247_s1.suite.yaml
@@ -20,5 +20,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/_V25_2500_语音记事本_语音记事本1050_记事本条目(#115181)_case_1625243_s1/_V25_2500_语音记事本_语音记事本1050_记事本条目(#115181)_case_1625243_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500_语音记事本_语音记事本1050_记事本条目(#115181)_case_1625243_s1/_V25_2500_语音记事本_语音记事本1050_记事本条目(#115181)_case_1625243_s1.suite.yaml
@@ -19,7 +19,7 @@ suites:
   steps:
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   - action: keyboard_hot_key
@@ -27,13 +27,13 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676419_s1.suite.yaml
@@ -17,23 +17,10 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
-  - action: dtk_context_menu
-    selector:
-      name: 记事本1
-      role: label
-    items:
-    - 新建笔记
-  - action: keyboard_hot_key
-    key: alt+m
   - action: keyboard_press
-    key: return
+    key: delete
   assert_steps:
   - action: assert_element
     selector:
-      name: 确定
+      name: 删除
       role: button

--- a/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1.suite.yaml
+++ b/tests/at/yaml/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1/_V25_2500（测试部专用）_B类解耦商店应用_语音记事本_语音记事本V25(#117769)_case_1676427_s1.suite.yaml
@@ -17,17 +17,14 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
+  - action: dtk_context_menu
     selector:
-      name: 新建记事本
-      role: button
-    do: click
-  - action: keyboard_hot_key
-    key: alt+m
-  - action: keyboard_press
-    key: return
+      name: 记事本1
+      role: label
+    items:
+    - DeleteFolderMenuItem
   assert_steps:
   - action: assert_element
     selector:
-      name: 确定
+      name: 删除
       role: button

--- a/tests/at/yaml/elements.yaml
+++ b/tests/at/yaml/elements.yaml
@@ -1,6 +1,6 @@
 elements:
   新建记事本:
-    name: 新建记事本
+    name: CreateFolderButton
     role: button
   记事本1:
     name: 记事本1

--- a/tests/at/yaml/压力测试(#115107)_case_1635299_s1/压力测试(#115107)_case_1635299_s1.suite.yaml
+++ b/tests/at/yaml/压力测试(#115107)_case_1635299_s1/压力测试(#115107)_case_1635299_s1.suite.yaml
@@ -17,19 +17,19 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 删除
+    - DeleteFolderMenuItem
+  - action: element_action
+    selector:
+      name: 删除
+      role: button
+    do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/压力测试(#115107)_case_1635301_s1/压力测试(#115107)_case_1635301_s1.suite.yaml
+++ b/tests/at/yaml/压力测试(#115107)_case_1635301_s1/压力测试(#115107)_case_1635301_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/启用语音记事本(#115131)_case_1634837_s1/启用语音记事本(#115131)_case_1634837_s1.suite.yaml
+++ b/tests/at/yaml/启用语音记事本(#115131)_case_1634837_s1/启用语音记事本(#115131)_case_1634837_s1.suite.yaml
@@ -20,7 +20,7 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
   - action: assert_window_count
     expected: 1

--- a/tests/at/yaml/快捷键(#115195)_case_1624611_s1/快捷键(#115195)_case_1624611_s1.suite.yaml
+++ b/tests/at/yaml/快捷键(#115195)_case_1624611_s1/快捷键(#115195)_case_1624611_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635259_s1/快捷键使用(#115113)_case_1635259_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635259_s1/快捷键使用(#115113)_case_1635259_s1.suite.yaml
@@ -30,5 +30,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635261_s1/快捷键使用(#115113)_case_1635261_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635261_s1/快捷键使用(#115113)_case_1635261_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635263_s1/快捷键使用(#115113)_case_1635263_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635263_s1/快捷键使用(#115113)_case_1635263_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635271_s1/快捷键使用(#115113)_case_1635271_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635271_s1/快捷键使用(#115113)_case_1635271_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635277_s1/快捷键使用(#115113)_case_1635277_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635277_s1/快捷键使用(#115113)_case_1635277_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635279_s1/快捷键使用(#115113)_case_1635279_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635279_s1/快捷键使用(#115113)_case_1635279_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/快捷键使用(#115113)_case_1635281_s1/快捷键使用(#115113)_case_1635281_s1.suite.yaml
+++ b/tests/at/yaml/快捷键使用(#115113)_case_1635281_s1/快捷键使用(#115113)_case_1635281_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/搜索功能(#115119)_case_1635179_s1/搜索功能(#115119)_case_1635179_s1.suite.yaml
+++ b/tests/at/yaml/搜索功能(#115119)_case_1635179_s1/搜索功能(#115119)_case_1635179_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: '@#$%'
   - action: keyboard_press
@@ -35,5 +30,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/搜索功能(#115119)_case_1635181_s1/搜索功能(#115119)_case_1635181_s1.suite.yaml
+++ b/tests/at/yaml/搜索功能(#115119)_case_1635181_s1/搜索功能(#115119)_case_1635181_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: 文本
   - action: keyboard_press
@@ -37,9 +32,9 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/搜索功能(#115119)_case_1635183_s1/搜索功能(#115119)_case_1635183_s1.suite.yaml
+++ b/tests/at/yaml/搜索功能(#115119)_case_1635183_s1/搜索功能(#115119)_case_1635183_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: 文本
   - action: keyboard_press
@@ -35,5 +30,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/搜索功能(#115119)_case_1635187_s1/搜索功能(#115119)_case_1635187_s1.suite.yaml
+++ b/tests/at/yaml/搜索功能(#115119)_case_1635187_s1/搜索功能(#115119)_case_1635187_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: ZZZ不匹配
   - action: keyboard_press
@@ -35,5 +30,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634891_s1/文本笔记详情页(#115125)_case_1634891_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634891_s1/文本笔记详情页(#115125)_case_1634891_s1.suite.yaml
@@ -17,19 +17,14 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634893_s1/文本笔记详情页(#115125)_case_1634893_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634893_s1/文本笔记详情页(#115125)_case_1634893_s1.suite.yaml
@@ -17,24 +17,19 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634895_s1/文本笔记详情页(#115125)_case_1634895_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634895_s1/文本笔记详情页(#115125)_case_1634895_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: 测试内容
   - action: keyboard_press
@@ -35,5 +30,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634903_s1/文本笔记详情页(#115125)_case_1634903_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634903_s1/文本笔记详情页(#115125)_case_1634903_s1.suite.yaml
@@ -17,24 +17,19 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634905_s1/文本笔记详情页(#115125)_case_1634905_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634905_s1/文本笔记详情页(#115125)_case_1634905_s1.suite.yaml
@@ -17,24 +17,19 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634907_s1/文本笔记详情页(#115125)_case_1634907_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634907_s1/文本笔记详情页(#115125)_case_1634907_s1.suite.yaml
@@ -17,29 +17,24 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634953_s1/文本笔记详情页(#115125)_case_1634953_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634953_s1/文本笔记详情页(#115125)_case_1634953_s1.suite.yaml
@@ -17,21 +17,16 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: 测试<>&#内容
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634955_s1/文本笔记详情页(#115125)_case_1634955_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634955_s1/文本笔记详情页(#115125)_case_1634955_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: 测试
   - action: keyboard_press
@@ -37,5 +32,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634957_s1/文本笔记详情页(#115125)_case_1634957_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634957_s1/文本笔记详情页(#115125)_case_1634957_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: 测试
   - action: keyboard_press
@@ -37,5 +32,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/文本笔记详情页(#115125)_case_1634959_s1/文本笔记详情页(#115125)_case_1634959_s1.suite.yaml
+++ b/tests/at/yaml/文本笔记详情页(#115125)_case_1634959_s1/文本笔记详情页(#115125)_case_1634959_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   - action: keyboard_type
     text: 测试文本
   - action: keyboard_hot_key
@@ -39,5 +34,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/记事本条目(#115181)_case_1625233_s1/记事本条目(#115181)_case_1625233_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目(#115181)_case_1625233_s1/记事本条目(#115181)_case_1625233_s1.suite.yaml
@@ -8,7 +8,7 @@ env_check: []
 setup:
 - action: session_start
   command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
-  wait: 6.0
+  wait: 10.0
 teardown:
 - action: session_stop
 suites:
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 重命名
+    - RenameMenuItem
   - action: keyboard_hot_key
     key: ctrl+a
   - action: keyboard_type

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634839_s1/记事本条目管理(#115129)_case_1634839_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634839_s1/记事本条目管理(#115129)_case_1634839_s1.suite.yaml
@@ -19,11 +19,11 @@ suites:
   steps:
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634841_s1/记事本条目管理(#115129)_case_1634841_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634841_s1/记事本条目管理(#115129)_case_1634841_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 重命名
+    - RenameMenuItem
   - action: keyboard_type
     text: 测试Test123<
   - action: keyboard_press
@@ -35,5 +30,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634843_s1/记事本条目管理(#115129)_case_1634843_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634843_s1/记事本条目管理(#115129)_case_1634843_s1.suite.yaml
@@ -17,21 +17,16 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 重命名
+    - RenameMenuItem
   - action: keyboard_press
     key: return
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634845_s1/记事本条目管理(#115129)_case_1634845_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634845_s1/记事本条目管理(#115129)_case_1634845_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 重命名
+    - RenameMenuItem
   - action: keyboard_type
     text: ' '
   - action: keyboard_press
@@ -35,5 +30,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634849_s1/记事本条目管理(#115129)_case_1634849_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634849_s1/记事本条目管理(#115129)_case_1634849_s1.suite.yaml
@@ -8,7 +8,7 @@ env_check: []
 setup:
 - action: session_start
   command: bash -lc 'exec ./tests/at/setup_voice_note_at.sh'
-  wait: 6.0
+  wait: 10.0
 teardown:
 - action: session_stop
 suites:
@@ -17,17 +17,16 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
+  - action: assert_element
     selector:
-      name: 新建记事本
-      role: button
-    do: click
+      name: 记事本1
+      role: label
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 重命名
+    - RenameMenuItem
   - action: keyboard_type
     text: abc
   - action: keyboard_press

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634851_s1/记事本条目管理(#115129)_case_1634851_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634851_s1/记事本条目管理(#115129)_case_1634851_s1.suite.yaml
@@ -19,12 +19,7 @@ suites:
   steps:
   - action: element_action
     selector:
-      name: 新建记事本
-      role: button
-    do: click
-  - action: element_action
-    selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   - action: dtk_context_menu
@@ -32,7 +27,7 @@ suites:
       name: 记事本1
       role: label
     items:
-    - 重命名
+    - RenameMenuItem
   - action: keyboard_type
     text: 记事本1
   - action: keyboard_press

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634853_s1/记事本条目管理(#115129)_case_1634853_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634853_s1/记事本条目管理(#115129)_case_1634853_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 重命名
+    - RenameMenuItem
   - action: keyboard_hot_key
     key: ctrl+a
   - action: keyboard_type

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634857_s1/记事本条目管理(#115129)_case_1634857_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634857_s1/记事本条目管理(#115129)_case_1634857_s1.suite.yaml
@@ -17,17 +17,12 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 重命名
+    - RenameMenuItem
   - action: keyboard_hot_key
     key: ctrl+a
   - action: keyboard_press
@@ -37,5 +32,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/记事本条目管理(#115129)_case_1634863_s1/记事本条目管理(#115129)_case_1634863_s1.suite.yaml
+++ b/tests/at/yaml/记事本条目管理(#115129)_case_1634863_s1/记事本条目管理(#115129)_case_1634863_s1.suite.yaml
@@ -19,11 +19,11 @@ suites:
   steps:
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/详情页编辑区(#115193)_case_1624639_s1/详情页编辑区(#115193)_case_1624639_s1.suite.yaml
+++ b/tests/at/yaml/详情页编辑区(#115193)_case_1624639_s1/详情页编辑区(#115193)_case_1624639_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音(#115191)_case_1624807_s1/语音(#115191)_case_1624807_s1.suite.yaml
+++ b/tests/at/yaml/语音(#115191)_case_1624807_s1/语音(#115191)_case_1624807_s1.suite.yaml
@@ -22,5 +22,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676213_s1/语音记事本V25(#117769)_case_1676213_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676213_s1/语音记事本V25(#117769)_case_1676213_s1.suite.yaml
@@ -24,5 +24,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676215_s1/语音记事本V25(#117769)_case_1676215_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676215_s1/语音记事本V25(#117769)_case_1676215_s1.suite.yaml
@@ -24,5 +24,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676341_s1/语音记事本V25(#117769)_case_1676341_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676341_s1/语音记事本V25(#117769)_case_1676341_s1.suite.yaml
@@ -17,19 +17,14 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676385_s1/语音记事本V25(#117769)_case_1676385_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676385_s1/语音记事本V25(#117769)_case_1676385_s1.suite.yaml
@@ -20,5 +20,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676411_s1/语音记事本V25(#117769)_case_1676411_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676411_s1/语音记事本V25(#117769)_case_1676411_s1.suite.yaml
@@ -19,16 +19,16 @@ suites:
   steps:
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676423_s1/语音记事本V25(#117769)_case_1676423_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676423_s1/语音记事本V25(#117769)_case_1676423_s1.suite.yaml
@@ -19,11 +19,11 @@ suites:
   steps:
   - action: element_action
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button
     do: click
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676425_s1/语音记事本V25(#117769)_case_1676425_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676425_s1/语音记事本V25(#117769)_case_1676425_s1.suite.yaml
@@ -17,19 +17,14 @@ suites:
   description: ''
   tags: []
   steps:
-  - action: element_action
-    selector:
-      name: 新建记事本
-      role: button
-    do: click
   - action: dtk_context_menu
     selector:
       name: 记事本1
       role: label
     items:
-    - 新建笔记
+    - NewNoteFromFolderMenuItem
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button

--- a/tests/at/yaml/语音记事本V25(#117769)_case_1676573_s1/语音记事本V25(#117769)_case_1676573_s1.suite.yaml
+++ b/tests/at/yaml/语音记事本V25(#117769)_case_1676573_s1/语音记事本V25(#117769)_case_1676573_s1.suite.yaml
@@ -20,5 +20,5 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: 新建记事本
+      name: CreateFolderButton
       role: button


### PR DESCRIPTION
Seed default note data for AT runs and update folder creation selector.

为AT运行预置默认记事数据，并更新新建记事本按钮定位。

Log: 更新语音记事本AT测试数据和元素定位

Influence: AT用例启动后具备稳定默认记事本和文本条目，并使用 CreateFolderButton 定位新建记事本按钮，提升用例运行稳定性。

## Summary by Sourcery

Improve voice-note AT reliability while keeping Tiptap migration disabled unless explicitly enabled for debugging.

Bug Fixes:
- Stabilize voice-note AT runs by provisioning a default notebook and text entry in the test database.

Enhancements:
- Use the CreateFolderButton accessibility selector for the new-notebook action.
- Restrict Tiptap migration startup and related migration UI activity to explicitly enabled debug environments.

Tests:
- Update voice-note AT suite fixtures and selectors to match the seeded default data and accessibility identifiers.