### PR TITLE
chore: update version to 6.5.66

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-voice-note (6.5.66) unstable; urgency=medium
+
+  * fix(startup): enable WebEngine debugging only for debug builds
+  * fix(startup): handle workspace loading fallback and shortcut position
+  * perf(startup): defer workspace initialization for empty notebooks
+  * chore: Sync by https://github.com/linuxdeepin/.github/commit/a300f8523d4876677112edab6a0772f7ad112976
+  * fix(editor): prevent keyboard flash on initial note creation
+
+ -- Wang Yu <wangyu@uniontech.com>  Wed, 26 Aug 2026 17:14:55 +0800
+
 deepin-voice-note (6.5.65) unstable; urgency=medium
 
   * fix(editor): align virtual keyboard behavior for new notes

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.voice.note
   name: deepin-voice-note
-  version: 6.5.65.1
+  version: 6.5.66.1
   kind: app
   description: |
     voice note for deepin os


### PR DESCRIPTION
- bump version to 6.5.66

Log : bump version to 6.5.66

## Summary by Sourcery

Chores:
- Update the Debian package metadata and Linglong manifest to version 6.5.66.