### PR TITLE
fix(tiptap): load editor from file path for local images

### DIFF
--- a/src/common/tiptapchannelbridge.cpp
+++ b/src/common/tiptapchannelbridge.cpp
@@ -78,11 +78,13 @@ bool TiptapChannelBridge::debugEnabled() const
 
 QString TiptapChannelBridge::tiptapHtmlPath() const
 {
-    // 首选 qrc 资源路径；若 qrc 不存在则回退 install 目录
-    if (QResource(":/tiptap-editor.html").isValid()) {
-        return QStringLiteral("qrc:/tiptap-editor.html");
+    // Tiptap needs to resolve AppData images through file:// URLs. Loading the
+    // editor itself from file:// keeps the page in QtWebEngine's local-file path.
+    const QString filePath = QStringLiteral(TIPTAP_WEB_PATH "/tiptap-editor.html");
+    if (QFile::exists(filePath)) {
+        return QUrl::fromLocalFile(filePath).toString();
     }
-    return QStringLiteral("file://" TIPTAP_WEB_PATH "/tiptap-editor.html");
+    return QStringLiteral("qrc:/tiptap-editor.html");
 }
 
 QString TiptapChannelBridge::resourceBaseUrl() const

--- a/src/common/tiptapchannelbridge.h
+++ b/src/common/tiptapchannelbridge.h
@@ -52,7 +52,7 @@ public:
     // 读 DVN_TIPTAP_DEBUG 环境变量，便于 QA 与 GTest
     Q_INVOKABLE bool debugEnabled() const;
 
-    // 返回 Tiptap 运行时 HTML 路径（首选 qrc，install 回退 file://）
+    // 返回 Tiptap 运行时 HTML 路径（首选 file://，资源缺失时回退 qrc）
     Q_INVOKABLE QString tiptapHtmlPath() const;
 
     // 返回宿主资源根 URL（file:// + WEB_PATH 或 TIPTAP_WEB_PATH），

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -523,13 +523,15 @@ Item {
                     backgroundColor: DTK.themeType === ApplicationHelper.LightType ? "white" : "black"
                     visible: true
 
+                    settings.localContentCanAccessFileUrls: true
+
                     Component.onCompleted: {
                         tiptapWebChannel.registerObject("tiptapChannel", TiptapChannel);
                         tiptapWebView.webChannel = tiptapWebChannel;
                         tiptapWebView.url = Qt.resolvedUrl(TiptapChannel.tiptapHtmlPath());
                     }
 
-                    onLoadingChanged: {
+                    onLoadingChanged: function(loadRequest) {
                         if (loadRequest.status === WebEngineView.LoadSucceededStatus) {
                             tiptapWebView.forceActiveFocus();
                             tiptapWebView.runJavaScript("window._dvnTiptapFocus && window._dvnTiptapFocus()");

--- a/src/importolddata/dbmigration/migrationreport.cpp
+++ b/src/importolddata/dbmigration/migrationreport.cpp
@@ -35,6 +35,7 @@ const QSet<QString> &extraDowngradeCodes()
         kCodeDangerousHtmlAttribute,
         kCodeMissingHtmlImageSrc,
         kCodeUnsafeHtmlImageSrc,
+        kCodeFileImageOutsideImagesDir,
         QStringLiteral("skipped-non-text-block")
     };
     return codes;

--- a/src/importolddata/tiptapmigration/migrationhtmlcodes.h
+++ b/src/importolddata/tiptapmigration/migrationhtmlcodes.h
@@ -19,6 +19,7 @@ inline const QString kCodeDowngradedInlineVoicebox = QStringLiteral("downgraded-
 inline const QString kCodeDowngradedOrphanListItem = QStringLiteral("downgraded-orphan-list-item");
 inline const QString kCodeDowngradedBase64Image = QStringLiteral("downgraded-base64-image");
 inline const QString kCodeMissingHtmlImageSrc = QStringLiteral("missing-html-image-src");
+inline const QString kCodeFileImageOutsideImagesDir = QStringLiteral("file-image-outside-images-dir");
 inline const QString kCodeUnsafeHtmlImageSrc = QStringLiteral("unsafe-html-image-src");
 inline const QString kCodeUnsupportedHtmlStyle = QStringLiteral("unsupported-html-style");
 inline const QString kCodeInvalidHtmlStyleValue = QStringLiteral("invalid-html-style-value");

--- a/src/importolddata/tiptapmigration/migrationhtmlconverter.cpp
+++ b/src/importolddata/tiptapmigration/migrationhtmlconverter.cpp
@@ -691,7 +691,7 @@ ImageReference resolvedImageReference(const QString &rawValue, bool preferRelPat
     }
 
     if (scheme == QStringLiteral("file")) {
-        return { QString(), QString(), kCodeUnsafeHtmlImageSrc, QStringLiteral("HTML file image URL has no extractable images/ path and was skipped") };
+        return { QString(), QString(), kCodeFileImageOutsideImagesDir, QStringLiteral("HTML file image URL has no images/ path segment and was skipped; manual relocation needed") };
     }
 
     if (!isSafeResolvedImageSrc(trimmed)) {

--- a/tests/src/tiptapchannel/ut_tiptapchannelbridge.cpp
+++ b/tests/src/tiptapchannel/ut_tiptapchannelbridge.cpp
@@ -5,6 +5,7 @@
 #include "tiptapchannelbridge.h"
 
 #include <QResource>
+#include <QFile>
 #include <QSignalSpy>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -229,15 +230,15 @@ TEST_F(UT_TiptapChannelBridge, UT_TiptapChannelBridge_resourceBaseUrl_001)
     EXPECT_TRUE(url.startsWith("file://")) << url.toStdString();
 }
 
-// tiptapHtmlPath 返回 qrc 或 file:// 路径
+// tiptapHtmlPath 优先返回 file://，文件不存在时回退 qrc
 TEST_F(UT_TiptapChannelBridge, UT_TiptapChannelBridge_tiptapHtmlPath_001)
 {
     TiptapChannelBridge bridge;
     QString path = bridge.tiptapHtmlPath();
-    if (QResource(":/tiptap-editor.html").isValid()) {
-        EXPECT_TRUE(path.startsWith("qrc:")) << path.toStdString();
-    } else {
+    if (QFile::exists(QStringLiteral(TIPTAP_WEB_PATH "/tiptap-editor.html"))) {
         EXPECT_TRUE(path.startsWith("file://")) << path.toStdString();
+    } else {
+        EXPECT_TRUE(path.startsWith("qrc:")) << path.toStdString();
     }
     EXPECT_TRUE(path.contains("tiptap-editor.html")) << path.toStdString();
 }


### PR DESCRIPTION
Prefer file based Tiptap editor loading for AppData image access.

优先使用本地文件路径加载Tiptap编辑器以访问AppData图片。

Classify file images outside images/ separately in migration reports.

在迁移报告中单独分类不在images目录下的file图片。

Log: 修复Tiptap迁移图片不显示

PMS: TASK-393985

Influence: Tiptap调试迁移后可正常显示本地图片，并改进图片迁移报告分类。

## Summary by Sourcery

Fix migrated local image display by preferring file-based Tiptap loading and improve reporting for file images that require manual relocation.

Bug Fixes:
- Load the Tiptap editor from a local file when available so local AppData images render correctly after migration.

Enhancements:
- Allow the Tiptap web view to access local file URLs and distinguish file images outside the images directory in migration reports.

Tests:
- Update Tiptap channel bridge coverage for file-first editor loading with qrc fallback.