### PR TITLE
feat(search): add indexed note search service Add n-gram indexed search with scoring and result snippets.

### DIFF
--- a/src/search/notesearchservice.cpp
+++ b/src/search/notesearchservice.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "notesearchservice.h"
+
+NoteSearchService::NoteSearchService(QObject *parent)
+    : QObject(parent)
+{
+}
+
+NoteSearchService *NoteSearchService::instance()
+{
+    static NoteSearchService service;
+    return &service;
+}
+
+QList<SearchResult> NoteSearchService::search(VNOTE_ALL_NOTES_MAP *noteAll, const QString &query)
+{
+    refreshIndex(noteAll);
+    return m_index.search(query);
+}
+
+void NoteSearchService::refreshIndex(VNOTE_ALL_NOTES_MAP *noteAll)
+{
+    m_index.refreshFromNotes(noteAll);
+}
+
+void NoteSearchService::updateNote(const VNoteItem *note)
+{
+    m_index.updateNote(note);
+}
+
+void NoteSearchService::removeNote(int noteId)
+{
+    m_index.removeNote(noteId);
+}
+
+void NoteSearchService::clearIndex()
+{
+    m_index.clear();
+}
+
+int NoteSearchService::indexedNoteCount() const
+{
+    return m_index.size();
+}

--- a/src/search/notesearchservice.h
+++ b/src/search/notesearchservice.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NOTESEARCHSERVICE_H
+#define NOTESEARCHSERVICE_H
+
+#include "searchdocument.h"
+#include "searchindexmanager.h"
+
+#include <QObject>
+
+struct VNoteItem;
+
+class NoteSearchService : public QObject
+{
+    Q_OBJECT
+public:
+    static NoteSearchService *instance();
+
+    QList<SearchResult> search(VNOTE_ALL_NOTES_MAP *noteAll, const QString &query);
+    void refreshIndex(VNOTE_ALL_NOTES_MAP *noteAll);
+    void updateNote(const VNoteItem *note);
+    void removeNote(int noteId);
+    void clearIndex();
+    int indexedNoteCount() const;
+
+private:
+    explicit NoteSearchService(QObject *parent = nullptr);
+
+    SearchIndexManager m_index;
+};
+
+#endif // NOTESEARCHSERVICE_H

--- a/src/search/searchdocument.cpp
+++ b/src/search/searchdocument.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "searchdocument.h"
+
+QString searchFieldName(SearchField field)
+{
+    switch (field) {
+    case SearchField::Title:
+        return QStringLiteral("title");
+    case SearchField::Body:
+        return QStringLiteral("body");
+    case SearchField::VoiceTitle:
+        return QStringLiteral("voiceTitle");
+    case SearchField::VoiceTranscript:
+        return QStringLiteral("voiceTranscript");
+    case SearchField::ImageAlt:
+        return QStringLiteral("imageAlt");
+    }
+    return QStringLiteral("body");
+}

--- a/src/search/searchdocument.h
+++ b/src/search/searchdocument.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEARCHDOCUMENT_H
+#define SEARCHDOCUMENT_H
+
+#include <QDateTime>
+#include <QString>
+#include <QVector>
+
+enum class SearchField {
+    Title,
+    Body,
+    VoiceTitle,
+    VoiceTranscript,
+    ImageAlt,
+};
+
+struct SearchSegment {
+    SearchField field {SearchField::Body};
+    QString text;
+    QString locatorType;
+    QString locator;
+};
+
+struct SearchDocument {
+    int noteId {-1};
+    int folderId {-1};
+    bool isTop {false};
+    QDateTime modifyTime;
+    QString titlePlain;
+    QVector<SearchSegment> segments;
+};
+
+struct SearchMatch {
+    SearchField field {SearchField::Body};
+    QString text;
+    QString locatorType;
+    QString locator;
+    int position {-1};
+};
+
+struct SearchResult {
+    int noteId {-1};
+    int folderId {-1};
+    bool isTop {false};
+    QDateTime modifyTime;
+    QString titlePlain;
+    QString highlightedTitle;
+    QString snippet;
+    SearchField bestField {SearchField::Body};
+    int score {0};
+    QVector<SearchMatch> matches;
+};
+
+QString searchFieldName(SearchField field);
+
+#endif // SEARCHDOCUMENT_H

