### PR TITLE
fix(at-spi): 补全QML交互控件AT-SPI无障碍信息

### DIFF
--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -257,6 +257,9 @@ Item {
     // 升级进度界面全屏覆盖层（单一 UpgradeView，迁移期间遮蔽主编辑界面，终态展示备份/报告路径）。
     UpgradeView {
         anchors.fill: parent
+
+        Accessible.name: "MainWindow_UpgradeView"
+        Accessible.role: Accessible.Pane
     }
 
     Connections {

--- a/src/gui/mainwindow/UpgradeView.qml
+++ b/src/gui/mainwindow/UpgradeView.qml
@@ -114,6 +114,9 @@ Item {
         // 取消按钮（运行态可见；cancelling 时置灰）。
         // DTK Button（org.deepin.dtk 1.0），固定宽高保证可见可点。
         Button {
+            Accessible.name: "UpgradeView_Button"
+            Accessible.role: Accessible.Button
+
             Layout.alignment: Qt.AlignHCenter
             width: 120
             height: 36
@@ -163,6 +166,9 @@ Item {
             interactive: contentHeight > height
 
             ScrollBar.vertical: ScrollBar {
+                Accessible.name: "UpgradeView_ScrollBar"
+                Accessible.role: Accessible.ScrollBar
+
                 policy: terminalFlickable.contentHeight > terminalFlickable.height
                         ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
             }

--- a/src/main.qml
+++ b/src/main.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2020 Deepin Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Deepin Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -92,6 +92,8 @@ ApplicationWindow {
 
     InitialInterface {
         id: initialInterface
+        Accessible.name: "InitialInterface"
+        Accessible.role: Accessible.Pane
 
         anchors.fill: parent
         visible: !workspaceLoader.active
@@ -109,6 +111,8 @@ ApplicationWindow {
 
     VNoteMessageDialogLoader {
         id: messageDialogLoader
+        Accessible.name: "MessageDialogLoader"
+        Accessible.role: Accessible.Dialog
     }
 
     Loader {


### PR DESCRIPTION
## 背景

deepin-voice-note QML 层存在 5 个交互控件缺失 AT-SPI 无障碍名称,导致辅助工具和 YouQu 自动化测试无法定位。

## 修改内容

补全 5 个 QML 元素的 `Accessible.name` 和 `Accessible.role`:

| 文件 | 元素 | Accessible.name | Accessible.role |
|------|------|-----------------|-----------------|
| `src/gui/mainwindow/MainWindow.qml` | UpgradeView | MainWindow_UpgradeView | Pane |
| `src/gui/mainwindow/UpgradeView.qml` | Button | UpgradeView_Button | Button |
| `src/gui/mainwindow/UpgradeView.qml` | ScrollBar | UpgradeView_ScrollBar | ScrollBar |
| `src/main.qml` | InitialInterface | InitialInterface | Pane |
| `src/main.qml` | VNoteMessageDialogLoader | MessageDialogLoader | Dialog |

## 覆盖率

| | 补全前 | 补全后 |
|---|--------|--------|
| QML 元素总数 | 70 | 70 |
| 已命名 | 65 | 70 |
| 缺失 | 5 | 0 |
| 覆盖率 | 92.9% | **100%** |

C++ 层无交互控件(0 widgets),UI 全部由 QML 实现。

Log: 升级界面与主界面交互控件补全AT-SPI无障碍名称

## Summary by Sourcery

Bug Fixes:
- 补全升级界面和主界面 5 个 QML 交互控件的 AT-SPI 无障碍名称与角色，确保辅助工具和自动化测试能够定位这些控件。