### PR TITLE
perf(startup): defer workspace initialization for empty notebooks

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -24,11 +24,14 @@
 #include "handler/voice_to_text_task_manager.h"
 #include "audio/recording_curves.h"
 #include "dbus/VoiceNoteDBusService.h"
+#include "db/vnotedbmanager.h"
 
 #include <QThreadPool>
 #include <QQmlApplicationEngine>
 // 条件编译：根据 Qt 版本包含不同的 WebEngine 头文件
-#ifndef USE_QT5
+#ifdef USE_QT5
+#include <QtWebEngine/QtWebEngine>
+#else
 #include <QtWebEngineQuick/qtwebenginequickglobal.h>
 #endif
 #include <QStringList>
@@ -45,6 +48,8 @@
 #include <QImageReader>
 #include <QTimer>
 #include <QSet>
+#include <QSqlQuery>
+#include <QSqlError>
 
 #include <DSysInfo>
 
@@ -90,6 +95,41 @@ VNoteMainManager *VNoteMainManager::instance()
     qInfo() << "VNoteMainManager instance requested";
     static VNoteMainManager instance;
     return &instance;
+}
+
+bool VNoteMainManager::hasExistingFolders()
+{
+    QSqlQuery query(VNoteDbManager::instance()->getVNoteDb());
+    if (!query.exec(QStringLiteral("SELECT 1 FROM %1 LIMIT 1")
+                    .arg(VNoteDbManager::FOLDER_TABLE_NAME))) {
+        qWarning() << "Failed to check existing folders:" << query.lastError().text();
+        return false;
+    }
+
+    return query.next();
+}
+
+void VNoteMainManager::prepareWorkspace()
+{
+    if (m_webEngineInitialized)
+        return;
+
+#ifdef USE_QT5
+    QtWebEngine::initialize();
+#else
+    QtWebEngineQuick::initialize();
+#endif
+    m_webEngineInitialized = true;
+}
+
+void VNoteMainManager::start()
+{
+    if (m_initialized)
+        return;
+
+    m_initialized = true;
+    initNote();
+    VTextSpeechAndTrManager::instance()->checkUosAiExists();
 }
 
 void VNoteMainManager::initNote()
@@ -247,6 +287,7 @@ void VNoteMainManager::onVNoteFoldersLoaded()
     //     pFileCleanupWorker->setAutoDelete(true);
     //     pFileCleanupWorker->setObjectName("FileCleanupWorker");
     //     QThreadPool::globalInstance()->start(pFileCleanupWorker);
+    emit initialDataReady();
     qInfo() << "VNote folders loaded handling finished";
 }
 

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -29,6 +29,9 @@ public:
     Q_ENUM(SaveAsType)
 
     static VNoteMainManager* instance();
+    static bool hasExistingFolders();
+    Q_INVOKABLE void prepareWorkspace();
+    Q_INVOKABLE void start();
     void initNote();
     void initQMLRegister();
 
@@ -104,6 +107,7 @@ public:
     bool updateVoiceBlockText(QJsonObject &node, const QString &voiceId, const QString &text);
 
 signals:
+    void initialDataReady();
     void finishedFolderLoad(const QList<QVariantMap> &foldersData);
     void updateNotes(const QList<QVariantMap> &notesData, const int &selectIndex);
     void selectNoteByIndex(const int &selectIndex);
@@ -163,6 +167,8 @@ private:
     QStringList m_folderSort;
     WebRichTextManager *m_richTextManager {nullptr};
     VoiceNoteDBusService *m_dbusService {nullptr};
+    bool m_initialized {false};
+    bool m_webEngineInitialized {false};
     QString m_searchText;
     QEventLoop m_eventloop;
     PendingAction m_pendingAction {PendingAction::None};

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -12,12 +12,16 @@ import "../" as VNoteComponents
 import "../dialog"
 import org.deepin.dtk 1.0
 