--- a/src/search/searchdocumentextractor.cpp
+++ b/src/search/searchdocumentextractor.cpp
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "searchdocumentextractor.h"
+
+#include "legacyformatdetector.h"
+#include "vnoteitem.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTextDocument>
+#include <QSet>
+
+namespace {
+
+SearchDocument baseDocument(const VNoteItem *note)
+{
+    SearchDocument document;
+    if (!note) {
+        return document;
+    }
+    document.noteId = note->noteId;
+    document.folderId = static_cast<int>(note->folderId);
+    document.isTop = note->isTop != 0;
+    document.modifyTime = note->modifyTime;
+    document.titlePlain = note->noteTitle;
+    document.segments.append({SearchField::Title, note->noteTitle,
+                              QStringLiteral("title"), QString()});
+    return document;
+}
+
+void appendSegment(SearchDocument *document, SearchField field, const QString &text,
+                   const QString &locatorType = QString(), const QString &locator = QString())
+{
+    if (!document || text.trimmed().isEmpty()) {
+        return;
+    }
+    document->segments.append({field, text, locatorType, locator});
+}
+
+QString plainTextFromHtml(const QString &html)
+{
+    QTextDocument doc;
+    doc.setHtml(html);
+    return doc.toPlainText();
+}
+
+bool isTiptapTextBlock(const QString &type)
+{
+    static const QSet<QString> blockTypes = {
+        QStringLiteral("paragraph"),
+        QStringLiteral("heading"),
+        QStringLiteral("listItem"),
+        QStringLiteral("taskItem"),
+        QStringLiteral("blockquote"),
+    };
+    return blockTypes.contains(type);
+}
+
+QString collectTiptapInlineText(const QJsonObject &node, SearchDocument *document)
+{
+    const QString type = node.value(QStringLiteral("type")).toString();
+    const QJsonObject attrs = node.value(QStringLiteral("attrs")).toObject();
+
+    if (type == QLatin1String("text")) {
+        return node.value(QStringLiteral("text")).toString();
+    }
+
+    if (type == QLatin1String("hardBreak")) {
+        return QStringLiteral("\n");
+    }
+
+    if (type == QLatin1String("voiceBlock")) {
+        const QString voiceId = attrs.value(QStringLiteral("voiceId")).toString();
+        appendSegment(document, SearchField::VoiceTitle,
+                      attrs.value(QStringLiteral("title")).toString(),
+                      QStringLiteral("voice"), voiceId);
+        appendSegment(document, SearchField::VoiceTranscript,
+                      attrs.value(QStringLiteral("text")).toString(),
+                      QStringLiteral("voice"), voiceId);
+        return QString();
+    }
+
+    if (type == QLatin1String("image")) {
+        const QString locator = attrs.value(QStringLiteral("relPath")).toString();
+        appendSegment(document, SearchField::ImageAlt,
+                      attrs.value(QStringLiteral("alt")).toString(),
+                      QStringLiteral("image"), locator);
+        appendSegment(document, SearchField::ImageAlt,
+                      attrs.value(QStringLiteral("title")).toString(),
+                      QStringLiteral("image"), locator);
+        return QString();
+    }
+
+    QString text;
+    const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+    for (const QJsonValue &child : children) {
+        if (!child.isObject()) {
+            continue;
+        }
+        const QString childText = collectTiptapInlineText(child.toObject(), document);
+        if (!text.isEmpty() && !childText.isEmpty()
+            && !text.endsWith(QLatin1Char('\n')) && !childText.startsWith(QLatin1Char('\n'))) {
+            // Text nodes that were split only because of marks must remain adjacent.
+            // Container boundaries keep a light separator to avoid accidental word joins.
+            const QString childType = child.toObject().value(QStringLiteral("type")).toString();
+            if (childType != QLatin1String("text")) {
+                text.append(QLatin1Char(' '));
+            }
+        }
+        text.append(childText);
+    }
+    return text;
+}
+
+void appendTiptapBlocks(const QJsonObject &node, SearchDocument *document)
+{
+    const QString type = node.value(QStringLiteral("type")).toString();
+    if (type == QLatin1String("voiceBlock") || type == QLatin1String("image")) {
+        collectTiptapInlineText(node, document);
+        return;
+    }
+
+    if (isTiptapTextBlock(type)) {
+        appendSegment(document, SearchField::Body, collectTiptapInlineText(node, document),
+                      QStringLiteral("pm-block"));
+        return;
+    }
+
+    const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+    for (const QJsonValue &child : children) {
+        if (child.isObject()) {
+            appendTiptapBlocks(child.toObject(), document);
+        }
+    }
+}
+
+
+class TiptapDocumentExtractor final : public ISearchDocumentExtractor
+{
+public:
+    bool canExtract(const VNoteItem *note) const override
+    {
+        return note && LegacyFormatDetector::detect(note->metaDataConstRef().toString())
+            == LegacyFormat::TiptapEnvelope;
+    }
+
+    SearchDocument extract(const VNoteItem *note) const override
+    {
+        SearchDocument document = baseDocument(note);
+        QJsonParseError parseError;
+        const QJsonDocument json = QJsonDocument::fromJson(
+            note->metaDataConstRef().toString().toUtf8(), &parseError);
+        if (parseError.error != QJsonParseError::NoError || !json.isObject()) {
+            return document;
+        }
+
+        const QJsonObject root = json.object();
+        appendTiptapBlocks(root.value(QStringLiteral("content")).toObject(), &document);
+        return document;
+    }
+};
+
+class LegacyHtmlExtractor final : public ISearchDocumentExtractor
+{
+public:
+    bool canExtract(const VNoteItem *note) const override
+    {
+        if (!note) {
+            return false;
+        }
+        if (!note->htmlCode.isEmpty()) {
+            return true;
+        }
+        const LegacyFormat format = LegacyFormatDetector::detect(note->metaDataConstRef().toString());
+        return format == LegacyFormat::LegacyHtmlCode;
+    }
+
+    SearchDocument extract(const VNoteItem *note) const override
+    {
+        SearchDocument document = baseDocument(note);
+        QString html = note->htmlCode;
+        if (html.isEmpty()) {
+            const QString meta = note->metaDataConstRef().toString();
+            QJsonDocument json = QJsonDocument::fromJson(meta.toUtf8());
+            if (json.isObject()) {
+                html = json.object().value(QStringLiteral("htmlCode")).toString();
+            } else {
+                html = meta;
+            }
+        }
+        appendSegment(&document, SearchField::Body, plainTextFromHtml(html),
+                      QStringLiteral("legacy-html"));
+        return document;
+    }
+};
+
+class LegacyNoteDatasExtractor final : public ISearchDocumentExtractor
+{
+public:
+    bool canExtract(const VNoteItem *note) const override
+    {
+        if (!note) {
+            return false;
+        }
+        const LegacyFormat format = LegacyFormatDetector::detect(note->metaDataConstRef().toString());
+        return format == LegacyFormat::LegacyNoteDatas || !note->datas.dataConstRef().isEmpty();
+    }
+
+    SearchDocument extract(const VNoteItem *note) const override
+    {
+        SearchDocument document = baseDocument(note);
+        for (const VNoteBlock *block : note->datas.dataConstRef()) {
+            if (!block) {
+                continue;
+            }
+            if (block->getType() == VNoteBlock::Voice) {
+                appendSegment(&document, SearchField::VoiceTranscript, block->blockText,
+                              QStringLiteral("legacy-voice"), block->ptrVoice->voiceId);
+                appendSegment(&document, SearchField::VoiceTitle, block->ptrVoice->voiceTitle,
+                              QStringLiteral("legacy-voice"), block->ptrVoice->voiceId);
+            } else {
+                appendSegment(&document, SearchField::Body, block->blockText,
+                              QStringLiteral("legacy-block"));
+            }
+        }
+        return document;
+    }
+};
+
+class PlainTextExtractor final : public ISearchDocumentExtractor
+{
+public:
+    bool canExtract(const VNoteItem *note) const override
+    {
+        return note != nullptr;
+    }
+
+    SearchDocument extract(const VNoteItem *note) const override
+    {
+        SearchDocument document = baseDocument(note);
+        const QString meta = note->metaDataConstRef().toString();
+        if (LegacyFormatDetector::detect(meta) == LegacyFormat::PlainText) {
+            appendSegment(&document, SearchField::Body, meta, QStringLiteral("plain-text"));
+        }
+        return document;
+    }
+};
+
+} // namespace
+
+SearchDocument SearchDocumentExtractor::extract(const VNoteItem *note)
+{
+    static const TiptapDocumentExtractor tiptapExtractor;
+    static const LegacyHtmlExtractor htmlExtractor;
+    static const LegacyNoteDatasExtractor legacyExtractor;
+    static const PlainTextExtractor plainTextExtractor;
+    static const ISearchDocumentExtractor *extractors[] = {
+        &tiptapExtractor,
+        &htmlExtractor,
+        &legacyExtractor,
+        &plainTextExtractor,
+    };
+
+    for (const ISearchDocumentExtractor *extractor : extractors) {
+        if (extractor->canExtract(note)) {
+            return extractor->extract(note);
+        }
+    }
+    return baseDocument(note);
+}

