### PR TITLE
fix: 异步化 getHtml 保存并引入防抖，修复巨量中文字符输入卡死

### DIFF
--- a/assets/web/index.js
+++ b/assets/web/index.js
@@ -221,8 +221,11 @@ function initSummernote() {
 
 
 
+//防抖计时器，连续输入期间不重复通知后台置脏
+var txtChangeDebounceTimer = null;
+
 /**
- * 通知后台存储页面内容
+ * 通知后台存储页面内容（jsCallTxtChange 已加 400ms 防抖）
  * @date 2021-08-19
  * @param {any} we
  * @param {any} contents
@@ -239,7 +242,14 @@ function changeContent(we, contents, $editable) {
                 $('#summernote').summernote('airPopover.hide')
             }
         }
-        webobj.jsCallTxtChange();
+        //对 jsCallTxtChange 包一层 400ms 防抖，连续输入期间不重复置脏
+        if (txtChangeDebounceTimer) {
+            clearTimeout(txtChangeDebounceTimer);
+        }
+        txtChangeDebounceTimer = setTimeout(function () {
+            txtChangeDebounceTimer = null;
+            webobj.jsCallTxtChange();
+        }, 400);
     }
 }
 
@@ -524,11 +534,13 @@ $('body').on('click', '.voicebtn', function (e) {
 //获取整个处理后Html串,去除所有标签中临时状态
 function getHtml() {
     var $cloneCode = $('.note-editable').clone();
+    //合并多轮 find 遍历，降低单次序列化成本
     $cloneCode.find('.li').removeClass('active');
-    $cloneCode.find('.voicebtn').removeClass('pause').addClass('play');
-    $cloneCode.find('.voicebtn').removeClass('now');
-    $cloneCode.find('.wifi-circle').removeClass('first').removeClass('second').removeClass('third').removeClass('four').removeClass('fifth').removeClass('sixth').removeClass('seventh');
-    $cloneCode.find('.translate').html("")
+    //voicebtn 合并为单次遍历：移除 pause/now 临时态并恢复 play
+    $cloneCode.find('.voicebtn').removeClass('pause now').addClass('play');
+    //wifi-circle 一次性移除全部动画临时类
+    $cloneCode.find('.wifi-circle').removeClass('first second third four fifth sixth seventh');
+    $cloneCode.find('.translate').html("");
     // 确保图片保存为相对路径
     $cloneCode.find('img').each(function () {
         var $img = $(this);
@@ -570,15 +582,20 @@ function getHtml() {
         }
     });
     // 清理格式切换产生的零宽空格锚点
-    $cloneCode.find('*').addBack().contents().filter(function() {
-        if (this.nodeType === 3 && /​/.test(this.textContent)) {
-            this.textContent = this.textContent.replace(/​/g, '');
-            if (this.textContent === '') {
-                this.parentNode.removeChild(this);
+    //先检查是否含零宽空格，避免对巨量无 ZWS 内容做全节点遍历
+    var html = $cloneCode[0].innerHTML;
+    if (html.indexOf('\u200b') >= 0) {
+        $cloneCode.find('*').addBack().contents().filter(function() {
+            if (this.nodeType === 3 && /\u200b/.test(this.textContent)) {
+                this.textContent = this.textContent.replace(/\u200b/g, '');
+                if (this.textContent === '') {
+                    this.parentNode.removeChild(this);
+                }
             }
-        }
-    });
-    return $cloneCode[0].innerHTML;
+        });
+        html = $cloneCode[0].innerHTML;
+    }
+    return html;
 }
 
 //获取当前所有的语音列表
@@ -780,6 +797,11 @@ function toggleState(state) {
 function setHtml(html) {
     if (html == '<p></p>') {
         html = '<p><br></p>'
+    }
+    //T1：笔记切换时清理防抖定时器，防止挂起的jsCallTxtChange在新笔记上下文中误触发
+    if (txtChangeDebounceTimer) {
+        clearTimeout(txtChangeDebounceTimer);
+        txtChangeDebounceTimer = null;
     }
     initFinish = false;
     $('#summernote').summernote('code', html);

--- a/src/views/vnotemainwindow.cpp
+++ b/src/views/vnotemainwindow.cpp
@@ -691,8 +691,8 @@ void VNoteMainWindow::onVNoteSearch()
                 m_richTextEdit->searchText(m_searchKey);
             } else {
                 m_searchKey = text;
-                //重新搜索之前先更新笔记内容
-                m_richTextEdit->updateNote();
+                //G1：重新搜索之前先同步更新笔记内容，确保最新编辑进入搜索
+                m_richTextEdit->updateNoteSync();
                 //重新搜索
                 loadSearchNotes(m_searchKey);
             }
@@ -1221,8 +1221,8 @@ void VNoteMainWindow::onMenuAbout2Show()
     QAction *topAction = ActionManager::Instance()->getActionById(ActionManager::NoteTop);
 
     if (menu == ActionManager::Instance()->noteContextMenu()) {
-        //右键弹出先更新数据，避免数据不同步
-        m_richTextEdit->updateNote();
+        //G2：右键弹出先同步更新数据，避免数据不同步
+        m_richTextEdit->updateNoteSync();
 
         bool notMultipleSelected = !m_middleView->isMultipleSelected();
         ActionManager::Instance()->visibleAction(ActionManager::NoteTop, notMultipleSelected);
@@ -1904,7 +1904,8 @@ void VNoteMainWindow::release()
     if (VTextSpeechAndTrManager::Success != stopStatus) {
         qWarning() << "Stop text to speech failed with status:" << stopStatus;
     }
-    m_richTextEdit->updateNote();
+    //S1：退出路径改调同步保存，防止异步回调因事件循环停止而丢失最后一段编辑
+    m_richTextEdit->updateNoteSync();
 
     if (stateOperation->isVoice2Text()) {
         QScopedPointer<VNoteA2TManager> releaseA2TManger(m_a2tManager);

--- a/src/views/webrichtexteditor.cpp
+++ b/src/views/webrichtexteditor.cpp
@@ -157,7 +157,7 @@ void WebRichTextEditor::initRightMenu()
 void WebRichTextEditor::initUpdateTimer()
 {
     m_updateTimer = new QTimer(this);
-    m_updateTimer->setInterval(1000);
+    m_updateTimer->setInterval(1500);
     connect(m_updateTimer, &QTimer::timeout, this, &WebRichTextEditor::updateNote);
 }
 
@@ -196,18 +196,63 @@ void WebRichTextEditor::insertVoiceItem(const QString &voicePath, qint64 voiceSi
 
 void WebRichTextEditor::updateNote()
 {
-    if (m_noteData) {
-        if (m_textChange) {
-            QVariant result = JsContent::instance()->callJsSynchronous(page(), QString("getHtml()"));
-            if (result.isValid()) {
-                m_noteData->htmlCode = result.toString();
-                VNoteItemOper noteOps(m_noteData);
+    if (m_noteData && m_textChange && !m_updateInProgress) {
+        //巨量内容下降低保存频率：跳过非紧急定时保存，每3次触发保存1次
+        //笔记切换/解绑仍走updateNoteSync确保数据不丢
+        static const int kLargeContentThreshold = 500 * 1024; //500KB
+        if (m_noteData->htmlCode.size() > kLargeContentThreshold) {
+            m_largeContentSkipCount++;
+            if (m_largeContentSkipCount < 3) {
+                return;
+            }
+            m_largeContentSkipCount = 0;
+        }
+        //异步获取HTML，避免QEventLoop::exec()同步阻塞主线程导致巨量内容下UI卡死
+        m_updateInProgress = true;
+        m_textChange = false;
+        VNoteItem *noteData = m_noteData;
+        int generation = ++m_updateGeneration;
+        page()->runJavaScript("getHtml()", [this, noteData, generation](const QVariant &result) {
+            m_updateInProgress = false;
+            //仅当代际匹配时才写入，避免笔记切换后过时回调将新笔记内容写入旧笔记
+            if (generation == m_updateGeneration && result.isValid()) {
+                noteData->htmlCode = result.toString();
+                VNoteItemOper noteOps(noteData);
                 if (!noteOps.updateNote()) {
                     qInfo() << "Save note error";
                 }
             }
-            m_textChange = false;
+        });
+        //G3：回调未触发时（页面错误/导航）的超时兜底，防止m_updateInProgress永久阻断定时器保存
+        QTimer::singleShot(5000, this, [this]() {
+            if (m_updateInProgress) {
+                m_updateInProgress = false;
+                m_textChange = true;
+            }
+        });
+    }
+}
+
+void WebRichTextEditor::updateNoteSync()
+{
+    //同步保存，用于笔记切换/解绑等需确保保存完成后再更换数据的场景
+    //S2：当异步保存进行中时也必须同步保存，否则切换笔记时m_textChange已被异步侧清零
+    //导致跳过保存，而未触发的异步回调随后将新笔记DOM内容写入旧noteData
+    if (m_noteData && (m_textChange || m_updateInProgress)) {
+        if (m_updateInProgress) {
+            //使过时的异步回调失效，防止其将切换后的新内容写入旧笔记
+            m_updateGeneration++;
+            m_updateInProgress = false;
         }
+        QVariant result = JsContent::instance()->callJsSynchronous(page(), QString("getHtml()"));
+        if (result.isValid()) {
+            m_noteData->htmlCode = result.toString();
+            VNoteItemOper noteOps(m_noteData);
+            if (!noteOps.updateNote()) {
+                qInfo() << "Save note error";
+            }
+        }
+        m_textChange = false;
     }
 }
 
@@ -224,8 +269,8 @@ void WebRichTextEditor::unboundCurrentNoteData()
 {
     //停止更新定时器
     m_updateTimer->stop();
-    //手动更新
-    updateNote();
+    //手动同步更新，确保保存完成后再解绑数据
+    updateNoteSync();
     //绑定数据设置为空
     m_noteData = nullptr;
 }
@@ -747,7 +792,7 @@ void WebRichTextEditor::setData(VNoteItem *data, const QString &reg)
     if (nullptr == data) {
         this->setVisible(false);
         //无数据时先保存之前数据
-        updateNote();
+        updateNoteSync();
         //解绑当前数据
         unboundCurrentNoteData();
         return;
@@ -758,7 +803,9 @@ void WebRichTextEditor::setData(VNoteItem *data, const QString &reg)
     m_searchKey = reg;
     if (m_noteData != data || reSet) { //笔记切换或清除搜索结果时设置笔记内容
         m_updateTimer->stop();
-        updateNote();
+        updateNoteSync();
+        //T2：切换笔记时复位巨量内容跳过计数器
+        m_largeContentSkipCount = 0;
         m_noteData = data;
         if (m_loadFinshSign) {
             if (data->htmlCode.isEmpty()) {

--- a/src/views/webrichtexteditor.h
+++ b/src/views/webrichtexteditor.h
@@ -61,6 +61,10 @@ public:
      */
     void updateNote();
     /**
+     * @brief 同步更新编辑区内容（用于笔记切换/解绑等需确保保存完成的场景）
+     */
+    void updateNoteSync();
+    /**
      * @brief 搜索当前笔记
      * @param searchKey : 搜索关键字
      */
@@ -234,6 +238,9 @@ private:
     VNoteItem *m_noteData {nullptr};
     QTimer *m_updateTimer {nullptr};
     bool m_textChange {false};
+    bool m_updateInProgress {false}; //异步保存进行中标志
+    int m_updateGeneration {0}; //异步保存代际计数器，用于使过时回调失效
+    int m_largeContentSkipCount {0}; //巨量内容下跳过非紧急保存的计数器
     QString m_searchKey {""};
     Menu m_menuType = MaxMenu;
     QVariant m_menuJson = {};


### PR DESCRIPTION
## 修复 PMS 261415：输入巨量中文字符卡死

### 根因
「内容变更通知 → 同步取 HTML 保存」链路全程无防抖/节流，且 HTML 提取采用 `QEventLoop::exec()` 同步阻塞 Qt 主线程，巨量 DOM 下单次取值耗时非线性增长导致主线程冻结。

### 修复内容

1. **异步化 `updateNote()`**（`src/views/webrichtexteditor.cpp`）
   - 去掉 `QEventLoop::exec()` 同步阻塞，改用 `page()->runJavaScript("getHtml()", callback)` 异步回调，回调中处理结果与落库
   - 新增 `m_updateInProgress` 防止并发保存，捕获 `noteData` 指针确保回调保存到正确笔记

2. **新增 `updateNoteSync()`**
   - 笔记切换/解绑（`unboundCurrentNoteData()`、`setData()`）等需确保保存完成后再更换数据的场景保留同步保存，保证数据一致性

3. **引入防抖**（`assets/web/index.js`）
   - `changeContent()` 中对 `webobj.jsCallTxtChange()` 包 400ms 防抖，连续输入期间不重复置脏

4. **优化 `getHtml()`**（`assets/web/index.js`）
   - 合并 `voicebtn` 两次 `find` 为单次遍历，合并 `wifi-circle` 链式 `removeClass`
   - 零宽空格清理加 `indexOf` 早退，避免巨量无 ZWS 内容全节点遍历

5. **定时器内容量保护**（`src/views/webrichtexteditor.cpp`）
   - 定时器间隔 1000ms→1500ms
   - `htmlCode > 500KB` 时每 3 次触发保存 1 次，降低巨量内容下保存频率

### 改动安全评估
- `callJsSynchronous` 保留不变，供 `insertVoiceItem`、`returnCopyFlag`、`isRangeVoice` 等仍需同步语义的调用点使用
- 笔记切换/解绑路径改用 `updateNoteSync()` 确保数据不丢
- 防抖仅延迟通知，不影响最终保存完整性

Log: 修复输入巨量中文字符卡死问题
Bug: https://pms.uniontech.com/bug/261415

## Summary by Sourcery

Prevent large-content editing freezes by decoupling routine HTML persistence from the UI thread while retaining synchronous saves for data-transition boundaries.

Bug Fixes:
- Prevent the editor from freezing when entering very large amounts of Chinese or other content by making routine note saves asynchronous and reducing redundant save notifications.
- Preserve data consistency during note switching, unbinding, searching, context-menu actions, and application exit with synchronous saves where completion is required.

Enhancements:
- Add debouncing and large-content save-rate protection to reduce repeated persistence during continuous editing.
- Optimize HTML cleanup for large documents by reducing DOM traversals and skipping zero-width-space processing when unnecessary.
- Add safeguards against overlapping or stale asynchronous save callbacks.