### PR TITLE
fix(startup): handle workspace loading fallback and shortcut position

### DIFF
--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -154,7 +154,7 @@ Item {
             itemListView.renameCurrentItem();
         }
         onShowShortCutView: {
-            VNoteMainManager.preViewShortcut(Qt.point(rootWindow.x + rootWindow.width / 2, rootWindow.y + rootWindow.height / 2));
+            VNoteMainManager.preViewShortcut(Qt.point((Window.window ? Window.window.x : 0) + rootWindow.width / 2, (Window.window ? Window.window.y : 0) + rootWindow.height / 2));
         }
         onStartRecording: {
             if (initRect.visible) {

--- a/src/main.qml
+++ b/src/main.qml
@@ -81,6 +81,13 @@ ApplicationWindow {
             initialInterface.visible = false;
             VNoteMainManager.start();
         }
+        onStatusChanged: {
+            if (status === Loader.Error) {
+                console.error("Failed to load workspace:", source);
+                workspaceLoader.active = false;
+                initialInterface.loadFinished(false);
+            }
+        }
     }
 
     InitialInterface {


### PR DESCRIPTION
Restore the lightweight page when workspace loading fails. 修复工作区加载失败时回退轻量首页的问题。

Correct shortcut preview coordinates for embedded windows. 修正嵌入式窗口下快捷键预览位置计算。

Log: 修复启动回退和快捷键预览位置
PMS: BUG-373423
Influence: 避免工作区加载失败时显示空白，并确保快捷键预览位置正确。

## Summary by Sourcery

Handle workspace startup failures gracefully and fix shortcut preview coordinates.

Bug Fixes:
- Restore the lightweight startup page when the workspace fails to load instead of leaving a blank screen.
- Correct shortcut preview positioning for embedded windows.