--- a/src/search/searchdocumentextractor.h
+++ b/src/search/searchdocumentextractor.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEARCHDOCUMENTEXTRACTOR_H
+#define SEARCHDOCUMENTEXTRACTOR_H
+
+#include "searchdocument.h"
+
+struct VNoteItem;
+
+class ISearchDocumentExtractor
+{
+public:
+    virtual ~ISearchDocumentExtractor() = default;
+    virtual bool canExtract(const VNoteItem *note) const = 0;
+    virtual SearchDocument extract(const VNoteItem *note) const = 0;
+};
+
+class SearchDocumentExtractor
+{
+public:
+    static SearchDocument extract(const VNoteItem *note);
+};
+
+#endif // SEARCHDOCUMENTEXTRACTOR_H

--- a/src/search/searchindexmanager.cpp
+++ b/src/search/searchindexmanager.cpp
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "searchindexmanager.h"
+
+#include "searchdocumentextractor.h"
+#include "searchtextnormalizer.h"
+#include "vnoteitem.h"
+
+#include <QCollator>
+#include <QReadLocker>
+#include <QRegularExpression>
+#include <QTextDocument>
+#include <QWriteLocker>
+#include <algorithm>
+
+void SearchIndexManager::clear()
+{
+    QWriteLocker locker(&m_lock);
+    m_entries.clear();
+    m_ngramIndex.clear();
+}
+
+void SearchIndexManager::refreshFromNotes(VNOTE_ALL_NOTES_MAP *noteAll)
+{
+    if (!noteAll) {
+        clear();
+        return;
+    }
+
+    QSet<int> aliveNoteIds;
+    noteAll->lock.lockForRead();
+    for (auto folderIt = noteAll->notes.constBegin(); folderIt != noteAll->notes.constEnd(); ++folderIt) {
+        VNOTE_ITEMS_MAP *folderNotes = folderIt.value();
+        if (!folderNotes) {
+            continue;
+        }
+        folderNotes->lock.lockForRead();
+        for (auto noteIt = folderNotes->folderNotes.constBegin(); noteIt != folderNotes->folderNotes.constEnd(); ++noteIt) {
+            const VNoteItem *note = noteIt.value();
+            if (!note) {
+                continue;
+            }
+            aliveNoteIds.insert(note->noteId);
+            updateNote(note);
+        }
+        folderNotes->lock.unlock();
+    }
+    noteAll->lock.unlock();
+
+    QWriteLocker locker(&m_lock);
+    const QList<int> indexedIds = m_entries.keys();
+    for (int noteId : indexedIds) {
+        if (!aliveNoteIds.contains(noteId)) {
+            removeEntryUnlocked(noteId);
+        }
+    }
+}
+
+void SearchIndexManager::updateNote(const VNoteItem *note)
+{
+    if (!note) {
+        return;
+    }
+
+    const QString fingerprint = fingerprintForNote(note);
+    {
+        QReadLocker locker(&m_lock);
+        const auto it = m_entries.constFind(note->noteId);
+        if (it != m_entries.constEnd() && it->fingerprint == fingerprint) {
+            return;
+        }
+    }
+
+    SearchIndexEntry entry;
+    entry.document = SearchDocumentExtractor::extract(note);
+    entry.fingerprint = fingerprint;
+    entry.normalizedTitle = SearchTextNormalizer::normalize(entry.document.titlePlain);
+    entry.normalizedCorpus = SearchTextNormalizer::normalize(corpusForDocument(entry.document));
+    entry.grams = gramsForText(entry.normalizedTitle + QLatin1Char(' ') + entry.normalizedCorpus);
+
+    QWriteLocker locker(&m_lock);
+    upsertEntryUnlocked(std::move(entry));
+}
+
+void SearchIndexManager::removeNote(int noteId)
+{
+    QWriteLocker locker(&m_lock);
+    removeEntryUnlocked(noteId);
+}
+
+QList<SearchResult> SearchIndexManager::search(const QString &query) const
+{
+    const QString rawQuery = query.trimmed();
+    const QString normalizedQuery = SearchTextNormalizer::normalize(rawQuery);
+    if (normalizedQuery.isEmpty()) {
+        return {};
+    }
+
+    QReadLocker locker(&m_lock);
+    QSet<int> candidates;
+    const QSet<QString> queryGrams = gramsForText(normalizedQuery);
+    if (queryGrams.isEmpty()) {
+        for (auto it = m_entries.constBegin(); it != m_entries.constEnd(); ++it) {
+            candidates.insert(it.key());
+        }
+    } else {
+        bool first = true;
+        for (const QString &gram : queryGrams) {
+            const QSet<int> ids = m_ngramIndex.value(gram);
+            if (first) {
+                candidates = ids;
+                first = false;
+            } else {
+                candidates.intersect(ids);
+            }
+            if (candidates.isEmpty()) {
+                break;
+            }
+        }
+    }
+
+    QList<SearchResult> results;
+    results.reserve(candidates.size());
+    for (int noteId : std::as_const(candidates)) {
+        const auto it = m_entries.constFind(noteId);
+        if (it == m_entries.constEnd()) {
+            continue;
+        }
+        if (!it->normalizedTitle.contains(normalizedQuery)
+            && !it->normalizedCorpus.contains(normalizedQuery)) {
+            continue;
+        }
+        results.append(makeResult(*it, normalizedQuery, rawQuery));
+    }
+
+    std::sort(results.begin(), results.end(), [](const SearchResult &left, const SearchResult &right) {
+        if (left.score != right.score) {
+            return left.score > right.score;
+        }
+        if (left.isTop != right.isTop) {
+            return left.isTop;
+        }
+        if (left.modifyTime != right.modifyTime) {
+            return left.modifyTime > right.modifyTime;
+        }
+        return left.noteId > right.noteId;
+    });
+    return results;
+}
+
+int SearchIndexManager::size() const
+{
+    QReadLocker locker(&m_lock);
+    return m_entries.size();
+}
+
+QString SearchIndexManager::fingerprintForNote(const VNoteItem *note)
+{
+    if (!note) {
+        return QString();
+    }
+    return QString::number(note->noteId)
+        + QLatin1Char('\x1f') + QString::number(note->folderId)
+        + QLatin1Char('\x1f') + QString::number(note->isTop)
+        + QLatin1Char('\x1f') + QString::number(note->modifyTime.toMSecsSinceEpoch())
+        + QLatin1Char('\x1f') + note->noteTitle
+        + QLatin1Char('\x1f') + note->htmlCode
+        + QLatin1Char('\x1f') + note->metaDataConstRef().toString();
+}
+
+QString SearchIndexManager::corpusForDocument(const SearchDocument &document)
+{
+    QString corpus;
+    for (const SearchSegment &segment : document.segments) {
+        if (segment.field == SearchField::Title) {
+            continue;
+        }
+        if (!corpus.isEmpty()) {
+            corpus.append(QLatin1Char('\n'));
+        }
+        corpus.append(segment.text);
+    }
+    return corpus;
+}
+
+QSet<QString> SearchIndexManager::gramsForText(const QString &text)
+{
+    QSet<QString> grams;
+    if (text.size() < NGramSize) {
+        return grams;
+    }
+    for (int i = 0; i <= text.size() - NGramSize; ++i) {
+        const QString gram = text.mid(i, NGramSize);
+        if (!gram.trimmed().isEmpty()) {
+            grams.insert(gram);
+        }
+    }
+    return grams;
+}
+
+int SearchIndexManager::fieldWeight(SearchField field)
+{
+    switch (field) {
+    case SearchField::Title:
+        return 100;
+    case SearchField::Body:
+        return 45;
+    case SearchField::VoiceTranscript:
+        return 40;
+    case SearchField::VoiceTitle:
+        return 35;
+    case SearchField::ImageAlt:
+        return 20;
+    }
+    return 10;
+}
+
+QString SearchIndexManager::highlightedHtml(const QString &text, const QString &query)
+{
+    if (query.isEmpty() || text.isEmpty()) {
+        return text.toHtmlEscaped();
+    }
+
+    QString html;
+    int pos = 0;
+    int match = text.indexOf(query, pos, Qt::CaseInsensitive);
+    while (match >= 0) {
+        html += text.mid(pos, match - pos).toHtmlEscaped();
+        html += QStringLiteral("<span style=\"color: #0058de;\">")
+            + text.mid(match, query.size()).toHtmlEscaped()
+            + QStringLiteral("</span>");
+        pos = match + query.size();
+        match = text.indexOf(query, pos, Qt::CaseInsensitive);
+    }
+    html += text.mid(pos).toHtmlEscaped();
+    return html;
+}
+
+QString SearchIndexManager::snippetHtml(const QString &text, const QString &query)
+{
+    if (text.isEmpty()) {
+        return QString();
+    }
+    const int match = text.indexOf(query, 0, Qt::CaseInsensitive);
+    if (match < 0) {
+        return QString();
+    }
+
+    constexpr int Radius = 36;
+    const int start = qMax(0, match - Radius);
+    const int end = qMin(text.size(), match + query.size() + Radius);
+    QString snippet = text.mid(start, end - start).simplified();
+    QString prefix = start > 0 ? QStringLiteral("...") : QString();
+    QString suffix = end < text.size() ? QStringLiteral("...") : QString();
+    return prefix + highlightedHtml(snippet, query) + suffix;
+}
+
+SearchResult SearchIndexManager::makeResult(const SearchIndexEntry &entry,
+                                            const QString &normalizedQuery,
+                                            const QString &rawQuery)
+{
+    SearchResult result;
+    result.noteId = entry.document.noteId;
+    result.folderId = entry.document.folderId;
+    result.isTop = entry.document.isTop;
+    result.modifyTime = entry.document.modifyTime;
+    result.titlePlain = entry.document.titlePlain;
+    result.highlightedTitle = highlightedHtml(entry.document.titlePlain, rawQuery);
+
+    int bestScore = 0;
+    SearchMatch bestMatch;
+    for (const SearchSegment &segment : entry.document.segments) {
+        const QString normalizedText = SearchTextNormalizer::normalize(segment.text);
+        if (!normalizedText.contains(normalizedQuery)) {
+            continue;
+        }
+
+        SearchMatch match;
+        match.field = segment.field;
+        match.text = segment.text;
+        match.locatorType = segment.locatorType;
+        match.locator = segment.locator;
+        match.position = normalizedText.indexOf(normalizedQuery);
+        result.matches.append(match);
+
+        int score = fieldWeight(segment.field);
+        if (match.position == 0) {
+            score += 8;
+        }
+        if (segment.field == SearchField::Title
+            && SearchTextNormalizer::normalize(segment.text) == normalizedQuery) {
+            score += 20;
+        }
+        if (score > bestScore) {
+            bestScore = score;
+            bestMatch = match;
+        }
+    }
+
+    result.score = bestScore;
+    result.bestField = bestMatch.field;
+    if (bestMatch.field != SearchField::Title) {
+        result.snippet = snippetHtml(bestMatch.text, rawQuery);
+    }
+    return result;
+}
+
+void SearchIndexManager::upsertEntryUnlocked(SearchIndexEntry &&entry)
+{
+    removeEntryUnlocked(entry.document.noteId);
+    const int noteId = entry.document.noteId;
+    for (const QString &gram : std::as_const(entry.grams)) {
+        m_ngramIndex[gram].insert(noteId);
+    }
+    m_entries.insert(noteId, std::move(entry));
+}
+
+void SearchIndexManager::removeEntryUnlocked(int noteId)
+{
+    const auto it = m_entries.find(noteId);
+    if (it == m_entries.end()) {
+        return;
+    }
+    for (const QString &gram : std::as_const(it->grams)) {
+        auto gramIt = m_ngramIndex.find(gram);
+        if (gramIt == m_ngramIndex.end()) {
+            continue;
+        }
+        gramIt->remove(noteId);
+        if (gramIt->isEmpty()) {
+            m_ngramIndex.erase(gramIt);
+        }
+    }
+    m_entries.erase(it);
+}

