### PR TITLE
test(migration): stabilize null orchestrator coverage test

### DIFF
--- a/tests/src/common/ut_misc_common_coverage.cpp
+++ b/tests/src/common/ut_misc_common_coverage.cpp
@@ -50,6 +50,9 @@ static MigrationOrchestrator *stub_startIfNeeded_returnsNull(QObject * /*consume
 
 TEST(MigrationViewControllerCoverage, start_withNullOrchestrator_rollBackCleanly)
 {
+    const QByteArray oldDebugEnv = qgetenv("DVN_TIPTAP_DEBUG");
+    qputenv("DVN_TIPTAP_DEBUG", "1");
+
     Stub stub;
     stub.set(ADDR(MigrationOrchestrator, startIfNeeded),
              stub_startIfNeeded_returnsNull);
@@ -68,6 +71,8 @@ TEST(MigrationViewControllerCoverage, start_withNullOrchestrator_rollBackCleanly
     ctrl->start();
     // After rollback migrationActive must be false.
     EXPECT_FALSE(ctrl->m_migrationActive);
+
+    qputenv("DVN_TIPTAP_DEBUG", oldDebugEnv);
 }
 
 // ============================================================================


### PR DESCRIPTION
Set the Tiptap debug gate explicitly during the coverage test.

在覆盖率测试中显式设置 Tiptap 调试开关。

Log: 修复迁移视图控制器覆盖率用例不稳定

Influence: 仅影响单元测试，避免用例依赖外部环境变量导致失败。

## Summary by Sourcery

Stabilize null-orchestrator migration coverage by controlling the Tiptap debug environment during the test.

Bug Fixes:
- Stabilize migration view controller coverage by explicitly enabling Tiptap debug behavior during the null-orchestrator rollback test and restoring the prior environment afterward.

Tests:
- Make the migration coverage test independent of the externally configured DVN_TIPTAP_DEBUG environment variable.