### PR TITLE
feat(tiptap): align search layout and note creation entry

### DIFF
--- a/src/common/datatypedef.cpp
+++ b/src/common/datatypedef.cpp
@@ -78,7 +78,7 @@ VNOTE_DATAS::~VNOTE_DATAS()
  * @brief VNOTE_DATAS::dataConstRef
  * @return 记事项数据
  */
-const VNOTE_DATA_VECTOR &VNOTE_DATAS::dataConstRef()
+const VNOTE_DATA_VECTOR &VNOTE_DATAS::dataConstRef() const
 {
     return datas;
 }

--- a/src/common/datatypedef.h
+++ b/src/common/datatypedef.h
@@ -64,7 +64,7 @@ struct VNOTE_ALL_NOTES_MAP {
 struct VNOTE_DATAS {
     ~VNOTE_DATAS();
 
-    const VNOTE_DATA_VECTOR &dataConstRef();
+    const VNOTE_DATA_VECTOR &dataConstRef() const;
 
 protected:
     //新建数据块

--- a/src/common/migrationviewcontroller.cpp
+++ b/src/common/migrationviewcontroller.cpp
@@ -6,6 +6,7 @@
 #include "tiptapchannelbridge.h"
 
 #include <QLoggingCategory>
+#include <QTimer>
 
 namespace {
 Q_LOGGING_CATEGORY(lcMigrationView, "voice_note_migration_view")
@@ -54,17 +55,26 @@ void MigrationViewController::start()
         return;
     }
 
-    // 展示进度界面并拉起后台编排器；startIfNeeded 内部在后台线程启动前以
-    // Qt::QueuedConnection 把进度/阶段/终态/中断信号连接到本控制器。
+    // 先通知界面进入迁移态，再把后台任务投递到下一轮事件循环。
+    // 如果这里立即启动迁移，空数据库或少量数据可能在 UpgradeView 首次绘制前
+    // 就完成，导致原始迁移页面完全看不到。
     setMigrationActive(true);
-    MigrationOrchestrator *orchestrator = MigrationOrchestrator::startIfNeeded(this);
-    if (!orchestrator) {
-        // 状态在判定与启动之间变化（磁盘异常边界）：回退为不放行展示。
-        qCWarning(lcMigrationView) << "start: startIfNeeded returned null, hide overlay";
-        setMigrationActive(false);
-        return;
-    }
-    m_orchestrator = orchestrator;
+    QTimer::singleShot(0, this, [this]() {
+        if (!m_migrationActive || m_orchestrator) {
+            return;
+        }
+
+        // startIfNeeded 内部在后台线程启动前以 Qt::QueuedConnection 把进度/阶段/终态/
+        // 中断信号连接到本控制器。此时 UpgradeView 已经有机会完成首帧绘制。
+        MigrationOrchestrator *orchestrator = MigrationOrchestrator::startIfNeeded(this);
+        if (!orchestrator) {
+            // 状态在判定与启动之间变化（磁盘异常边界）：回退为不放行展示。
+            qCWarning(lcMigrationView) << "start: startIfNeeded returned null, hide overlay";
+            setMigrationActive(false);
+            return;
+        }
+        m_orchestrator = orchestrator;
+    });
 }
 
 void MigrationViewController::requestCancel()

--- a/src/common/vnoteitem.cpp
+++ b/src/common/vnoteitem.cpp
@@ -450,7 +450,7 @@ VNoteBlock::~VNoteBlock()
  * @brief VNoteBlock::getType
  * @return 数据类型
  */
-qint32 VNoteBlock::getType()
+qint32 VNoteBlock::getType() const
 {
     // qInfo() << "Getting block type:" << blockType;
     return blockType;

--- a/src/common/vnoteitem.h
+++ b/src/common/vnoteitem.h
@@ -127,7 +127,7 @@ struct VNoteBlock {
     //释放资源，语音时用于删除文件
     virtual void releaseSpecificData() = 0;
     //获取数据类型
-    qint32 getType();
+    qint32 getType() const;
 
     qint32 blockType {InValid};
     /*

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -254,14 +254,6 @@ Item {
 
     }
 
-    // 升级进度界面全屏覆盖层（单一 UpgradeView，迁移期间遮蔽主编辑界面，终态展示备份/报告路径）。
-    UpgradeView {
-        anchors.fill: parent
-
-        Accessible.name: "MainWindow_UpgradeView"
-        Accessible.role: Accessible.Pane
-    }
-
     Connections {
         target: MigrationViewController
 

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -41,6 +41,22 @@ Item {
         return twoColumnModeBtn.x + twoColumnModeBtn.width + 8 - middleColumnLayout.anchors.leftMargin;
     }
 
+    function createNoteFromWorkspace() {
+        if (initRect.visible) {
+            console.warn("Cannot create note on initial page");
+            return;
+        }
+        if (isRecordingAudio || folderListView.isPlay || webEngineView.titleBar.isPlaying) {
+            console.log("Cannot create note while recording or playing audio");
+            return;
+        }
+        if (isVoiceToText) {
+            console.log("Cannot create note while voice to text is in progress");
+            return;
+        }
+        VNoteMainManager.createNote();
+    }
+
     function toggleTwoColumnMode() {
         if (hideLeftArea.running) {
             hideLeftArea.stop();
@@ -115,22 +131,7 @@ Item {
             VNoteMainManager.vNoteCreateFolder();
         }
         onCreateNote: {
-            // 初始页面可见时，屏蔽 Ctrl+B
-            if (initRect.visible) {
-                console.warn("Cannot create note on initial page");
-                return;
-            }
-            // 录音时不允许创建笔记
-            if (isRecordingAudio || folderListView.isPlay) {
-                console.log("Cannot create note while recording or playing audio");
-                return;
-            }
-            // 语音转文字时不允许创建笔记，避免转文字结果丢失
-            if (isVoiceToText) {
-                console.log("Cannot create note while voice to text is in progress");
-                return;
-            }
-            VNoteMainManager.createNote();
+            createNoteFromWorkspace();
         }
 
         onRenameFolder: {
@@ -484,14 +485,12 @@ Item {
             VNoteMainManager.vNoteChanged(modelItem.noteId);
         }
         onNoSearchResult: {
-            label.visible = false;
             webEngineView.webVisible = false;
             webEngineView.noSearchResult = true;
             webEngineView.titleBar.isSearching = true;
             itemListView.isSearching = true;
         }
         onSearchFinished: {
-            label.visible = false;
             webEngineView.webVisible = true;
             webEngineView.noSearchResult = false;
             webEngineView.titleBar.isSearching = true;
@@ -834,7 +833,6 @@ Item {
                             itemListView.searchLoader.item.visible = false;
                         }
                         itemListView.view.visible = true;
-                        label.visible = true;
                         itemListView.isSearch = false;
                         itemListView.isSearching = false;
                         // 退出搜索时，只有当前记事本有笔记时才显示富文本编辑器
@@ -889,7 +887,6 @@ Item {
                                 itemListView.searchLoader.item.visible = false;
                             }
                             itemListView.view.visible = true;
-                            label.visible = true;
                             itemListView.isSearch = false;
                             itemListView.isSearching = false;
                             // 清空搜索文本时，只有当前记事本有笔记时才显示富文本编辑器
@@ -909,15 +906,59 @@ Item {
                     }
                 }
 
-                Label {
-                    id: label
+                RowLayout {
+                    id: noteListHeader
 
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 18
+                    Layout.preferredHeight: 30
                     Layout.topMargin: 5
-                    color: DTK.themeType === ApplicationHelper.LightType ? "#BB000000" : "#BBFFFFFF"
-                    font.pixelSize: 16
-                    text: ""
+                    spacing: 0
+                    visible: !initRect.visible
+                             && !webEngineView.noSearchResult
+                             && !itemListView.isSearch
+                             && !itemListView.isSearching
+                             && !webEngineView.titleBar.isSearching
+
+                    Label {
+                        id: label
+
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 18
+                        color: DTK.themeType === ApplicationHelper.LightType ? "#BB000000" : "#BBFFFFFF"
+                        font.pixelSize: 16
+                        text: ""
+                    }
+
+                    VNoteComponents.VNoteToolButton {
+                        Accessible.name: "NewNoteButton"
+                        Accessible.role: Accessible.Button
+
+                        id: newNoteBtn
+
+                        Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                        Layout.preferredHeight: 30
+                        Layout.preferredWidth: 30
+                        Layout.rightMargin: 10
+                        enabled: !rootWindow.isRecordingAudio
+                                  && !folderListView.isPlay
+                                  && !webEngineView.titleBar.isPlaying
+                                  && !webEngineView.titleBar.isSearching
+                                  && !rootWindow.isVoiceToText
+                        icon.height: 16
+                        icon.name: "new_note"
+                        icon.width: 16
+                        height: 30
+                        width: 30
+
+                        onClicked: {
+                            rootWindow.createNoteFromWorkspace();
+                        }
+
+                        ToolTip {
+                            text: qsTr("Create Note")
+                            visible: newNoteBtn.hovered
+                        }
+                    }
                 }
 
                 ItemListView {

--- a/src/gui/mainwindow/UpgradeView.qml
+++ b/src/gui/mainwindow/UpgradeView.qml
@@ -3,238 +3,105 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 
 import org.deepin.dtk 1.0
-
 import VNote 1.0
 
-// 升级进度界面全屏覆盖层（回归单一 UpgradeView 身份）。
-// 运行态忠实复刻老 QWidget UpgradeView 的视觉：DTK WaterProgressBar 复刻
-// DWaterProgress 水波动画 + tooltip 文案，布局对齐老 QWidget（水波居中、
-// tooltip 居中置于水波下方）。
-// 终态页布局策略：将"进入应用"按钮锚定到窗口底部可视区（位于 Flickable 之外），
-// 标题与路径信息放入按钮上方的 Flickable 中独立滚动。这样无论窗口几何如何
-// （含小窗口场景），"进入应用"按钮始终可见且可点击，彻底消除
-// 原先整页 Flickable 在小窗口下按钮被 clip 截断且不可滚动到达的困死症状。
-// 仅绑定计数/阶段/路径属性，不展示笔记正文/信封/meta_data/失败 note id 清单。
+// 使用 DTK Declarative 原生 WaterProgressBar 复刻原始 QWidget UpgradeView。
+// 页面只覆盖 titlebar 下方的 central widget 区域。
 Item {
     id: root
 
-    // 覆盖层可见：迁移进行中 或 终态结果待用户放行。
-    visible: MigrationViewController.migrationActive || MigrationViewController.terminalState !== ""
-    z: 9999
+    property int titleBarHeight: 0
 
-    // 终态结果待放行（Completed/PartialCompleted/Failed）。
-    readonly property bool terminalVisible: MigrationViewController.terminalState !== ""
-    // 迁移进行中（含等待态/Migrating），非终态。
-    readonly property bool runningActive: MigrationViewController.migrationActive && !terminalVisible
-
-    // 运行态水波进度值（0-100）。Migrating 阶段按已处理/总数推进；
-    // 其余运行阶段保持微小值以维持水波动画视觉（对齐老 DWaterProgress 行为）。
-    readonly property int waterValue: {
-        if (!runningActive) return 0
-        if (MigrationViewController.stage === "Migrating" && MigrationViewController.total > 0) {
-            return Math.round(MigrationViewController.processed * 100.0 / MigrationViewController.total)
+    readonly property int progressValue: {
+        if (MigrationViewController.stage === "Migrating"
+                && MigrationViewController.total > 0) {
+            return Math.round(MigrationViewController.processed * 100.0
+                              / MigrationViewController.total)
         }
         return 1
     }
 
+    visible: MigrationViewController.migrationActive
+    z: 9999
+
     Rectangle {
-        id: background
-        anchors.fill: parent
-        color: "#FFFFFF"
-        opacity: 0.97
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.topMargin: root.titleBarHeight
+        anchors.bottom: parent.bottom
+        color: Window.window
+               ? Window.window.palette.window
+               : (DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#242424")
     }
 
-    // 吸收鼠标事件，迁移期间/终态放行前阻止与下层主编辑界面交互。
-    // 声明于内容层之前，作为底层；上方的内容容器、Flickable、按钮均在其之上，
-    // 故按钮点击与 Flickable 滚动手势不会被本 MouseArea 抢占。
+    // central widget 区域阻止迁移期间的编辑器交互，但不覆盖 titlebar。
     MouseArea {
-        anchors.fill: parent
-        hoverEnabled: true
-        propagateComposedEvents: false
-        onClicked: function(mouse) { mouse.accepted = true }
-        onPressed: function(mouse) { mouse.accepted = true }
-        onPositionChanged: function(mouse) { mouse.accepted = true }
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.topMargin: root.titleBarHeight
+        anchors.bottom: parent.bottom
+        acceptedButtons: Qt.AllButtons
+        z: 1
     }
 
-    // 运行态：水波 + tooltip + 阶段 + 计数 + 取消按钮，整体居中。
-    // 运行态内容高度有限（水波 80 + 文案数行 + 取消按钮），常规窗口可直接容纳，
-    // 不依赖滚动；核心诉求在终态页，运行态布局保持居中复刻老 QWidget。
     ColumnLayout {
-        id: runningColumn
-        anchors.centerIn: parent
-        width: Math.min(420, parent.width - 80)
-        visible: runningActive
-        spacing: 20
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.topMargin: root.titleBarHeight
+        anchors.bottom: parent.bottom
+        spacing: 0
+        z: 2
 
-        // 水波进度（复刻老 QWidget DWaterProgress，80x80 居中）。
-        // 对齐 src/gui/mainwindow/InitialInterface.qml 的 WaterProgressBar 写法：
-        // 只用 value + visible（由父 runningColumn 的 visible 控制运行态显隐），
-        // 不设 running——当前 DTK/QML 环境该属性不存在，设置会导致控件创建失败、
-        // 中断整个 QML 组件树加载（用户运行时实测根因）。
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+
         WaterProgressBar {
             Layout.alignment: Qt.AlignHCenter
             Layout.preferredWidth: 80
             Layout.preferredHeight: 80
-            value: root.waterValue
+            running: root.visible
+            value: root.progressValue
         }
 
-        // 运行态 tooltip 文案（对齐老 QWidget：水波下方居中提示文本）。
-        Text {
-            Layout.alignment: Qt.AlignHCenter
-            text: qsTr("正在升级笔记数据，请勿关闭应用")
-            font.pixelSize: 18
-            font.bold: true
-            color: "#303030"
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 10
         }
 
-        // 阶段文案（运行态展示当前阶段）。
-        Text {
+        Label {
             Layout.alignment: Qt.AlignHCenter
-            text: stageText(MigrationViewController.stage)
+            color: Window.window
+                   ? Window.window.palette.text
+                   : (DTK.themeType === ApplicationHelper.LightType ? "#000000" : "#FFFFFF")
             font.pixelSize: 14
-            color: "#666666"
+            text: qsTr("Importing notes from the old version, please wait...")
         }
 
-        // Migrating 计数（已处理/总数/成功/失败）。
-        Text {
-            Layout.alignment: Qt.AlignHCenter
-            visible: MigrationViewController.stage === "Migrating"
-            text: qsTr("已处理 %1 / %2　成功 %3　失败 %4")
-                  .arg(MigrationViewController.processed)
-                  .arg(MigrationViewController.total)
-                  .arg(MigrationViewController.success)
-                  .arg(MigrationViewController.fail)
-            font.pixelSize: 13
-            color: "#888888"
-        }
-
-        // 取消按钮（运行态可见；cancelling 时置灰）。
-        // DTK Button（org.deepin.dtk 1.0），固定宽高保证可见可点。
-        Button {
-            Accessible.name: "UpgradeView_Button"
-            Accessible.role: Accessible.Button
-
-            Layout.alignment: Qt.AlignHCenter
-            width: 120
-            height: 36
-            enabled: !MigrationViewController.cancelling
-            text: MigrationViewController.cancelling ? qsTr("正在取消…") : qsTr("取消迁移")
-            onClicked: MigrationViewController.requestCancel()
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
         }
     }
 
-    // 终态层：标题+路径放入 Flickable 独立滚动，"进入应用"按钮锚定窗口底部。
-    // 按钮位于 Flickable 之外，任何窗口几何下都恒可见可点。
-    Item {
-        id: terminalLayer
-        anchors.fill: parent
-        visible: terminalVisible
+    // 原始 UpgradeView 在升级完成后通过 upgradeDone 切回主页面；
+    // 这里保持相同语义，不展示额外的终态报告页面。
+    Connections {
+        target: MigrationViewController
 
-        // "进入应用"放行入口：锚定窗口底部居中，始终位于可视区内。
-        // DTK RecommandButton（主操作 CTA，对齐 InitialInterface.qml 的主按钮写法），
-        // 固定宽高保证可见可点。
-        RecommandButton {
-            id: enterAppButton
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: 24
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: 120
-            height: 36
-            text: qsTr("进入应用")
-            onClicked: MigrationViewController.enterApp()
-            z: 2
-        }
-
-        // 可滚动内容区：标题 + 备份/报告路径 + 计数摘要。
-        // 顶边贴窗口顶部，底边贴"进入应用"按钮顶部；内容溢出时垂直滚动，
-        // 不溢出时直接展示。按钮始终可见，与内容是否溢出无关。
-        Flickable {
-            id: terminalFlickable
-            anchors.top: parent.top
-            anchors.topMargin: 40
-            anchors.bottom: enterAppButton.top
-            anchors.bottomMargin: 20
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: Math.min(420, parent.width - 80)
-            clip: true
-            contentHeight: terminalContent.implicitHeight
-            flickableDirection: Flickable.VerticalFlick
-            boundsBehavior: Flickable.StopAtBounds
-            interactive: contentHeight > height
-
-            ScrollBar.vertical: ScrollBar {
-                Accessible.name: "UpgradeView_ScrollBar"
-                Accessible.role: Accessible.ScrollBar
-
-                policy: terminalFlickable.contentHeight > terminalFlickable.height
-                        ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+        function onTerminalStateChanged() {
+            if (MigrationViewController.terminalState !== "") {
+                MigrationViewController.enterApp()
             }
-
-            ColumnLayout {
-                id: terminalContent
-                width: terminalFlickable.width
-                spacing: 16
-
-                // 终态标题。
-                Text {
-                    Layout.alignment: Qt.AlignHCenter
-                    text: terminalTitle()
-                    font.pixelSize: 18
-                    font.bold: true
-                    color: "#303030"
-                }
-
-                // 终态信息：备份与报告路径 + 计数摘要（仅计数，不渲染报告正文）。
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: 8
-
-                    Text {
-                        Layout.fillWidth: true
-                        visible: MigrationViewController.backupPath !== ""
-                        text: qsTr("备份位置：%1").arg(MigrationViewController.backupPath)
-                        font.pixelSize: 13
-                        color: "#555555"
-                        wrapMode: Text.WrapAnywhere
-                    }
-                    Text {
-                        Layout.fillWidth: true
-                        visible: MigrationViewController.reportPath !== ""
-                        text: qsTr("迁移报告：%1").arg(MigrationViewController.reportPath)
-                        font.pixelSize: 13
-                        color: "#555555"
-                        wrapMode: Text.WrapAnywhere
-                    }
-                    // 部分完成/失败的计数摘要（仅计数，不展示失败 note id 清单）。
-                    Text {
-                        Layout.fillWidth: true
-                        visible: MigrationViewController.terminalState !== "Completed"
-                        text: qsTr("成功 %1　失败 %2").arg(MigrationViewController.success).arg(MigrationViewController.fail)
-                        font.pixelSize: 13
-                        color: "#888888"
-                    }
-                }
-            }
-        }
-    }
-
-    function terminalTitle() {
-        var s = MigrationViewController.terminalState;
-        if (s === "Completed") return qsTr("升级完成");
-        if (s === "PartialCompleted") return qsTr("升级部分完成");
-        if (s === "Failed") return qsTr("升级失败");
-        return qsTr("升级完成");
-    }
-
-    function stageText(stage) {
-        switch (stage) {
-            case "BackingUp": return qsTr("正在备份数据…");
-            case "Scanning": return qsTr("正在扫描笔记…");
-            case "Migrating": return qsTr("正在迁移笔记…");
-            default: return qsTr("正在准备…");
         }
     }
 }

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -571,7 +571,9 @@ Item {
             id: tiptapLoader
 
             active: TiptapChannel.debugEnabled
-            visible: active
+            // 搜索无结果时由 noSearchRect 占据编辑区，Tiptap 不应继续参与布局，
+            // 否则会被 ColumnLayout 排到无结果区域下方，导致工具栏出现在底部。
+            visible: active && !noSearchResult
             Layout.fillHeight: true
             Layout.fillWidth: true
 
@@ -939,11 +941,6 @@ Item {
     Connections {
         target: title
 
-        onCreateNote: {
-            if (!initialVisible && !rootItem.isVoiceToText) {
-                VNoteMainManager.createNote();
-            }
-        }
         onIsPlayingChanged: rootItem.syncTiptapResourceButtons()
         onIsSearchingChanged: rootItem.syncTiptapResourceButtons()
         onRecorderBtnEnableChanged: rootItem.syncTiptapResourceButtons()

--- a/src/gui/mainwindow/WindowTitleBar.qml
+++ b/src/gui/mainwindow/WindowTitleBar.qml
@@ -20,7 +20,6 @@ TitleBar {
     property bool recorderBtnEnable: true
     property bool recordBtnEnabled: recorderBtnEnable && !isPlaying && !isSearching && !isRecordingAudio && !isVoiceToText
 
-    signal createNote
     signal titleOpenSetting
 
     enableInWindowBlendBlur: false
@@ -48,33 +47,5 @@ TitleBar {
             titleBar.titleOpenSetting();
         }
     }
-
-    VNoteComponents.VNoteToolButton {
-        Accessible.name: "NewNoteButton"
-        Accessible.role: Accessible.Button
-        id: newNoteBtn
-
-        anchors.left: titleBar.left
-        anchors.leftMargin: 10
-        anchors.verticalCenter: titleBar.verticalCenter
-        enabled: !isPlaying && !isSearching && !isRecordingAudio && !isVoiceToText
-        hoverEnabled: !isInitialInterface
-        visible: !isInitialInterface
-        icon.height: 16
-        icon.name: "new_note"
-        icon.width: 16
-        height: 30
-        width: 30
-
-        onClicked: {
-            createNote();
-        }
-
-        ToolTip {
-            text: qsTr("Create Note")
-            visible: newNoteBtn.hovered
-        }
-    }
-
 
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -119,6 +119,17 @@ ApplicationWindow {
         id: settingDlgLoader
     }
 
+    // 迁移期间只覆盖主窗口内容区，保留原有 titlebar 区域。
+    UpgradeView {
+        Accessible.name: "MainWindow_UpgradeView"
+        Accessible.role: Accessible.Pane
+
+        id: migrationView
+
+        anchors.fill: parent
+        titleBarHeight: workspaceLoader.active ? 50 : 40
+    }
+
     Connections {
         target: VNoteMainManager
 


### PR DESCRIPTION
feat(tiptap): align search layout and note creation entry
Hide the Tiptap editor when search returns no results.
Move the new note entry to the note list header.

搜索无结果时隐藏Tiptap编辑器，避免编辑区域布局异常。
将新建笔记入口移动到笔记列表标题栏。

Log: 修复搜索布局并调整新建笔记入口

PMS: TASK-393985

Influence: 搜索无结果时工具栏不再出现在页面底部，
新建笔记入口位置和显示状态更加稳定。

## Summary by Sourcery

Align the workspace search and note-creation layouts while improving migration-screen presentation and flow.

New Features:
- Move the new-note action into the note list header with stable visibility and availability rules.

Bug Fixes:
- Hide the Tiptap editor when a search produces no results to prevent the editor toolbar from appearing below the empty-results view.
- Ensure the migration screen is rendered before migration starts and limits its overlay to the main content area.

Enhancements:
- Simplify migration progress handling by automatically returning to the application after migration reaches a terminal state.
- Improve const-correctness of note data and block accessors.