### PR TITLE
perf(startup): defer workspace initialization for empty notebooks

### DIFF
--- a/src/common/VNoteMainManager.cpp
+++ b/src/common/VNoteMainManager.cpp
@@ -21,11 +21,14 @@
 #include "handler/voice_to_text_task_manager.h"
 #include "audio/recording_curves.h"
 #include "dbus/VoiceNoteDBusService.h"
+#include "db/vnotedbmanager.h"
 
 #include <QThreadPool>
 #include <QQmlApplicationEngine>
 // 条件编译：根据 Qt 版本包含不同的 WebEngine 头文件
-#ifndef USE_QT5
+#ifdef USE_QT5
+#include <QtWebEngine/QtWebEngine>
+#else
 #include <QtWebEngineQuick/qtwebenginequickglobal.h>
 #endif
 #include <QStringList>
@@ -42,6 +45,8 @@
 #include <QImageReader>
 #include <QTimer>
 #include <QSet>
+#include <QSqlQuery>
+#include <QSqlError>
 
 #include <DSysInfo>
 
@@ -87,6 +92,41 @@ VNoteMainManager *VNoteMainManager::instance()
     qInfo() << "VNoteMainManager instance requested";
     static VNoteMainManager instance;
     return &instance;
+}
+
+bool VNoteMainManager::hasExistingFolders()
+{
+    QSqlQuery query(VNoteDbManager::instance()->getVNoteDb());
+    if (!query.exec(QStringLiteral("SELECT 1 FROM %1 LIMIT 1")
+                    .arg(VNoteDbManager::FOLDER_TABLE_NAME))) {
+        qWarning() << "Failed to check existing folders:" << query.lastError().text();
+        return false;
+    }
+
+    return query.next();
+}
+
+void VNoteMainManager::prepareWorkspace()
+{
+    if (m_webEngineInitialized)
+        return;
+
+#ifdef USE_QT5
+    QtWebEngine::initialize();
+#else
+    QtWebEngineQuick::initialize();
+#endif
+    m_webEngineInitialized = true;
+}
+
+void VNoteMainManager::start()
+{
+    if (m_initialized)
+        return;
+
+    m_initialized = true;
+    initNote();
+    VTextSpeechAndTrManager::instance()->checkUosAiExists();
 }
 
 void VNoteMainManager::initNote()
@@ -210,6 +250,7 @@ void VNoteMainManager::onVNoteFoldersLoaded()
     //     pFileCleanupWorker->setAutoDelete(true);
     //     pFileCleanupWorker->setObjectName("FileCleanupWorker");
     //     QThreadPool::globalInstance()->start(pFileCleanupWorker);
+    emit initialDataReady();
     qInfo() << "VNote folders loaded handling finished";
 }
 

--- a/src/common/VNoteMainManager.h
+++ b/src/common/VNoteMainManager.h
@@ -29,6 +29,9 @@ public:
     Q_ENUM(SaveAsType)
 
     static VNoteMainManager* instance();
+    static bool hasExistingFolders();
+    Q_INVOKABLE void prepareWorkspace();
+    Q_INVOKABLE void start();
     void initNote();
     void initQMLRegister();
 
@@ -101,6 +104,7 @@ public:
     void insertVoiceTextToNote(int noteId, const QString &voiceId, const QString &text);
 
 signals:
+    void initialDataReady();
     void finishedFolderLoad(const QList<QVariantMap> &foldersData);
     void updateNotes(const QList<QVariantMap> &notesData, const int &selectIndex);
     void selectNoteByIndex(const int &selectIndex);
@@ -160,6 +164,8 @@ private:
     QStringList m_folderSort;
     WebRichTextManager *m_richTextManager {nullptr};
     VoiceNoteDBusService *m_dbusService {nullptr};
+    bool m_initialized {false};
+    bool m_webEngineInitialized {false};
     QString m_searchText;
     QEventLoop m_eventloop;
     PendingAction m_pendingAction {PendingAction::None};

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -12,12 +12,16 @@ import "../" as VNoteComponents
 import "../dialog"
 import org.deepin.dtk 1.0
 