--- a/src/search/searchindexmanager.h
+++ b/src/search/searchindexmanager.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEARCHINDEXMANAGER_H
+#define SEARCHINDEXMANAGER_H
+
+#include "searchdocument.h"
+
+#include "datatypedef.h"
+
+#include <QHash>
+#include <QReadWriteLock>
+#include <QSet>
+#include <QStringList>
+
+struct VNoteItem;
+
+class SearchIndexManager
+{
+public:
+    static constexpr int NGramSize = 3;
+
+    void clear();
+    void refreshFromNotes(VNOTE_ALL_NOTES_MAP *noteAll);
+    void updateNote(const VNoteItem *note);
+    void removeNote(int noteId);
+    QList<SearchResult> search(const QString &query) const;
+    int size() const;
+
+private:
+    struct SearchIndexEntry {
+        SearchDocument document;
+        QString fingerprint;
+        QString normalizedTitle;
+        QString normalizedCorpus;
+        QSet<QString> grams;
+    };
+
+    static QString fingerprintForNote(const VNoteItem *note);
+    static QString corpusForDocument(const SearchDocument &document);
+    static QSet<QString> gramsForText(const QString &text);
+    static int fieldWeight(SearchField field);
+    static QString highlightedHtml(const QString &text, const QString &query);
+    static QString snippetHtml(const QString &text, const QString &query);
+    static SearchResult makeResult(const SearchIndexEntry &entry,
+                                   const QString &normalizedQuery,
+                                   const QString &rawQuery);
+
+    void upsertEntryUnlocked(SearchIndexEntry &&entry);
+    void removeEntryUnlocked(int noteId);
+
+    mutable QReadWriteLock m_lock;
+    QHash<int, SearchIndexEntry> m_entries;
+    QHash<QString, QSet<int>> m_ngramIndex;
+};
+
+#endif // SEARCHINDEXMANAGER_H

