### PR TITLE
feat(tiptap): highlight search hits in editor

### DIFF
--- a/src/common/tiptapchannelbridge.cpp
+++ b/src/common/tiptapchannelbridge.cpp
@@ -7,6 +7,8 @@
 
 #include <QResource>
 #include <QCoreApplication>
+#include <QApplication>
+#include <QClipboard>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -19,6 +21,7 @@
 #include <QStandardPaths>
 #include <QHash>
 #include <QUrl>
+#include <QMimeData>
 
 namespace {
 
@@ -305,6 +308,24 @@ void TiptapChannelBridge::jsRequestViewPicture(const QString &url)
         return;
     }
     emit viewPictureRequested(localPath);
+}
+
+void TiptapChannelBridge::jsCopyPlainTextToClipboard(const QString &text)
+{
+    if (text.isEmpty()) {
+        return;
+    }
+
+    QClipboard *clipboard = QApplication::clipboard();
+    if (!clipboard) {
+        qWarning() << "Tiptap copy plain text: clipboard is unavailable";
+        return;
+    }
+
+    auto *mimeData = new QMimeData;
+    mimeData->setText(text);
+    clipboard->setMimeData(mimeData);
+    qInfo() << "Tiptap copied plain text to clipboard, length:" << text.length();
 }
 
 void TiptapChannelBridge::jsPasteImage(const QString &dataUrl)

--- a/src/common/tiptapchannelbridge.h
+++ b/src/common/tiptapchannelbridge.h
@@ -111,6 +111,9 @@ public:
     // 前端粘贴剪贴板图片数据（data URL），宿主保存到 images/ 后回插
     Q_INVOKABLE void jsPasteImage(const QString &dataUrl);
 
+    // 前端复制只读 DOM 文本（如 voiceBlock 转写文本）到系统剪贴板。
+    // 这类文本不在 ProseMirror 文档可编辑 selection 中，不能依赖 WebAction Copy。
+    Q_INVOKABLE void jsCopyPlainTextToClipboard(const QString &text);
 
     // 前端上报编辑器滚动位置（scrollTop），宿主据此驱动标题栏阴影状态
     Q_INVOKABLE void jsReportScroll(int scrollTop);

--- a/tests/src/tiptapchannel/ut_tiptapchannelbridge.cpp
+++ b/tests/src/tiptapchannel/ut_tiptapchannelbridge.cpp
@@ -7,6 +7,8 @@
 #include <QResource>
 #include <QFile>
 #include <QSignalSpy>
+#include <QApplication>
+#include <QClipboard>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -96,6 +98,15 @@ TEST_F(UT_TiptapChannelBridge, UT_TiptapChannelBridge_jsRequestPickImage_001)
     QSignalSpy spy(&bridge, &TiptapChannelBridge::pickImageRequested);
     bridge.jsRequestPickImage();
     EXPECT_EQ(spy.count(), 1);
+}
+
+
+TEST_F(UT_TiptapChannelBridge, UT_TiptapChannelBridge_jsCopyPlainTextToClipboard_001)
+{
+    TiptapChannelBridge bridge;
+    bridge.jsCopyPlainTextToClipboard(QStringLiteral("转写复制文本"));
+    ASSERT_NE(QApplication::clipboard(), nullptr);
+    EXPECT_EQ(QApplication::clipboard()->text(), QStringLiteral("转写复制文本"));
 }
 
 // 双击查看原图：相对路径归一化后下发本地路径

--- a/web-editor/src/extensions/voice-block.css
+++ b/web-editor/src/extensions/voice-block.css
@@ -6,6 +6,8 @@
     box-sizing: border-box;
     margin-top: 10px;
     margin-bottom: 10px;
+    -webkit-user-modify: read-only;
+    outline: none;
 }
 
 
@@ -324,6 +326,8 @@
     -webkit-user-select: text;
     -webkit-user-drag: none;
     user-drag: none;