-ApplicationWindow {
+Item {
     id: rootWindow
 
+    anchors.fill: parent
+
+    property bool active: Window.window ? Window.window.active : false
     property int createFolderBtnHeight: 30
     property bool isRecording: webEngineView.isRecording
     property bool isRecordingAudio: false
+    property bool layoutInitialized: false
     property bool isVoiceToText: false
     property int leftAreaMaxWidth: 300
     property int leftAreaMinWidth: 125
@@ -53,43 +57,19 @@ ApplicationWindow {
         }
     }
 
-    DWindow.alphaBufferSize: 8
-    DWindow.enabled: true
-    color: "transparent"
-    flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
-    height: 681
-    minimumHeight: windowMiniHeight
-    minimumWidth: windowMiniWidth
-    visible: true
-    width: 1096
+    function stopAndClose() {
+        webEngineView.stopAndClose();
+    }
 
     Component.onCompleted: {
-        x = Screen.width / 2 - width / 2;
-        y = Screen.height / 2 - height / 2;
-        checkAndCreateDataPath();
+        Qt.callLater(function() {
+            layoutInitialized = true;
+        });
     }
-    onClosing: function(close) {
-        close.accepted = false;
-        if (isRecording) {
-            close.accepted = false;
-            messageDialogLoader.showDialog(VNoteMessageDialogHandler.AbortRecord, ret => {
-                if (ret) {
-                    webEngineView.stopAndClose();
-                    VNoteMainManager.forceExit(true);
-                }
-            });
-        } else {
-            if (VNoteMainManager.isVoiceToText()) {
-                messageDialogLoader.showDialog(VNoteMessageDialogHandler.AborteAsr, ret => {
-                    if (ret) {
-                        VNoteMainManager.forceExit();
-                    }
-                });
-            } else
-                VNoteMainManager.forceExit();
-        }
-    }
+
     onWidthChanged: {
+        if (!layoutInitialized)
+            return;
         if (rightBgArea.width < rightAreaMinWidth) {
             var reduce = rightAreaMinWidth - rightBgArea.width;
             if (middleBgArea.width - reduce >= middleAreaMinWidth - rightDragHandle.width) {
@@ -567,7 +547,7 @@ ApplicationWindow {
     // 全窗级毛玻璃：左侧文件夹栏 + 笔记列表区域透明可见，列表项保持实色卡片
     VNoteComponents.SidebarBlurBackground {
         anchors.fill: parent
-        windowControl: rootWindow
+        windowControl: Window.window
         z: 0
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,13 +24,6 @@
 #include <QCommandLineParser>
 #include <QTimer>
 
-// 条件编译：根据 Qt 版本包含不同的 WebEngine 头文件
-#ifdef USE_QT5
-#include <QtWebEngine/QtWebEngine>
-#else
-#include <QtWebEngineQuick/qtwebenginequickglobal.h>
-#endif
-
 #include <DApplication>
 #include <DGuiApplicationHelper>
 #include <DLog>
@@ -105,21 +98,16 @@ int main(int argc, char *argv[])
     qputenv("QTWEBENGINE_REMOTE_DEBUGGING", "7777");
     VNoteMainManager::instance()->initQMLRegister();
     
-    // 条件编译：根据 Qt 版本使用不同的 WebEngine 初始化方法
-#ifdef USE_QT5
-    QtWebEngine::initialize();
-#else
-    QtWebEngineQuick::initialize();
-#endif
-    
     ImageProvider *imageProvider = ImageProvider::instance();
-    qInfo() << "QML and WebEngine initialized successfully";
+    qInfo() << "QML types initialized successfully";
 
     app->loadTranslator();
     app->setApplicationDisplayName(QObject::tr("deepin-voice-note"));
     QQmlApplicationEngine engine;
     const QUrl url(QStringLiteral("qrc:/main.qml"));
     engine.addImageProvider("Provider", imageProvider);
+    engine.rootContext()->setContextProperty(
+        "hasExistingFolders", VNoteMainManager::hasExistingFolders());
     QObject::connect(
         &engine,
         &QQmlApplicationEngine::objectCreated,
@@ -134,15 +122,9 @@ int main(int argc, char *argv[])
     engine.load(url);
     qInfo() << "QML engine loaded successfully";
 
-    VNoteMainManager::instance()->initNote();
-    qInfo() << "Note manager initialized";
-
     DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();
     qInfo() << "Log system initialized";
 
-    VTextSpeechAndTrManager::instance()->checkUosAiExists();
-    qInfo() << "UOS AI check completed";
-    
     return app->exec();
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -6,8 +6,117 @@
 import QtQuick 2.15
 import QtQuick.Window 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
+import VNote 1.0
 import "./gui/mainwindow"
+import "./gui/dialog"
+import org.deepin.dtk 1.0
 
-MainWindow {
-    id: root
+ApplicationWindow {
+    id: rootWindow
+
+    Accessible.name: "VoiceNoteMainWindow"
+    Accessible.role: Accessible.Window
+
+    property bool workspaceActive: workspaceLoader.active
+    property bool createFirstNotebook: false
+    property bool isRecording: workspaceLoader.item ? workspaceLoader.item.isRecording : false
+
+    DWindow.enabled: true
+    color: DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#101010"
+    flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
+    height: 681
+    minimumHeight: 300
+    minimumWidth: 685
+    visible: true
+    width: 1096
+
+    function activateWorkspace(createFirstNotebook) {
+        if (workspaceLoader.active)
+            return;
+
+        rootWindow.createFirstNotebook = createFirstNotebook;
+        initialInterface.visible = false;
+        VNoteMainManager.prepareWorkspace();
+        workspaceLoader.active = true;
+        workspaceLoader.source = "gui/mainwindow/MainWindow.qml";
+    }
+
+    Component.onCompleted: {
+        x = Screen.width / 2 - width / 2;
+        y = Screen.height / 2 - height / 2;
+        if (hasExistingFolders)
+            activateWorkspace(false);
+        else
+            initialInterface.loadFinished(false);
+    }
+
+    onClosing: function(close) {
+        close.accepted = false;
+        if (isRecording) {
+            messageDialogLoader.showDialog(VNoteMessageDialogHandler.AbortRecord, ret => {
+                if (ret) {
+                    workspaceLoader.item.stopAndClose();
+                    VNoteMainManager.forceExit(true);
+                }
+            });
+        } else if (VNoteMainManager.isVoiceToText()) {
+            messageDialogLoader.showDialog(VNoteMessageDialogHandler.AborteAsr, ret => {
+                if (ret)
+                    VNoteMainManager.forceExit();
+            });
+        } else {
+            VNoteMainManager.forceExit();
+        }
+    }
+
+    Loader {
+        id: workspaceLoader
+
+        anchors.fill: parent
+        active: false
+        asynchronous: false
+
+        onLoaded: {
+            initialInterface.visible = false;
+            VNoteMainManager.start();
+        }
+    }
+
+    InitialInterface {
+        id: initialInterface
+
+        anchors.fill: parent
+        visible: !workspaceLoader.active
+
+        onCreateFolder: {
+            rootWindow.activateWorkspace(true);
+        }
+        onTitleOpenSetting: {
+            if (settingDlgLoader.status === Loader.Null)
+                settingDlgLoader.setSource("gui/dialog/SettingDialog.qml");
+            if (settingDlgLoader.status === Loader.Ready)
+                settingDlgLoader.item.show();
+        }
+    }
+
+    VNoteMessageDialogLoader {
+        id: messageDialogLoader
+    }
+
+    Loader {
+        id: settingDlgLoader
+    }
+
+    Connections {
+        target: VNoteMainManager
+
+        function onInitialDataReady() {
+            if (!rootWindow.createFirstNotebook)
+                return;
+
+            rootWindow.createFirstNotebook = false;
+            VNoteMainManager.vNoteCreateFolder();
+        }
+    }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -z relro -z now -z noexecstack -pie")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fstack-protector-all")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -fstack-protector-all")
 
+add_definitions(-DUSE_QT5)
 find_package(Qt5Test REQUIRED)
+find_package(Qt5 5.15 REQUIRED COMPONENTS WebEngine)
 find_package(GTest REQUIRED)
 find_package(Qt5Svg REQUIRED)
 find_package(Qt5Xml REQUIRED)
@@ -90,6 +92,7 @@ target_link_libraries(${PROJECT_NAME_TEST}
     Qt5::Multimedia
     Qt5::Test
     Qt5::WebChannel
+    Qt5::WebEngine
     Qt5::WebEngineWidgets
     ${Qt5Svg_LIBRARIES}
     ${Qt5Xml_LIBRARIES}


### PR DESCRIPTION
Show the lightweight interface before loading the full workspace. 将无记事本场景提前显示轻量界面，延后完整工作区加载。

Defer WebEngine, data, audio, and D-Bus initialization until needed. 按需延后 WebEngine、数据、音频和 D-Bus 初始化。

Log: 优化无记事本场景启动速度
PMS: BUG-373423
Influence: 无记事本时减少启动阶段加载内容；有记事本时保持原工作区流程。

## Summary by Sourcery

Improve startup performance for empty notebooks by displaying the lightweight interface before initializing the full workspace.

New Features:
- Add a lightweight initial interface for sessions without existing notebooks, with workspace activation on demand.
- Support creating the first notebook after the full workspace becomes ready.

Enhancements:
- Defer WebEngine, note data, speech, audio, and D-Bus-related workspace initialization until the workspace is needed.
- Preserve the existing full workspace startup flow for sessions with existing notebooks.

Tests:
- Update the test configuration to include Qt 5 WebEngine support.