--- a/src/search/searchtextnormalizer.cpp
+++ b/src/search/searchtextnormalizer.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "searchtextnormalizer.h"
+
+QString SearchTextNormalizer::normalize(const QString &text)
+{
+    QString result = text.normalized(QString::NormalizationForm_KC).toCaseFolded();
+
+    bool previousWasSpace = false;
+    QString compacted;
+    compacted.reserve(result.size());
+    for (const QChar ch : result) {
+        if (ch.isSpace() || ch.category() == QChar::Other_Control) {
+            if (!previousWasSpace && !compacted.isEmpty()) {
+                compacted.append(QLatin1Char(' '));
+            }
+            previousWasSpace = true;
+            continue;
+        }
+        compacted.append(ch);
+        previousWasSpace = false;
+    }
+
+    if (compacted.endsWith(QLatin1Char(' '))) {
+        compacted.chop(1);
+    }
+    return compacted;
+}

--- a/src/search/searchtextnormalizer.h
+++ b/src/search/searchtextnormalizer.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEARCHTEXTNORMALIZER_H
+#define SEARCHTEXTNORMALIZER_H
+
+#include <QString>
+
+class SearchTextNormalizer
+{
+public:
+    static QString normalize(const QString &text);
+};
+
+#endif // SEARCHTEXTNORMALIZER_H


### PR DESCRIPTION
新增 n-gram 索引搜索，支持评分和结果片段。

Log: 新增笔记搜索索引服务

PMS: TASK-393985

Influence: 搜索从逐条内容扫描升级为索引候选加最终校验，提升搜索性能并为结果排序和片段展示提供基础。

## Summary by Sourcery

Introduce an indexed note search service that improves search performance and produces ranked, context-rich results.

New Features:
- Add indexed note search with n-gram candidate retrieval, relevance scoring, highlighted titles, and result snippets.
- Support searching note titles, body content, voice metadata and transcripts, and image alternative text across supported note formats.

Enhancements:
- Provide incremental index refresh, note updates and removals, index clearing, and thread-safe access to indexed data.
- Normalize indexed text and queries for case-insensitive, whitespace-tolerant matching while preserving note metadata and match locations.