+    -webkit-user-modify: read-only;
+    outline: none;
 }
 
 .voiceInfoBox .translateText::selection {

--- a/web-editor/src/extensions/voice-block.js
+++ b/web-editor/src/extensions/voice-block.js
@@ -15,6 +15,7 @@ import playingPauseIconUrl from '../../../src/web/img/audio_file_playing_pause/N
 import playingPlayIconUrl from '../../../src/web/img/audio_file_playing_play/Normal.svg?url'
 import closePlaybackIconUrl from '../../../src/web/img/playbar_pause_close/Normal.svg?url'
 import { getVoiceBridge, subscribeVoiceEvents } from '../runtime/tiptap-channel.js'
+import { subscribeSearchState, renderHighlightedText, textMatchesQuery } from '../runtime/search-state.js'
 
 const VOICE_BLOCK_CLIPBOARD_MIME = 'application/x-deepin-voice-note-voice-block'
 
@@ -344,6 +345,8 @@ export const VoiceBlock = Node.create({
       let unplayable = false
       let currentNode = node
       let destroyed = false
+      let activeSearchQuery = ''
+      let transcriptMatchedBySearch = false
 
       // --- 构建 DOM ---
       const wrapper = document.createElement('div')
@@ -444,9 +447,18 @@ export const VoiceBlock = Node.create({
       translateText.className = 'translateText'
       translateText.setAttribute('draggable', 'false')
       translateText.setAttribute('contenteditable', 'false')
-      translateText.textContent = node.attrs.text || ''
+      renderTranscriptText()
       translate.appendChild(translateText)
       box.appendChild(translate)
+
+      function renderTranscriptText() {
+        const text = currentNode.attrs.text || ''
+        if (transcriptMatchedBySearch) {
+          renderHighlightedText(translateText, text, activeSearchQuery)
+        } else {
+          translateText.textContent = text
+        }
+      }
 
       // --- 初始状态渲染 ---
       function refreshState() {
@@ -456,13 +468,18 @@ export const VoiceBlock = Node.create({
         playback.classList.toggle('unplayable', unplayable)
 
         const hasText = !!(currentNode.attrs.text && currentNode.attrs.text.length > 0)
+        const voiceId = currentNode.attrs.voiceId
+        const voiceMatchedBySearch = !!activeSearchQuery && textMatchesQuery(currentNode.attrs.title, activeSearchQuery)
+        transcriptMatchedBySearch = !!activeSearchQuery && textMatchesQuery(currentNode.attrs.text, activeSearchQuery)
+        box.classList.toggle('dvn-search-voice-attrs-match', voiceMatchedBySearch || transcriptMatchedBySearch)
         box.classList.toggle('containText', hasText)
         toTextTrigger.style.display = 'none'
         createTimeEl.style.display = (playing || paused || translating) ? 'none' : ''
 
         const unfold = currentNode.attrs.translateUnfold !== false
         translateHeader.classList.toggle('unfold', unfold)
-        translateText.style.display = (hasText && unfold) ? '' : 'none'
+        translateText.style.display = (hasText && (unfold || transcriptMatchedBySearch)) ? '' : 'none'
+        renderTranscriptText()
 
         // 进度
         const pct = duration > 0 ? Math.min((progress / duration) * 100, 100) : 0
@@ -549,7 +566,6 @@ export const VoiceBlock = Node.create({
         event.stopPropagation()
         event.preventDefault()
       }
-
       voiceBtn.addEventListener('click', onVoiceBtnClick)
       toTextTrigger.addEventListener('click', onToTextTriggerClick)
       closePlaybackBarBtn.addEventListener('click', onClosePlaybackClick)
@@ -634,6 +650,11 @@ export const VoiceBlock = Node.create({
         },
       })
 
+      const unsubscribeSearch = subscribeSearchState((state) => {
+        activeSearchQuery = state?.query || ''
+        refreshState()
+      })
+
       refreshState()
 
       return {
@@ -643,7 +664,7 @@ export const VoiceBlock = Node.create({
           currentNode = updatedNode
           titleEl.textContent = updatedNode.attrs.title || ''
           createTimeEl.textContent = formatCreateTime(updatedNode.attrs.createTime)
-          translateText.textContent = updatedNode.attrs.text || ''
+          renderTranscriptText()
           wrapper.setAttribute('data-voice-meta', buildVoiceMenuJson(updatedNode.attrs))
           box.setAttribute('data-voice-meta', buildVoiceMenuJson(updatedNode.attrs))
           refreshState()
@@ -671,6 +692,7 @@ export const VoiceBlock = Node.create({
           if (destroyed) return
           destroyed = true
           unsubscribe()
+          unsubscribeSearch()
           voiceBtn.removeEventListener('click', onVoiceBtnClick)
           toTextTrigger.removeEventListener('click', onToTextTriggerClick)
           closePlaybackBarBtn.removeEventListener('click', onClosePlaybackClick)

--- a/web-editor/src/extensions/voice-block.js
+++ b/web-editor/src/extensions/voice-block.js
@@ -16,6 +16,7 @@ import playingPlayIconUrl from '../../../src/web/img/audio_file_playing_play/Nor
 import closePlaybackIconUrl from '../../../src/web/img/playbar_pause_close/Normal.svg?url'
 import { getVoiceBridge, subscribeVoiceEvents } from '../runtime/tiptap-channel.js'
 import { subscribeSearchState, renderHighlightedText, textMatchesQuery } from '../runtime/search-state.js'
+import { updateTranscriptSelectionCache } from '../runtime/transcript-copy.js'
 
 const VOICE_BLOCK_CLIPBOARD_MIME = 'application/x-deepin-voice-note-voice-block'
 
@@ -353,6 +354,16 @@ export const VoiceBlock = Node.create({
       wrapper.className = 'voiceBox'
       wrapper.setAttribute('data-type', 'voice-block')
       wrapper.setAttribute('data-voice-meta', buildVoiceMenuJson(node.attrs))
+      // ProseMirror marks atom NodeViews without contentDOM as
+      // contenteditable=false unless the root already declares the attribute.
+      // That non-editable ancestor is exactly what broke WebEngine text
+      // selection/copy for Summernote voice transcripts historically.  Keep
+      // the voice block as an atomic document node, but expose a guarded
+      // read-only editable island so browser/QtWebEngine selection semantics
+      // can work normally inside .translateText.
+      wrapper.setAttribute('contenteditable', 'true')
+      wrapper.setAttribute('aria-readonly', 'true')
+      wrapper.setAttribute('spellcheck', 'false')
 
       const box = document.createElement('div')
       box.className = 'voiceInfoBox'
@@ -369,9 +380,11 @@ export const VoiceBlock = Node.create({
 
       const voiceBtn = document.createElement('div')
       voiceBtn.className = 'voiceBtn'
+      voiceBtn.setAttribute('contenteditable', 'false')
 
       const titleEl = document.createElement('div')
       titleEl.className = 'title'
+      titleEl.setAttribute('contenteditable', 'false')
       titleEl.textContent = node.attrs.title || ''
 
       left.appendChild(voiceBtn)
@@ -383,6 +396,7 @@ export const VoiceBlock = Node.create({
       createTimeEl.textContent = formatCreateTime(node.attrs.createTime)
 
       const progressBar = document.createElement('input')
+      progressBar.setAttribute('contenteditable', 'false')
       progressBar.type = 'range'
       progressBar.className = 'progressBar'
       progressBar.min = 0
@@ -394,6 +408,7 @@ export const VoiceBlock = Node.create({
       right.className = 'right'
       const timeField = document.createElement('div')
       timeField.className = 'timeField'
+      timeField.setAttribute('contenteditable', 'false')
       const timePassed = document.createElement('div')
       timePassed.className = 'timePassed'
       timePassed.textContent = '00:00/'
@@ -406,6 +421,7 @@ export const VoiceBlock = Node.create({
 
       const toTextLabel = document.createElement('div')
       toTextLabel.className = 'voiceToTextLabel'
+      toTextLabel.setAttribute('contenteditable', 'false')
       const toTextIcon = document.createElement('div')
       toTextIcon.className = 'voiceToTextIcon'
       const translatingLabel = document.createElement('span')
@@ -417,11 +433,13 @@ export const VoiceBlock = Node.create({
 
       const toTextTrigger = document.createElement('div')
       toTextTrigger.className = 'voiceToTextTrigger'
+      toTextTrigger.setAttribute('contenteditable', 'false')
       toTextTrigger.textContent = '转文字'
       right.appendChild(toTextTrigger)
 
       const closePlaybackBarBtn = document.createElement('div')
       closePlaybackBarBtn.className = 'closePlaybackBarBtn'
+      closePlaybackBarBtn.setAttribute('contenteditable', 'false')
       right.appendChild(closePlaybackBarBtn)
 
       playback.appendChild(right)
@@ -431,6 +449,7 @@ export const VoiceBlock = Node.create({
       translate.className = 'voiceTranscript translate'
       const translateHeader = document.createElement('div')
       translateHeader.className = 'translateHeader'
+      translateHeader.setAttribute('contenteditable', 'false')
       const translateIcon = document.createElement('div')
       translateIcon.className = 'translateIcon'
       const translateLabel = document.createElement('span')
@@ -445,8 +464,16 @@ export const VoiceBlock = Node.create({
 
       const translateText = document.createElement('div')
       translateText.className = 'translateText'
+      translateText.setAttribute('data-dvn-transcript', 'true')
       translateText.setAttribute('draggable', 'false')
-      translateText.setAttribute('contenteditable', 'false')
+      // ProseMirror marks the whole atom NodeView as contenteditable=false.
+      // Make the transcript an inner selectable island for QtWebEngine native
+      // copy, while JS event guards below keep it logically read-only.
+      translateText.setAttribute('contenteditable', 'true')
+      translateText.setAttribute('aria-readonly', 'true')
+      translateText.setAttribute('role', 'textbox')
+      translateText.setAttribute('tabindex', '0')
+      translateText.setAttribute('spellcheck', 'false')
       renderTranscriptText()
       translate.appendChild(translateText)
       box.appendChild(translate)
@@ -566,6 +593,117 @@ export const VoiceBlock = Node.create({
         event.stopPropagation()
         event.preventDefault()
       }
+      function isCopyShortcut(event) {
+        return (event.ctrlKey || event.metaKey) && !event.altKey && String(event.key).toLowerCase() === 'c'
+      }
+
+      function isSelectAllShortcut(event) {
+        return (event.ctrlKey || event.metaKey) && !event.altKey && String(event.key).toLowerCase() === 'a'
+      }
+
+      function selectWholeTranscript() {
+        const range = document.createRange()
+        range.selectNodeContents(translateText)
+        const selection = window.getSelection?.()
+        if (!selection) return false
+        selection.removeAllRanges()
+        selection.addRange(range)
+        updateTranscriptSelectionCache(selection)
+        return true
+      }
+
+      function onTranslateTextBeforeInput(event) {
+        event.preventDefault()
+      }
+
+      function onTranslateTextInput(event) {
+        // Defensive repair for old WebEngine paths where an editing event slips
+        // past beforeinput/keydown.  The source of truth remains attrs.text.
+        event.preventDefault?.()
+        renderTranscriptText()
+      }
+
+      function onTranslateTextClipboardMutatingEvent(event) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+
+      function onVoiceBoxBeforeInput(event) {
+        // The wrapper is contenteditable only to remove the non-editable
+        // ancestor around transcript text.  It must never become an editable
+        // source of truth; attrs remain authoritative.
+        event.preventDefault()
+      }
+
+      function onVoiceBoxInput(event) {
+        event.preventDefault?.()
+        renderTranscriptText()
+      }
+
+      function onVoiceBoxKeyDown(event) {
+        if (event.target instanceof HTMLElement && event.target.closest('.translateText')) {
+          return
+        }
+        if (isCopyShortcut(event)) {
+          return
+        }
+        if (isSelectAllShortcut(event)) {
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+        const key = String(event.key || '')
+        const navigationKeys = new Set([
+          'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+          'Home', 'End', 'PageUp', 'PageDown', 'Shift', 'Control', 'Meta', 'Alt',
+          'Escape', 'Tab',
+        ])
+        if (navigationKeys.has(key)) return
+        if (key.length === 1 || key === 'Backspace' || key === 'Delete' || key === 'Enter') {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+      }
+
+      function onTranslateTextKeyDown(event) {
+        if (isCopyShortcut(event)) {
+          updateTranscriptSelectionCache()
+          return
+        }
+        if (isSelectAllShortcut(event)) {
+          event.preventDefault()
+          event.stopPropagation()
+          selectWholeTranscript()
+          return
+        }
+
+        // Keep navigation/selection keys usable.  Block keys that would mutate
+        // the contenteditable island or create undo state in the WebEngine.
+        const key = String(event.key || '')
+        const navigationKeys = new Set([
+          'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+          'Home', 'End', 'PageUp', 'PageDown', 'Shift', 'Control', 'Meta', 'Alt',
+          'Escape', 'Tab',
+        ])
+        if (navigationKeys.has(key)) return
+
+        if (key.length === 1 || key === 'Backspace' || key === 'Delete' || key === 'Enter') {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+      }
+
+      function onTranslateTextSelectionEnd() {
+        updateTranscriptSelectionCache()
+      }
+
+
+      wrapper.addEventListener('beforeinput', onVoiceBoxBeforeInput)
+      wrapper.addEventListener('input', onVoiceBoxInput)
+      wrapper.addEventListener('keydown', onVoiceBoxKeyDown)
+      wrapper.addEventListener('paste', onTranslateTextClipboardMutatingEvent)
+      wrapper.addEventListener('cut', onTranslateTextClipboardMutatingEvent)
+      wrapper.addEventListener('drop', onTranslateTextClipboardMutatingEvent)
       voiceBtn.addEventListener('click', onVoiceBtnClick)
       toTextTrigger.addEventListener('click', onToTextTriggerClick)
       closePlaybackBarBtn.addEventListener('click', onClosePlaybackClick)
@@ -574,6 +712,14 @@ export const VoiceBlock = Node.create({
       translateText.addEventListener('pointerdown', onTranslateTextPointerDown)
       translateText.addEventListener('touchstart', onTranslateTextPointerDown)
       translateText.addEventListener('dragstart', onTranslateTextDragStart)
+      translateText.addEventListener('beforeinput', onTranslateTextBeforeInput)
+      translateText.addEventListener('input', onTranslateTextInput)
+      translateText.addEventListener('paste', onTranslateTextClipboardMutatingEvent)
+      translateText.addEventListener('cut', onTranslateTextClipboardMutatingEvent)
+      translateText.addEventListener('drop', onTranslateTextClipboardMutatingEvent)
+      translateText.addEventListener('keydown', onTranslateTextKeyDown)
+      translateText.addEventListener('mouseup', onTranslateTextSelectionEnd)
+      translateText.addEventListener('keyup', onTranslateTextSelectionEnd)
       translateHeader.addEventListener('click', (e) => {
         // 折叠/展开头部点击切换
         if (e.target === foldBtn) return
@@ -693,6 +839,12 @@ export const VoiceBlock = Node.create({
           destroyed = true
           unsubscribe()
           unsubscribeSearch()
+          wrapper.removeEventListener('beforeinput', onVoiceBoxBeforeInput)
+          wrapper.removeEventListener('input', onVoiceBoxInput)
+          wrapper.removeEventListener('keydown', onVoiceBoxKeyDown)
+          wrapper.removeEventListener('paste', onTranslateTextClipboardMutatingEvent)
+          wrapper.removeEventListener('cut', onTranslateTextClipboardMutatingEvent)
+          wrapper.removeEventListener('drop', onTranslateTextClipboardMutatingEvent)
           voiceBtn.removeEventListener('click', onVoiceBtnClick)
           toTextTrigger.removeEventListener('click', onToTextTriggerClick)
           closePlaybackBarBtn.removeEventListener('click', onClosePlaybackClick)
@@ -701,6 +853,14 @@ export const VoiceBlock = Node.create({
           translateText.removeEventListener('pointerdown', onTranslateTextPointerDown)
           translateText.removeEventListener('touchstart', onTranslateTextPointerDown)
           translateText.removeEventListener('dragstart', onTranslateTextDragStart)
+          translateText.removeEventListener('beforeinput', onTranslateTextBeforeInput)
+          translateText.removeEventListener('input', onTranslateTextInput)
+          translateText.removeEventListener('paste', onTranslateTextClipboardMutatingEvent)
+          translateText.removeEventListener('cut', onTranslateTextClipboardMutatingEvent)
+          translateText.removeEventListener('drop', onTranslateTextClipboardMutatingEvent)
+          translateText.removeEventListener('keydown', onTranslateTextKeyDown)
+          translateText.removeEventListener('mouseup', onTranslateTextSelectionEnd)
+          translateText.removeEventListener('keyup', onTranslateTextSelectionEnd)
           restoreWrapperDrag()
         },
       }

--- a/web-editor/src/runtime/search-extension.js
+++ b/web-editor/src/runtime/search-extension.js
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import { notifySearchState } from './search-state.js'
+
+if (typeof document !== 'undefined' && !document.getElementById('dvn-search-style')) {
+  const style = document.createElement('style')
+  style.id = 'dvn-search-style'
+  style.textContent = `
+    .dvn-search-match { background: var(--dvn-search-match-bg, rgba(255, 214, 0, 0.55)); border-radius: 2px; }
+    .dvn-search-current { background: var(--dvn-search-current-bg, rgba(255, 150, 0, 0.75)); }
+    .dvn-search-voice-match .voiceInfoBox { outline: 2px solid var(--dvn-search-match-outline, rgba(255, 214, 0, 0.75)); outline-offset: 1px; }
+    .dvn-search-current-voice .voiceInfoBox { outline-color: var(--dvn-search-current-outline, rgba(255, 150, 0, 0.95)); }
+  `
+  document.head.appendChild(style)
+}
+
+export const searchPluginKey = new PluginKey('dvnSearch')
+
+function normalize(value) {
+  return String(value ?? '').toLocaleLowerCase()
+}
+
+function findInlineMatches(text, query) {
+  const matches = []
+  if (!text || !query) return matches
+  const haystack = normalize(text)
+  const needle = normalize(query)
+  let index = haystack.indexOf(needle)
+  while (index >= 0) {
+    matches.push({ fromOffset: index, toOffset: index + query.length })
+    index = haystack.indexOf(needle, index + Math.max(1, query.length))
+  }
+  return matches
+}
+
+function buildSearchState(doc, query, currentIndex = 0) {
+  const normalizedQuery = String(query ?? '').trim()
+  if (!normalizedQuery) {
+    return {
+      query: '',
+      matches: [],
+      currentIndex: 0,
+      decorationSet: DecorationSet.empty,
+      matchedVoiceIds: new Set(),
+      matchedVoiceTranscriptIds: new Set(),
+      currentVoiceId: null,
+    }
+  }
+
+  const decorations = []
+  const matches = []
+  const matchedVoiceIds = new Set()
+  const matchedVoiceTranscriptIds = new Set()
+
+  doc.descendants((node, pos) => {
+    if (node.isText) {
+      for (const match of findInlineMatches(node.text, normalizedQuery)) {
+        const from = pos + match.fromOffset
+        const to = pos + match.toOffset
+        const index = matches.length
+        matches.push({ type: 'text', from, to })
+        decorations.push(Decoration.inline(from, to, {
+          class: index === currentIndex
+            ? 'dvn-search-match dvn-search-current'
+            : 'dvn-search-match',
+        }))
+      }
+      return false
+    }
+
+    if (node.type?.name === 'voiceBlock') {
+      const voiceId = node.attrs?.voiceId
+      const titleMatched = normalize(node.attrs?.title).includes(normalize(normalizedQuery))
+      const transcriptMatched = normalize(node.attrs?.text).includes(normalize(normalizedQuery))
+      if (voiceId && (titleMatched || transcriptMatched)) {
+        const index = matches.length
+        matchedVoiceIds.add(voiceId)
+        if (transcriptMatched) matchedVoiceTranscriptIds.add(voiceId)
+        matches.push({ type: 'voiceBlock', from: pos, to: pos + node.nodeSize, voiceId })
+        decorations.push(Decoration.node(pos, pos + node.nodeSize, {
+          class: index === currentIndex
+            ? 'dvn-search-voice-match dvn-search-current-voice'
+            : 'dvn-search-voice-match',
+        }))
+      }
+      return false
+    }
+    return true
+  })
+
+  const safeCurrentIndex = matches.length === 0
+    ? 0
+    : Math.max(0, Math.min(currentIndex, matches.length - 1))
+  const current = matches[safeCurrentIndex]
+
+  return {
+    query: normalizedQuery,
+    matches,
+    currentIndex: safeCurrentIndex,
+    decorationSet: DecorationSet.create(doc, decorations),
+    matchedVoiceIds,
+    matchedVoiceTranscriptIds,
+    currentVoiceId: current?.voiceId ?? null,
+  }
+}
+
+function scrollCurrentIntoView(editor) {
+  const state = searchPluginKey.getState(editor.state)
+  if (!state?.query || state.matches.length === 0) return
+  window.requestAnimationFrame(() => {
+    const current = editor.view.dom.querySelector('.dvn-search-current, .dvn-search-current-voice')
+      || editor.view.dom.querySelector('.dvn-search-match, .dvn-search-voice-match')
+    current?.scrollIntoView?.({ block: 'center', inline: 'nearest' })
+  })
+}
+
+export function setTiptapSearchQuery(editor, query) {
+  if (!editor?.view) return false
+  editor.view.dispatch(editor.state.tr.setMeta(searchPluginKey, {
+    type: 'setQuery',
+    query: String(query ?? ''),
+  }))
+  scrollCurrentIntoView(editor)
+  return true
+}
+
+export function clearTiptapSearch(editor) {
+  return setTiptapSearchQuery(editor, '')
+}
+
+export const SearchExtension = Extension.create({
+  name: 'dvnSearch',
+
+  addProseMirrorPlugins() {
+    return [new Plugin({
+      key: searchPluginKey,
+      state: {
+        init(_, state) {
+          return buildSearchState(state.doc, '')
+        },
+        apply(tr, previous, _oldState, newState) {
+          const meta = tr.getMeta(searchPluginKey)
+          if (meta?.type === 'setQuery') {
+            return buildSearchState(newState.doc, meta.query, 0)
+          }
+          if (tr.docChanged && previous?.query) {
+            return buildSearchState(newState.doc, previous.query, previous.currentIndex)
+          }
+          if (tr.mapping && previous?.decorationSet) {
+            return {
+              ...previous,
+              decorationSet: previous.decorationSet.map(tr.mapping, tr.doc),
+            }
+          }
+          return previous
+        },
+      },
+      props: {
+        decorations(state) {
+          return searchPluginKey.getState(state)?.decorationSet || DecorationSet.empty
+        },
+      },
+      view(view) {
+        let lastState = null
+        const publish = () => {
+          const state = searchPluginKey.getState(view.state)
+          if (state === lastState) return
+          lastState = state
+          notifySearchState(state)
+        }
+        publish()
+        return {
+          update() { publish() },
+          destroy() { notifySearchState(buildSearchState(view.state.doc, '')) },
+        }
+      },
+    })]
+  },
+})

--- a/web-editor/src/runtime/search-state.js
+++ b/web-editor/src/runtime/search-state.js
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+const subscribers = new Set()
+let currentSearchState = {
+  query: '',
+  matchedVoiceIds: new Set(),
+  matchedVoiceTranscriptIds: new Set(),
+  currentVoiceId: null,
+  version: 0,
+}
+
+export function getCurrentSearchState() {
+  return currentSearchState
+}
+
+export function subscribeSearchState(callback) {
+  if (typeof callback !== 'function') return () => {}
+  subscribers.add(callback)
+  callback(currentSearchState)
+  return () => subscribers.delete(callback)
+}
+
+export function notifySearchState(state) {
+  currentSearchState = {
+    query: String(state?.query ?? ''),
+    matchedVoiceIds: state?.matchedVoiceIds instanceof Set ? state.matchedVoiceIds : new Set(state?.matchedVoiceIds || []),
+    matchedVoiceTranscriptIds: state?.matchedVoiceTranscriptIds instanceof Set
+      ? state.matchedVoiceTranscriptIds
+      : new Set(state?.matchedVoiceTranscriptIds || []),
+    currentVoiceId: state?.currentVoiceId ?? null,
+    version: (currentSearchState.version || 0) + 1,
+  }
+  for (const callback of Array.from(subscribers)) {
+    callback(currentSearchState)
+  }
+}
+
+export function renderHighlightedText(element, text, query, className = 'dvn-search-match') {
+  if (!element) return
+  const source = String(text ?? '')
+  const needle = String(query ?? '')
+  element.replaceChildren()
+  if (!source || !needle) {
+    element.textContent = source
+    return
+  }
+
+  const lowerSource = source.toLocaleLowerCase()
+  const lowerNeedle = needle.toLocaleLowerCase()
+  let pos = 0
+  let match = lowerSource.indexOf(lowerNeedle, pos)
+  while (match >= 0) {
+    if (match > pos) {
+      element.appendChild(document.createTextNode(source.slice(pos, match)))
+    }
+    const span = document.createElement('span')
+    span.className = className
+    span.textContent = source.slice(match, match + needle.length)
+    element.appendChild(span)
+    pos = match + needle.length
+    match = lowerSource.indexOf(lowerNeedle, pos)
+  }
+  if (pos < source.length) {
+    element.appendChild(document.createTextNode(source.slice(pos)))
+  }
+}
+
+export function textMatchesQuery(text, query) {
+  const source = String(text ?? '')
+  const needle = String(query ?? '')
+  return !!needle && source.toLocaleLowerCase().includes(needle.toLocaleLowerCase())
+}

--- a/web-editor/src/runtime/tiptap-editor.js
+++ b/web-editor/src/runtime/tiptap-editor.js
@@ -17,6 +17,7 @@ import { createFormatToolbar } from './format-toolbar.js'
 import { setupImagePaste, setupImageViewAndMenu } from './image-interactions.js'
 import { shouldFocusEditorOnDocumentMouseDown } from './focus-behavior.js'
 import { setTiptapSearchQuery, clearTiptapSearch } from './search-extension.js'
+import { currentTranscriptCopyText, copyTranscriptTextViaBridge, installTranscriptCopyHandler } from './transcript-copy.js'
 
 // ---------------------------------------------------------------------------
 // 编辑器初始化模块（本接口不替换此模块）
@@ -50,8 +51,10 @@ function setupTransientScrollbar() {
 // ---------------------------------------------------------------------------
 
 setupTransientScrollbar()
+installTranscriptCopyHandler()
 const editor = createTiptapEditor(document.getElementById('app'))
 const appElement = document.getElementById('app')
+let tiptapBridge = null
 function syncEditorEmptyState() {
   appElement.classList.toggle('is-empty', editor.isEmpty)
 }
@@ -64,6 +67,15 @@ editor.on('transaction', syncEditorEmptyState)
 if (typeof window !== 'undefined') {
   window.__dvnTiptapEditor = editor
   window.__dvnTiptapContextTranscript = null
+  window.__dvnTiptapGetContextTranscriptCopyText = function () {
+    return currentTranscriptCopyText({ useContext: true, allowCachedContext: true, allowWholeContext: true, allowCachedRecent: true })
+  }
+  window.__dvnTiptapGetShortcutTranscriptCopyText = function () {
+    return currentTranscriptCopyText({ useContext: false, allowCachedRecent: true })
+  }
+  window.__dvnTiptapCopyContextTranscript = function () {
+    return copyTranscriptTextViaBridge(tiptapBridge)
+  }
   window.__dvnTiptapSelectContextAll = function () {
     const transcript = window.__dvnTiptapContextTranscript
     if (transcript && document.contains(transcript)) {
@@ -106,7 +118,6 @@ if (typeof window !== 'undefined') {
 syncEditorEmptyState()
 const toolbar = createFormatToolbar(editor, document.getElementById('toolbar-host'))
 const titleInput = document.getElementById('note-title-input')
-let tiptapBridge = null
 let pendingPickImage = false
 let pendingRecordVoice = false
 let currentTitleNoteId = -1

--- a/web-editor/src/runtime/tiptap-extensions.js
+++ b/web-editor/src/runtime/tiptap-extensions.js
@@ -28,6 +28,7 @@ import { ImageBlock } from '../extensions/image-block.js'
 import { VoiceBlock } from '../extensions/voice-block.js'
 import { ListNestingGuard } from './list-nesting-guard.js'
 import { UndoRedo } from './undo-redo.js'
+import { SearchExtension } from './search-extension.js'
 
 export function createTiptapExtensions() {
   return [
@@ -53,6 +54,7 @@ export function createTiptapExtensions() {
     FontFamilyMark,
     FontSizeMark,
     UndoRedo,
+    SearchExtension,
     ListNestingGuard,
   ]
 }

--- a/web-editor/src/runtime/transcript-copy.js
+++ b/web-editor/src/runtime/transcript-copy.js
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Copy support for read-only voice transcription text rendered inside the
+// atom voiceBlock NodeView.  ProseMirror selections cannot represent partial
+// text inside atom-node DOM, so transcript copy must be driven from the native
+// DOM Selection and isolated from ProseMirror's regular copy pipeline.
+
+let lastTranscriptSelection = {
+  element: null,
+  text: '',
+  time: 0,
+}
+
+const TRANSCRIPT_SELECTION_CACHE_TTL_MS = 30000
+
+function clearContextTranscript() {
+  if (hasDom()) {
+    window.__dvnTiptapContextTranscript = null
+  }
+}
+
+function setContextTranscript(transcript) {
+  if (!hasDom()) return null
+  window.__dvnTiptapContextTranscript = transcript && document.contains(transcript) ? transcript : null
+  return window.__dvnTiptapContextTranscript
+}
+
+function hasDom() {
+  return typeof window !== 'undefined' && typeof document !== 'undefined'
+}
+
+function selectionRangeIntersectsElement(range, element) {
+  if (!range || !element) return false
+  if (typeof range.intersectsNode === 'function') {
+    try {
+      return range.intersectsNode(element)
+    } catch (_) {
+      // Fall through to boundary comparison for engines that throw on detached
+      // or non-standard nodes.
+    }
+  }
+
+  const elementRange = document.createRange()
+  elementRange.selectNodeContents(element)
+  return range.compareBoundaryPoints(Range.END_TO_START, elementRange) > 0
+    && range.compareBoundaryPoints(Range.START_TO_END, elementRange) < 0
+}
+
+function clippedRangeText(range, element) {
+  if (!selectionRangeIntersectsElement(range, element)) return ''
+
+  const elementRange = document.createRange()
+  elementRange.selectNodeContents(element)
+
+  const clipped = range.cloneRange()
+  if (clipped.compareBoundaryPoints(Range.START_TO_START, elementRange) < 0) {
+    clipped.setStart(elementRange.startContainer, elementRange.startOffset)
+  }
+  if (clipped.compareBoundaryPoints(Range.END_TO_END, elementRange) > 0) {
+    clipped.setEnd(elementRange.endContainer, elementRange.endOffset)
+  }
+  return clipped.toString()
+}
+
+export function selectedTextWithinElement(element, selection = (hasDom() ? window.getSelection?.() : null)) {
+  if (!element || !selection || selection.rangeCount === 0 || selection.isCollapsed) return ''
+
+  let text = ''
+  for (let i = 0; i < selection.rangeCount; i++) {
+    const part = clippedRangeText(selection.getRangeAt(i), element)
+    if (!part) continue
+    if (text) text += '\n'
+    text += part
+  }
+  return text
+}
+
+function closestTranscriptFromNode(node) {
+  const element = node && node.nodeType === 1 ? node : node?.parentElement
+  return element?.closest?.('.translateText') || null
+}
+
+function liveSelectedTranscriptElement(selection) {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null
+
+  // Only take over keyboard/native copy when the DOM selection belongs to one
+  // transcript.  Mixed selections should continue through ProseMirror/WebEngine
+  // so normal rich-text copy semantics are preserved.
+  const anchorTranscript = closestTranscriptFromNode(selection.anchorNode)
+  const focusTranscript = closestTranscriptFromNode(selection.focusNode)
+  if (anchorTranscript && anchorTranscript === focusTranscript && document.contains(anchorTranscript)) {
+    return anchorTranscript
+  }
+  return null
+}
+
+export function updateTranscriptSelectionCache(selection = (hasDom() ? window.getSelection?.() : null)) {
+  if (!hasDom() || !selection || selection.rangeCount === 0 || selection.isCollapsed) return false
+
+  const matches = []
+  const directTranscript = liveSelectedTranscriptElement(selection)
+  if (directTranscript) {
+    const text = selectedTextWithinElement(directTranscript, selection)
+    if (text) matches.push({ element: directTranscript, text })
+  } else {
+    for (const transcript of document.querySelectorAll('.translateText')) {
+      const text = selectedTextWithinElement(transcript, selection)
+      if (text) matches.push({ element: transcript, text })
+    }
+  }
+
+  if (matches.length === 0) {
+    lastTranscriptSelection = { element: null, text: '', time: 0 }
+    return false
+  }
+  if (matches.length !== 1) return false
+  lastTranscriptSelection = { ...matches[0], time: Date.now() }
+  return true
+}
+
+export function currentTranscriptElement({ useContext = false } = {}) {
+  if (!hasDom()) return null
+
+  if (useContext) {
+    const transcript = window.__dvnTiptapContextTranscript
+    if (transcript && document.contains(transcript)) return transcript
+  }
+
+  return liveSelectedTranscriptElement(window.getSelection?.())
+}
+
+export function currentTranscriptCopyText({ useContext = false, allowCachedContext = false, allowWholeContext = false, allowCachedRecent = false } = {}) {
+  const transcript = currentTranscriptElement({ useContext })
+  if (!transcript) {
+    if (allowCachedRecent
+      && lastTranscriptSelection.text
+      && lastTranscriptSelection.element
+      && document.contains(lastTranscriptSelection.element)
+      && Date.now() - lastTranscriptSelection.time <= TRANSCRIPT_SELECTION_CACHE_TTL_MS) {
+      return lastTranscriptSelection.text
+    }
+    return ''
+  }
+
+  const liveText = selectedTextWithinElement(transcript)
+  if (liveText) {
+    lastTranscriptSelection = { element: transcript, text: liveText, time: Date.now() }
+    return liveText
+  }
+
+  // QtWebEngine may collapse or move the DOM Selection while opening the native
+  // context menu.  The QML menu first records the clicked transcript element;
+  // only in that explicit context do we reuse the last non-empty transcript
+  // selection, avoiding stale hijacks of normal Ctrl+C/rich-text copy.
+  if (allowCachedContext
+    && useContext
+    && lastTranscriptSelection.element === transcript
+    && document.contains(lastTranscriptSelection.element)) {
+    return lastTranscriptSelection.text
+  }
+
+  // Context-menu fallback: when the user right-clicks transcript text without
+  // a usable selection, copy the whole transcript instead of doing nothing.
+  // This is intentionally opt-in so Ctrl+C on a collapsed caret does not
+  // unexpectedly copy an entire voice transcript.
+  if (allowWholeContext && useContext) {
+    return transcript.textContent || ''
+  }
+  return ''
+}
+
+function htmlFromPlainText(text) {
+  const div = document.createElement('div')
+  div.textContent = text
+  return div.innerHTML.replace(/\n/g, '<br>')
+}
+
+export function writeTranscriptCopyEvent(event, text = currentTranscriptCopyText()) {
+  if (!text || !event?.clipboardData) return false
+  event.clipboardData.setData('text/plain', text)
+  event.clipboardData.setData('text/html', htmlFromPlainText(text))
+  event.preventDefault()
+  event.stopPropagation()
+  return true
+}
+
+export function copyTranscriptTextViaBridge(bridge, text = currentTranscriptCopyText({ useContext: true, allowCachedContext: true, allowWholeContext: true, allowCachedRecent: true })) {
+  if (!text || !bridge || typeof bridge.jsCopyPlainTextToClipboard !== 'function') return false
+  bridge.jsCopyPlainTextToClipboard(text)
+  return true
+}
+
+export function setContextTranscriptFromEvent(event) {
+  const transcript = event?.target?.closest?.('.translateText') || null
+  setContextTranscript(transcript)
+  if (transcript) {
+    updateTranscriptSelectionCache()
+  }
+  return transcript
+}
+
+export function installTranscriptCopyHandler() {
+  if (!hasDom()) return () => {}
+  const onCopy = (event) => {
+    writeTranscriptCopyEvent(event)
+  }
+  const updateCache = () => {
+    updateTranscriptSelectionCache()
+  }
+  const clearCacheWhenStartingOutsideTranscript = (event) => {
+    if (!event.target?.closest?.('.translateText')) {
+      lastTranscriptSelection = { element: null, text: '', time: 0 }
+      clearContextTranscript()
+    }
+  }
+  const onContextMenu = (event) => {
+    setContextTranscriptFromEvent(event)
+  }
+  document.addEventListener('copy', onCopy, true)
+  document.addEventListener('mousedown', clearCacheWhenStartingOutsideTranscript, true)
+  document.addEventListener('pointerdown', clearCacheWhenStartingOutsideTranscript, true)
+  document.addEventListener('contextmenu', onContextMenu, true)
+  document.addEventListener('selectionchange', updateCache, true)
+  document.addEventListener('mouseup', updateCache, true)
+  document.addEventListener('pointerup', updateCache, true)
+  document.addEventListener('touchend', updateCache, true)
+  document.addEventListener('keyup', updateCache, true)
+  return () => {
+    document.removeEventListener('copy', onCopy, true)
+    document.removeEventListener('mousedown', clearCacheWhenStartingOutsideTranscript, true)
+    document.removeEventListener('pointerdown', clearCacheWhenStartingOutsideTranscript, true)
+    document.removeEventListener('contextmenu', onContextMenu, true)
+    document.removeEventListener('selectionchange', updateCache, true)
+    document.removeEventListener('mouseup', updateCache, true)
+    document.removeEventListener('pointerup', updateCache, true)
+    document.removeEventListener('touchend', updateCache, true)
+    document.removeEventListener('keyup', updateCache, true)
+  }
+}

--- a/web-editor/test/search-plugin.test.mjs
+++ b/web-editor/test/search-plugin.test.mjs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { Window } from 'happy-dom'
+import { Editor } from '@tiptap/core'
+import { createTiptapExtensions } from '../src/runtime/tiptap-extensions.js'
+import { createEmptyDoc } from '../src/schema/document-envelope.js'
+import { setTiptapSearchQuery, clearTiptapSearch, searchPluginKey } from '../src/runtime/search-extension.js'
+
+function defineGlobal(name, value) {
+  Object.defineProperty(globalThis, name, {
+    value,
+    writable: true,
+    configurable: true,
+  })
+}
+
+function setupDom() {
+  const window = new Window()
+  defineGlobal('window', window)
+  defineGlobal('document', window.document)
+  defineGlobal('navigator', window.navigator)
+  defineGlobal('Node', window.Node)
+  defineGlobal('Element', window.Element)
+  defineGlobal('HTMLElement', window.HTMLElement)
+  defineGlobal('DocumentFragment', window.DocumentFragment)
+  defineGlobal('Event', window.Event)
+  defineGlobal('CustomEvent', window.CustomEvent)
+  defineGlobal('MutationObserver', window.MutationObserver)
+  defineGlobal('getComputedStyle', window.getComputedStyle.bind(window))
+  defineGlobal('requestAnimationFrame', (cb) => setTimeout(cb, 0))
+  defineGlobal('cancelAnimationFrame', (id) => clearTimeout(id))
+  return window
+}
+
+function createEditor() {
+  setupDom()
+  const element = document.createElement('div')
+  document.body.appendChild(element)
+  const editor = new Editor({
+    element,
+    extensions: createTiptapExtensions(),
+    content: createEmptyDoc(),
+  })
+  return editor
+}
+
+test('search extension highlights only document text without changing JSON', () => {
+  const editor = createEditor()
+  editor.commands.setContent({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello Tiptap search' }] }],
+  })
+  const before = JSON.stringify(editor.getJSON())
+
+  assert.equal(setTiptapSearchQuery(editor, 'tiptap'), true)
+  const state = searchPluginKey.getState(editor.state)
+  assert.equal(state.matches.length, 1)
+  assert.ok(editor.view.dom.querySelector('.dvn-search-match'))
+  assert.equal(JSON.stringify(editor.getJSON()), before, 'search must not mutate persisted document')
+
+  clearTiptapSearch(editor)
+  assert.equal(searchPluginKey.getState(editor.state).matches.length, 0)
+  assert.equal(editor.view.dom.querySelector('.dvn-search-match'), null)
+  editor.destroy()
+})
+
+test('search extension highlights voice transcript at runtime and restores folded state', () => {
+  const editor = createEditor()
+  editor.commands.setContent({
+    type: 'doc',
+    content: [{
+      type: 'voiceBlock',
+      attrs: {
+        voiceId: 'voice-search-js',
+        voicePath: 'voicenote/search.wav',
+        voiceSize: 1000,
+        title: '会议录音',
+        text: '这是一段可以搜索的转写内容',
+        translateUnfold: false,
+      },
+    }],
+  })
+
+  const translateText = editor.view.dom.querySelector('.translateText')
+  assert.ok(translateText, 'voice transcript should render')
+  assert.equal(translateText.style.display, 'none', 'folded transcript is hidden before search')
+
+  setTiptapSearchQuery(editor, '搜索')
+  const state = searchPluginKey.getState(editor.state)
+  assert.equal(state.matchedVoiceTranscriptIds.has('voice-search-js'), true)
+  assert.notEqual(translateText.style.display, 'none', 'matched folded transcript is shown at runtime')
+  assert.ok(translateText.querySelector('.dvn-search-match'), 'matched transcript text is highlighted')
+
+  clearTiptapSearch(editor)
+  assert.equal(translateText.style.display, 'none', 'clearing search restores folded transcript visibility')
+  assert.equal(translateText.querySelector('.dvn-search-match'), null)
+  editor.destroy()
+})


### PR DESCRIPTION
Render runtime search highlights without changing document content.

在不修改文档内容的前提下渲染运行态搜索高亮。

Log: 添加 Tiptap 搜索高亮渲染

PMS: TASK-393985

Influence: Tiptap 正文和语音块转写文本可显示搜索命中高亮，不会进入保存内容或 undo/redo 历史。

## Summary by Sourcery

Render transient search matches in Tiptap content and voice transcripts while keeping read-only transcript copying outside the document and editing history.

New Features:
- Add runtime search highlighting for text and voice transcription matches in the Tiptap editor, including current-match navigation and visibility for folded transcripts.
- Support selecting and copying read-only voice transcription text to the system clipboard without adding it to document content or editing history.

Bug Fixes:
- Prevent voice transcription selections and copy operations from mutating the ProseMirror document or creating undo/redo history.

Enhancements:
- Expose synchronized search state to voice block NodeViews and preserve normal document serialization while rendering transient highlights.

Tests:
- Add coverage verifying runtime highlights do not change document JSON and that voice transcript highlighting respects folded state.