### PR TITLE
fix(startup): enable WebEngine debugging only for debug builds

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,7 +95,9 @@ int main(int argc, char *argv[])
     app->setApplicationVersion(VERSION);
     qInfo() << "Application initialized with version:" << VERSION;
 
+#ifndef NDEBUG
     qputenv("QTWEBENGINE_REMOTE_DEBUGGING", "7777");
+#endif
     VNoteMainManager::instance()->initQMLRegister();
     
     ImageProvider *imageProvider = ImageProvider::instance();


### PR DESCRIPTION
Keep the remote debugging port available for debug builds only. 仅在调试构建中开启 WebEngine 远程调试端口。

Log: 限制 WebEngine 远程调试端口
PMS: BUG-373423
Influence: Release 构建不再默认开放 7777 调试端口，Debug 构建仍保留 Inspector 调试能力。

## Summary by Sourcery

Bug Fixes:
- Restrict the WebEngine remote debugging port to debug builds so release builds no longer expose port 7777 by default.