-ApplicationWindow {
+Item {
     id: rootWindow
 
+    anchors.fill: parent
+
+    property bool active: Window.window ? Window.window.active : false
     property int createFolderBtnHeight: 30
     property bool isRecording: webEngineView.isRecording
     property bool isRecordingAudio: false
+    property bool layoutInitialized: false
     property bool isVoiceToText: false
     property int leftAreaMaxWidth: 300
     property int leftAreaMinWidth: 125
@@ -53,43 +57,19 @@ ApplicationWindow {
         }
     }
 
-    DWindow.alphaBufferSize: 8
-    DWindow.enabled: true
-    color: "transparent"
-    flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
-    height: 681
-    minimumHeight: windowMiniHeight
-    minimumWidth: windowMiniWidth
-    visible: true
-    width: 1096
+    function stopAndClose() {
+        webEngineView.stopAndClose();
+    }
 
     Component.onCompleted: {
-        x = Screen.width / 2 - width / 2;
-        y = Screen.height / 2 - height / 2;
-        checkAndCreateDataPath();
+        Qt.callLater(function() {
+            layoutInitialized = true;
+        });
     }
-    onClosing: function(close) {
-        close.accepted = false;
-        if (isRecording) {
-            close.accepted = false;
-            messageDialogLoader.showDialog(VNoteMessageDialogHandler.AbortRecord, ret => {
-                if (ret) {
-                    webEngineView.stopAndClose();
-                    VNoteMainManager.forceExit(true);
-                }
-            });
-        } else {
-            if (VNoteMainManager.isVoiceToText()) {
-                messageDialogLoader.showDialog(VNoteMessageDialogHandler.AborteAsr, ret => {
-                    if (ret) {
-                        VNoteMainManager.forceExit();
-                    }
-                });
-            } else
-                VNoteMainManager.forceExit();
-        }
-    }
+
     onWidthChanged: {
+        if (!layoutInitialized)
+            return;
         if (rightBgArea.width < rightAreaMinWidth) {
             var reduce = rightAreaMinWidth - rightBgArea.width;
             if (middleBgArea.width - reduce >= middleAreaMinWidth - rightDragHandle.width) {
@@ -593,7 +573,7 @@ ApplicationWindow {
         Accessible.role: Accessible.Panel
 
         anchors.fill: parent
-        windowControl: rootWindow
+        windowControl: Window.window
         z: 0
     }
 

--- a/src/importolddata/dbmigration/migrationbackup.cpp
+++ b/src/importolddata/dbmigration/migrationbackup.cpp
@@ -14,6 +14,7 @@
 #include <QSqlError>
 #include <QSqlQuery>
 #include <QStandardPaths>
+#include <QVariant>
 
 #include <cerrno>       // errno
 #include <cstdio>       // std::rename

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,13 +27,6 @@
 #include <QCommandLineParser>
 #include <QTimer>
 
-// 条件编译：根据 Qt 版本包含不同的 WebEngine 头文件
-#ifdef USE_QT5
-#include <QtWebEngine/QtWebEngine>
-#else
-#include <QtWebEngineQuick/qtwebenginequickglobal.h>
-#endif
-
 #include <DApplication>
 #include <DGuiApplicationHelper>
 #include <DLog>
@@ -108,21 +101,16 @@ int main(int argc, char *argv[])
     qputenv("QTWEBENGINE_REMOTE_DEBUGGING", "7777");
     VNoteMainManager::instance()->initQMLRegister();
     
-    // 条件编译：根据 Qt 版本使用不同的 WebEngine 初始化方法
-#ifdef USE_QT5
-    QtWebEngine::initialize();
-#else
-    QtWebEngineQuick::initialize();
-#endif
-    
     ImageProvider *imageProvider = ImageProvider::instance();
-    qInfo() << "QML and WebEngine initialized successfully";
+    qInfo() << "QML types initialized successfully";
 
     app->loadTranslator();
     app->setApplicationDisplayName(QObject::tr("deepin-voice-note"));
     QQmlApplicationEngine engine;
     const QUrl url(QStringLiteral("qrc:/main.qml"));
     engine.addImageProvider("Provider", imageProvider);
+    engine.rootContext()->setContextProperty(
+        "hasExistingFolders", VNoteMainManager::hasExistingFolders());
     QObject::connect(
         &engine,
         &QQmlApplicationEngine::objectCreated,
@@ -137,9 +125,6 @@ int main(int argc, char *argv[])
     engine.load(url);
     qInfo() << "QML engine loaded successfully";
 
-    VNoteMainManager::instance()->initNote();
-    qInfo() << "Note manager initialized";
-
     // Tiptap 数据迁移仍处于调试验证阶段，只允许在 DVN_TIPTAP_DEBUG=1 下启动。
     // 未开启调试开关时，禁止展示迁移页、备份、扫描或写回 Summernote 数据。
     if (TiptapChannelBridge::instance()->debugEnabled()) {
@@ -152,8 +137,5 @@ int main(int argc, char *argv[])
     DLogManager::registerFileAppender();
     qInfo() << "Log system initialized";
 
-    VTextSpeechAndTrManager::instance()->checkUosAiExists();
-    qInfo() << "UOS AI check completed";
-    
     return app->exec();
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -1,15 +1,122 @@
 // Copyright (C) 2020 ~ 2020 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15
 import QtQuick.Window 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
+import VNote 1.0
 import "./gui/mainwindow"
+import "./gui/dialog"
+import org.deepin.dtk 1.0
 
-MainWindow {
-    id: root
+ApplicationWindow {
+    id: rootWindow
+
     Accessible.name: "VoiceNoteMainWindow"
     Accessible.role: Accessible.Window
+
+    property bool workspaceActive: workspaceLoader.active
+    property bool createFirstNotebook: false
+    property bool isRecording: workspaceLoader.item ? workspaceLoader.item.isRecording : false
+
+    DWindow.enabled: true
+    color: DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#101010"
+    flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
+    height: 681
+    minimumHeight: 300
+    minimumWidth: 685
+    visible: true
+    width: 1096
+
+    function activateWorkspace(createFirstNotebook) {
+        if (workspaceLoader.active)
+            return;
+
+        rootWindow.createFirstNotebook = createFirstNotebook;
+        initialInterface.visible = false;
+        VNoteMainManager.prepareWorkspace();
+        workspaceLoader.active = true;
+        workspaceLoader.source = "gui/mainwindow/MainWindow.qml";
+    }
+
+    Component.onCompleted: {
+        x = Screen.width / 2 - width / 2;
+        y = Screen.height / 2 - height / 2;
+        if (hasExistingFolders)
+            activateWorkspace(false);
+        else
+            initialInterface.loadFinished(false);
+    }
+
+    onClosing: function(close) {
+        close.accepted = false;
+        if (isRecording) {
+            messageDialogLoader.showDialog(VNoteMessageDialogHandler.AbortRecord, ret => {
+                if (ret) {
+                    workspaceLoader.item.stopAndClose();
+                    VNoteMainManager.forceExit(true);
+                }
+            });
+        } else if (VNoteMainManager.isVoiceToText()) {
+            messageDialogLoader.showDialog(VNoteMessageDialogHandler.AborteAsr, ret => {
+                if (ret)
+                    VNoteMainManager.forceExit();
+            });
+        } else {
+            VNoteMainManager.forceExit();
+        }
+    }
+
+    Loader {
+        id: workspaceLoader
+
+        anchors.fill: parent
+        active: false
+        asynchronous: false
+
+        onLoaded: {
+            initialInterface.visible = false;
+            VNoteMainManager.start();
+        }
+    }
+
+    InitialInterface {
+        id: initialInterface
+
+        anchors.fill: parent
+        visible: !workspaceLoader.active
+
+        onCreateFolder: {
+            rootWindow.activateWorkspace(true);
+        }
+        onTitleOpenSetting: {
+            if (settingDlgLoader.status === Loader.Null)
+                settingDlgLoader.setSource("gui/dialog/SettingDialog.qml");
+            if (settingDlgLoader.status === Loader.Ready)
+                settingDlgLoader.item.show();
+        }
+    }
+
+    VNoteMessageDialogLoader {
+        id: messageDialogLoader
+    }
+
+    Loader {
+        id: settingDlgLoader
+    }
+
+    Connections {
+        target: VNoteMainManager
+
+        function onInitialDataReady() {
+            if (!rootWindow.createFirstNotebook)
+                return;
+
+            rootWindow.createFirstNotebook = false;
+            VNoteMainManager.vNoteCreateFolder();
+        }
+    }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,11 +52,11 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -fstack-protector-all")
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "mips.*")
     message(STATUS "Testing for MIPS architecture, using Qt5")
     add_definitions(-DUSE_QT5)
-    find_package(Qt5 5.15 REQUIRED COMPONENTS Core Gui Widgets DBus Sql Multimedia Test Xml Svg WebChannel WebEngineWidgets)
+    find_package(Qt5 5.15 REQUIRED COMPONENTS Core Gui Widgets DBus Sql Multimedia Test Xml Svg WebChannel WebEngine WebEngineWidgets)
     find_package(Dtk COMPONENTS Core Widget Gui REQUIRED)
 else()
     message(STATUS "Testing for Non-MIPS architecture, using Qt6")
-    find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Widgets DBus Sql Multimedia Test Xml Svg WebChannel WebEngineWidgets)
+    find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Widgets DBus Sql Multimedia Test Xml Svg WebChannel WebEngineQuick WebEngineWidgets)
     find_package(Dtk6 COMPONENTS Core Widget Gui REQUIRED)
 endif()
 
@@ -153,6 +153,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "mips.*")
         Qt5::Multimedia
         Qt5::Test
         Qt5::WebChannel
+        Qt5::WebEngine
         Qt5::WebEngineWidgets
         Qt5::Svg
         Qt5::Xml
@@ -175,6 +176,7 @@ else()
         Qt6::Multimedia
         Qt6::Test
         Qt6::WebChannel
+        Qt6::WebEngineQuick
         Qt6::WebEngineWidgets
         Qt6::Svg
         Qt6::Xml


### PR DESCRIPTION
Show the lightweight interface before loading the full workspace. 将无记事本场景提前显示轻量界面，延后完整工作区加载。

Defer WebEngine, data, audio, and D-Bus initialization until needed. 按需延后 WebEngine、数据、音频和 D-Bus 初始化。

Log: 优化无记事本场景启动速度
PMS: BUG-373423
Influence: 无记事本时减少启动阶段加载内容；有记事本时保持原工作区流程。

## Summary by Sourcery

Defer full workspace initialization to provide a faster lightweight startup experience when no notebooks exist.

New Features:
- Add a lightweight initial interface for launches without existing notebooks, with workspace and settings loaded on demand.

Enhancements:
- Defer WebEngine initialization and note-manager startup until the full workspace is activated.
- Preserve the existing workspace startup flow for users with existing folders and support creating the first notebook after deferred initialization.

CI:
- Update test dependencies and linking for the platform-specific Qt WebEngine initialization modules.