### PR TITLE
feat(export): support Tiptap document export

### DIFF
--- a/src/common/tiptapdocumentexporter.cpp
+++ b/src/common/tiptapdocumentexporter.cpp
@@ -1,0 +1,640 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "tiptapdocumentexporter.h"
+
+#include "utils.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QRegularExpression>
+#include <QSet>
+#include <QStandardPaths>
+#include <QUrl>
+
+namespace {
+
+constexpr int kTiptapSchemaVersion = 1;
+
+const QSet<QString> kRuntimeVoiceAttrs = {
+    QStringLiteral("playing"),
+    QStringLiteral("paused"),
+    QStringLiteral("progress"),
+    QStringLiteral("duration"),
+    QStringLiteral("translating"),
+    QStringLiteral("unplayable"),
+    QStringLiteral("seeking"),
+    QStringLiteral("current"),
+};
+
+QString htmlDocumentHead()
+{
+    return QStringLiteral(
+        "<!DOCTYPE html>"
+        "<html lang=\"zh-CN\">"
+        "<head>"
+        "<meta charset=\"UTF-8\">"
+        "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">"
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
+        "<title>Document</title>"
+        "<style>"
+        "body{font-family:'Helvetica','Noto Sans CJK SC',sans-serif;font-size:14px;"
+        "line-height:1.72;max-width:780px;margin:0 auto;padding:0;word-wrap:break-word;}"
+        "p{margin:0 0 8px;}h1,h2,h3,h4,h5,h6{margin:16px 0 8px;}"
+        "blockquote{margin:8px 0;padding-left:12px;border-left:3px solid #d0d0d0;color:#5f6368;}"
+        "ul,ol{padding-left:24px;}li>p{margin:0;}"
+        "ul[data-type='taskList']{list-style:none;padding-left:0;}"
+        "li[data-type='taskItem']{list-style:none;}"
+        "img{max-width:100%;height:auto;}"
+        ".voiceBox{background:rgba(0,0,0,.05);border-radius:12px;margin:10px 0;overflow:hidden;}"
+        ".voicePlayback{min-height:42px;display:flex;align-items:center;justify-content:space-between;padding:0 12px;}"
+        ".voiceTitle{font-size:14px;color:#001a2e;}"
+        ".voiceTime{font-size:12px;color:rgba(65,77,104,1);margin-left:12px;}"
+        ".translate{border-top:1px solid rgba(0,0,0,.06);padding:8px 20px 12px;}"
+        ".translateHeader{font-size:12px;color:rgba(65,77,104,1);margin-bottom:6px;}"
+        ".translateText{white-space:pre-wrap;word-break:break-word;}"
+        "</style>"
+        "</head><body><div class=\"note-editable\" contenteditable=\"false\">");
+}
+
+QString htmlDocumentTail()
+{
+    return QStringLiteral("</div></body></html>");
+}
+
+bool parseTiptapPayload(const QString &payload, QJsonObject *document)
+{
+    QJsonParseError parseError;
+    const QJsonDocument json = QJsonDocument::fromJson(payload.trimmed().toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !json.isObject()) {
+        return false;
+    }
+
+    const QJsonObject root = json.object();
+    QJsonObject content;
+    if (root.value(QStringLiteral("format")).toString() == QStringLiteral("tiptap")) {
+        const QJsonValue versionValue = root.value(QStringLiteral("schemaVersion"));
+        if (!versionValue.isDouble() || versionValue.toInt() != kTiptapSchemaVersion) {
+            return false;
+        }
+        content = root.value(QStringLiteral("content")).toObject();
+    } else if (root.value(QStringLiteral("type")).toString() == QStringLiteral("doc")) {
+        content = root;
+    } else {
+        return false;
+    }
+
+    if (content.value(QStringLiteral("type")).toString() != QStringLiteral("doc")) {
+        return false;
+    }
+
+    if (document) {
+        *document = content;
+    }
+    return true;
+}
+
+QString textValue(const QJsonObject &object, const QString &key)
+{
+    const QJsonValue value = object.value(key);
+    return value.isString() ? value.toString() : QString();
+}
+
+QString htmlAttr(QString value)
+{
+    return value.toHtmlEscaped().replace(QLatin1Char('\n'), QLatin1Char(' '));
+}
+
+QString safeCssValue(QString value)
+{
+    value = value.trimmed();
+    value.remove(QRegularExpression(QStringLiteral("[;{}<>\\\"]")));
+    return value;
+}
+
+QString sanitizedImageRelPath(const QString &relPath)
+{
+    const QString normalized = QDir::cleanPath(QDir::fromNativeSeparators(relPath.trimmed()));
+    if (!normalized.startsWith(QStringLiteral("images/"))
+        || normalized.split(QLatin1Char('/')).contains(QStringLiteral(".."))) {
+        return QString();
+    }
+    return normalized;
+}
+
+QString localImagePath(const QJsonObject &attrs)
+{
+    QString relPath = sanitizedImageRelPath(textValue(attrs, QStringLiteral("relPath")));
+    if (relPath.isEmpty()) {
+        const QUrl url(textValue(attrs, QStringLiteral("src")));
+        if (url.isLocalFile()) {
+            const QString filePath = QDir::cleanPath(QDir::fromNativeSeparators(url.toLocalFile()));
+            const QString appData = QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+            const QString imageRoot = QDir(appData).filePath(QStringLiteral("images"));
+            const QString imageRootWithSep = QDir::cleanPath(imageRoot) + QLatin1Char('/');
+            if (filePath.startsWith(imageRootWithSep)) {
+                relPath = QStringLiteral("images/") + filePath.mid(imageRootWithSep.size());
+            }
+        }
+    }
+    if (relPath.isEmpty()) {
+        return QString();
+    }
+
+    const QString appData = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    if (appData.isEmpty()) {
+        return QString();
+    }
+    return QDir::cleanPath(QDir(appData).filePath(relPath));
+}
+
+bool isSafeExportImageSrc(const QString &src)
+{
+    const QString trimmed = src.trimmed();
+    if (trimmed.isEmpty()) {
+        return false;
+    }
+
+    const QString normalized = QString(trimmed).remove(QRegularExpression(QStringLiteral("[\\x00-\\x20\\x7f\\s]")));
+    if (normalized.isEmpty()
+        || normalized.startsWith(QStringLiteral("//"))
+        || normalized.startsWith(QStringLiteral("\\\\"))) {
+        return false;
+    }
+
+    const QRegularExpression schemeRe(QStringLiteral("^([a-z][a-z0-9+.-]*):"), QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch schemeMatch = schemeRe.match(normalized);
+    if (!schemeMatch.hasMatch()) {
+        return true;
+    }
+
+    const QString scheme = schemeMatch.captured(1).toLower();
+    if (scheme == QStringLiteral("http") || scheme == QStringLiteral("https")) {
+        return true;
+    }
+    return scheme == QStringLiteral("data") && normalized.startsWith(QStringLiteral("data:image/"), Qt::CaseInsensitive);
+}
+
+QString imageSrcForHtml(const QJsonObject &attrs)
+{
+    const QString path = localImagePath(attrs);
+    if (!path.isEmpty()) {
+        QString base64;
+        if (Utils::pictureToBase64(path, base64)) {
+            return base64;
+        }
+    }
+
+    const QString src = textValue(attrs, QStringLiteral("src"));
+    if (isSafeExportImageSrc(src)) {
+        return src.trimmed();
+    }
+
+    return sanitizedImageRelPath(textValue(attrs, QStringLiteral("relPath")));
+}
+
+QString imageLabel(const QJsonObject &attrs)
+{
+    const QString title = textValue(attrs, QStringLiteral("title"));
+    if (!title.trimmed().isEmpty()) {
+        return title.trimmed();
+    }
+    const QString alt = textValue(attrs, QStringLiteral("alt"));
+    if (!alt.trimmed().isEmpty()) {
+        return alt.trimmed();
+    }
+    const QString relPath = textValue(attrs, QStringLiteral("relPath"));
+    if (!relPath.trimmed().isEmpty()) {
+        return QFileInfo(relPath).fileName();
+    }
+    return QStringLiteral("image");
+}
+
+QString voiceTitle(const QJsonObject &attrs)
+{
+    const QString title = textValue(attrs, QStringLiteral("title"));
+    if (!title.trimmed().isEmpty()) {
+        return title.trimmed();
+    }
+    const QString path = textValue(attrs, QStringLiteral("voicePath"));
+    if (!path.trimmed().isEmpty()) {
+        return QFileInfo(path).completeBaseName();
+    }
+    return QStringLiteral("voice");
+}
+
+QString voiceCreateTime(const QJsonObject &attrs)
+{
+    return textValue(attrs, QStringLiteral("createTime"));
+}
+
+QJsonObject persistedVoiceAttrs(const QJsonObject &attrs)
+{
+    QJsonObject persisted;
+    for (auto it = attrs.constBegin(); it != attrs.constEnd(); ++it) {
+        if (kRuntimeVoiceAttrs.contains(it.key())) {
+            continue;
+        }
+        persisted.insert(it.key(), it.value());
+    }
+    return persisted;
+}
+
+QString plainInline(const QJsonObject &node);
+QString plainBlock(const QJsonObject &node);
+QString htmlInline(const QJsonObject &node);
+QString htmlBlock(const QJsonObject &node);
+void collectVoiceJsons(const QJsonObject &node, QStringList *voices);
+
+QString joinPlainBlocks(const QJsonArray &children)
+{
+    QStringList blocks;
+    for (const QJsonValue &child : children) {
+        if (!child.isObject()) {
+            continue;
+        }
+        const QString text = plainBlock(child.toObject()).trimmed();
+        if (!text.isEmpty()) {
+            blocks.append(text);
+        }
+    }
+    return blocks.join(QStringLiteral("\n"));
+}
+
+QString plainChildren(const QJsonObject &node)
+{
+    QString text;
+    const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+    for (const QJsonValue &child : children) {
+        if (child.isObject()) {
+            text += plainInline(child.toObject());
+        }
+    }
+    return text;
+}
+
+QString plainBlockChildren(const QJsonObject &node)
+{
+    QStringList blocks;
+    const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+    for (const QJsonValue &child : children) {
+        if (!child.isObject()) {
+            continue;
+        }
+        const QString text = plainBlock(child.toObject()).trimmed();
+        if (!text.isEmpty()) {
+            blocks.append(text);
+        }
+    }
+    return blocks.join(QStringLiteral("\n"));
+}
+
+QString withListMarker(QString text, const QString &marker)
+{
+    text = text.trimmed();
+    if (text.isEmpty()) {
+        return QString();
+    }
+    return marker + text.replace(QStringLiteral("\n"), QStringLiteral("\n") + QString(marker.size(), QLatin1Char(' ')));
+}
+
+QString plainInline(const QJsonObject &node)
+{
+    const QString type = node.value(QStringLiteral("type")).toString();
+    if (type == QStringLiteral("text")) {
+        return textValue(node, QStringLiteral("text"));
+    }
+    if (type == QStringLiteral("hardBreak")) {
+        return QStringLiteral("\n");
+    }
+    if (type == QStringLiteral("image")) {
+        return QStringLiteral("[图片: %1]").arg(imageLabel(node.value(QStringLiteral("attrs")).toObject()));
+    }
+    if (type == QStringLiteral("voiceBlock")) {
+        return plainBlock(node);
+    }
+    return plainChildren(node);
+}
+
+QString plainBlock(const QJsonObject &node)
+{
+    const QString type = node.value(QStringLiteral("type")).toString();
+    if (type == QStringLiteral("doc")) {
+        return joinPlainBlocks(node.value(QStringLiteral("content")).toArray());
+    }
+    if (type == QStringLiteral("paragraph") || type == QStringLiteral("heading")) {
+        return plainChildren(node);
+    }
+    if (type == QStringLiteral("blockquote") || type == QStringLiteral("listItem")) {
+        return plainBlockChildren(node);
+    }
+    if (type == QStringLiteral("taskItem")) {
+        const QString marker = node.value(QStringLiteral("attrs")).toObject().value(QStringLiteral("checked")).toBool(false)
+            ? QStringLiteral("[x] ") : QStringLiteral("[ ] ");
+        return withListMarker(plainBlockChildren(node), marker);
+    }
+    if (type == QStringLiteral("bulletList") || type == QStringLiteral("orderedList") || type == QStringLiteral("taskList")) {
+        QStringList items;
+        int index = 1;
+        const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+        for (const QJsonValue &child : children) {
+            if (!child.isObject()) {
+                continue;
+            }
+            QString text = plainBlock(child.toObject()).trimmed();
+            if (text.isEmpty()) {
+                continue;
+            }
+            if (type == QStringLiteral("bulletList")) {
+                text = withListMarker(text, QStringLiteral("- "));
+            } else if (type == QStringLiteral("orderedList")) {
+                text = withListMarker(text, QString::number(index++) + QStringLiteral(". "));
+            }
+            if (!text.isEmpty()) {
+                items.append(text);
+            }
+        }
+        return items.join(QStringLiteral("\n"));
+    }
+    if (type == QStringLiteral("image")) {
+        return QStringLiteral("[图片: %1]").arg(imageLabel(node.value(QStringLiteral("attrs")).toObject()));
+    }
+    if (type == QStringLiteral("voiceBlock")) {
+        const QJsonObject attrs = persistedVoiceAttrs(node.value(QStringLiteral("attrs")).toObject());
+        // TXT 导出面向用户可读内容：语音节点只导出转写正文。
+        // 录音标题、voiceId、路径等结构元数据由 HTML/语音文件导出表达，
+        // 不能混入文本结果形成“[语音: xxx]”这类伪正文。
+        return textValue(attrs, QStringLiteral("text"));
+    }
+    return plainChildren(node);
+}
+
+QString markOpenHtml(const QJsonObject &mark)
+{
+    const QString type = mark.value(QStringLiteral("type")).toString();
+    const QJsonObject attrs = mark.value(QStringLiteral("attrs")).toObject();
+    if (type == QStringLiteral("bold")) return QStringLiteral("<strong>");
+    if (type == QStringLiteral("italic")) return QStringLiteral("<em>");
+    if (type == QStringLiteral("underline")) return QStringLiteral("<u>");
+    if (type == QStringLiteral("strike")) return QStringLiteral("<s>");
+    if (type == QStringLiteral("color")) {
+        const QString color = safeCssValue(textValue(attrs, QStringLiteral("color")));
+        return color.isEmpty() ? QString() : QStringLiteral("<span style=\"color:%1\">").arg(htmlAttr(color));
+    }
+    if (type == QStringLiteral("highlight")) {
+        const QString color = safeCssValue(textValue(attrs, QStringLiteral("color")));
+        return color.isEmpty() ? QStringLiteral("<mark>") : QStringLiteral("<mark style=\"background-color:%1\">").arg(htmlAttr(color));
+    }
+    if (type == QStringLiteral("fontFamily")) {
+        const QString family = safeCssValue(textValue(attrs, QStringLiteral("fontFamily")));
+        return family.isEmpty() ? QString() : QStringLiteral("<span style=\"font-family:%1\">").arg(htmlAttr(family));
+    }
+    if (type == QStringLiteral("fontSize")) {
+        const QString size = safeCssValue(textValue(attrs, QStringLiteral("fontSize")));
+        return size.isEmpty() ? QString() : QStringLiteral("<span style=\"font-size:%1\">").arg(htmlAttr(size));
+    }
+    return QString();
+}
+
+QString markCloseHtml(const QJsonObject &mark)
+{
+    const QString type = mark.value(QStringLiteral("type")).toString();
+    if (type == QStringLiteral("bold")) return QStringLiteral("</strong>");
+    if (type == QStringLiteral("italic")) return QStringLiteral("</em>");
+    if (type == QStringLiteral("underline")) return QStringLiteral("</u>");
+    if (type == QStringLiteral("strike")) return QStringLiteral("</s>");
+    if (type == QStringLiteral("color") || type == QStringLiteral("fontFamily") || type == QStringLiteral("fontSize")) return QStringLiteral("</span>");
+    if (type == QStringLiteral("highlight")) return QStringLiteral("</mark>");
+    return QString();
+}
+
+QString applyMarks(QString html, const QJsonArray &marks)
+{
+    QString prefix;
+    QString suffix;
+    for (const QJsonValue &value : marks) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QJsonObject mark = value.toObject();
+        const QString open = markOpenHtml(mark);
+        const QString close = markCloseHtml(mark);
+        if (open.isEmpty() || close.isEmpty()) {
+            continue;
+        }
+        prefix += open;
+        suffix.prepend(close);
+    }
+    return prefix + html + suffix;
+}
+
+QString htmlChildren(const QJsonObject &node)
+{
+    QString html;
+    const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+    for (const QJsonValue &child : children) {
+        if (child.isObject()) {
+            html += htmlInline(child.toObject());
+        }
+    }
+    return html;
+}
+
+QString htmlInline(const QJsonObject &node)
+{
+    const QString type = node.value(QStringLiteral("type")).toString();
+    if (type == QStringLiteral("text")) {
+        QString html = textValue(node, QStringLiteral("text")).toHtmlEscaped();
+        html.replace(QLatin1Char('\n'), QStringLiteral("<br>"));
+        return applyMarks(html, node.value(QStringLiteral("marks")).toArray());
+    }
+    if (type == QStringLiteral("hardBreak")) {
+        return QStringLiteral("<br>");
+    }
+    if (type == QStringLiteral("image")) {
+        const QJsonObject attrs = node.value(QStringLiteral("attrs")).toObject();
+        const QString src = imageSrcForHtml(attrs);
+        if (src.trimmed().isEmpty()) {
+            return QString();
+        }
+        QString html = QStringLiteral("<img src=\"%1\"").arg(htmlAttr(src));
+        const QString alt = textValue(attrs, QStringLiteral("alt"));
+        const QString title = textValue(attrs, QStringLiteral("title"));
+        if (!alt.isEmpty()) html += QStringLiteral(" alt=\"%1\"").arg(htmlAttr(alt));
+        if (!title.isEmpty()) html += QStringLiteral(" title=\"%1\"").arg(htmlAttr(title));
+        html += QStringLiteral(">");
+        return html;
+    }
+    if (type == QStringLiteral("voiceBlock")) {
+        return htmlBlock(node);
+    }
+    return htmlChildren(node);
+}
+
+QString blockContentOrBreak(const QJsonObject &node)
+{
+    const QString html = htmlChildren(node);
+    return html.isEmpty() ? QStringLiteral("<br>") : html;
+}
+
+QString htmlBlockChildren(const QJsonObject &node)
+{
+    QString html;
+    const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+    for (const QJsonValue &child : children) {
+        if (child.isObject()) {
+            html += htmlBlock(child.toObject());
+        }
+    }
+    return html;
+}
+
+QString htmlBlock(const QJsonObject &node)
+{
+    const QString type = node.value(QStringLiteral("type")).toString();
+    if (type == QStringLiteral("doc")) {
+        QString html;
+        const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+        for (const QJsonValue &child : children) {
+            if (child.isObject()) {
+                html += htmlBlock(child.toObject());
+            }
+        }
+        return html;
+    }
+    if (type == QStringLiteral("paragraph")) {
+        return QStringLiteral("<p>%1</p>").arg(blockContentOrBreak(node));
+    }
+    if (type == QStringLiteral("heading")) {
+        const int level = qBound(1, node.value(QStringLiteral("attrs")).toObject().value(QStringLiteral("level")).toInt(1), 6);
+        return QStringLiteral("<h%1>%2</h%1>").arg(level).arg(blockContentOrBreak(node));
+    }
+    if (type == QStringLiteral("blockquote")) {
+        return QStringLiteral("<blockquote>%1</blockquote>").arg(blockContentOrBreak(node));
+    }
+    if (type == QStringLiteral("bulletList")) {
+        return QStringLiteral("<ul>%1</ul>").arg(htmlBlockChildren(node));
+    }
+    if (type == QStringLiteral("orderedList")) {
+        return QStringLiteral("<ol>%1</ol>").arg(htmlBlockChildren(node));
+    }
+    if (type == QStringLiteral("taskList")) {
+        return QStringLiteral("<ul data-type=\"taskList\">%1</ul>").arg(htmlBlockChildren(node));
+    }
+    if (type == QStringLiteral("listItem")) {
+        return QStringLiteral("<li>%1</li>").arg(htmlBlockChildren(node));
+    }
+    if (type == QStringLiteral("taskItem")) {
+        const bool checked = node.value(QStringLiteral("attrs")).toObject().value(QStringLiteral("checked")).toBool(false);
+        return QStringLiteral("<li data-type=\"taskItem\" data-checked=\"%1\"><input type=\"checkbox\" disabled%2> %3</li>")
+            .arg(checked ? QStringLiteral("true") : QStringLiteral("false"),
+                 checked ? QStringLiteral(" checked") : QString(),
+                 htmlBlockChildren(node));
+    }
+    if (type == QStringLiteral("image")) {
+        return QStringLiteral("<p>%1</p>").arg(htmlInline(node));
+    }
+    if (type == QStringLiteral("voiceBlock")) {
+        const QJsonObject attrs = persistedVoiceAttrs(node.value(QStringLiteral("attrs")).toObject());
+        const QString title = voiceTitle(attrs).toHtmlEscaped();
+        const QString createTime = voiceCreateTime(attrs).toHtmlEscaped();
+        const QString transcript = textValue(attrs, QStringLiteral("text"));
+        QString html = QStringLiteral("<div class=\"voiceBox\" data-type=\"voice-block\">");
+        html += QStringLiteral("<div class=\"voicePlayback\"><div class=\"voiceTitle\">%1</div>").arg(title);
+        if (!createTime.isEmpty()) {
+            html += QStringLiteral("<div class=\"voiceTime\">%1</div>").arg(createTime);
+        }
+        html += QStringLiteral("</div>");
+        if (!transcript.trimmed().isEmpty()) {
+            html += QStringLiteral("<div class=\"translate\"><div class=\"translateHeader\">语音转文字</div><div class=\"translateText\">%1</div></div>")
+                        .arg(transcript.toHtmlEscaped().replace(QLatin1Char('\n'), QStringLiteral("<br>")));
+        }
+        html += QStringLiteral("</div>");
+        return html;
+    }
+    return htmlChildren(node);
+}
+
+void collectVoiceJsons(const QJsonObject &node, QStringList *voices)
+{
+    if (!voices) {
+        return;
+    }
+    const QString type = node.value(QStringLiteral("type")).toString();
+    if (type == QStringLiteral("voiceBlock")) {
+        const QJsonObject attrs = persistedVoiceAttrs(node.value(QStringLiteral("attrs")).toObject());
+        const QString voicePath = textValue(attrs, QStringLiteral("voicePath"));
+        if (!voicePath.trimmed().isEmpty()) {
+            QJsonObject legacy;
+            legacy.insert(QStringLiteral("type"), 2);
+            legacy.insert(QStringLiteral("voiceId"), textValue(attrs, QStringLiteral("voiceId")));
+            legacy.insert(QStringLiteral("voicePath"), voicePath);
+            legacy.insert(QStringLiteral("voiceSize"), attrs.value(QStringLiteral("voiceSize")).toInt(0));
+            legacy.insert(QStringLiteral("createTime"), textValue(attrs, QStringLiteral("createTime")));
+            legacy.insert(QStringLiteral("title"), voiceTitle(attrs));
+            const QString transcript = textValue(attrs, QStringLiteral("text"));
+            legacy.insert(QStringLiteral("text"), transcript);
+            legacy.insert(QStringLiteral("state"), !transcript.trimmed().isEmpty());
+            voices->append(QString::fromUtf8(QJsonDocument(legacy).toJson(QJsonDocument::Compact)));
+        }
+        return;
+    }
+
+    const QJsonArray children = node.value(QStringLiteral("content")).toArray();
+    for (const QJsonValue &child : children) {
+        if (child.isObject()) {
+            collectVoiceJsons(child.toObject(), voices);
+        }
+    }
+}
+
+} // namespace
+
+bool TiptapDocumentExporter::isTiptapEnvelope(const QString &payload)
+{
+    return parseTiptapPayload(payload, nullptr);
+}
+
+QString TiptapDocumentExporter::toPlainText(const QString &payload)
+{
+    QJsonObject document;
+    if (!parseTiptapPayload(payload, &document)) {
+        return QString();
+    }
+    return plainBlock(document);
+}
+
+QString TiptapDocumentExporter::toHtml(const QString &payload)
+{
+    QJsonObject document;
+    if (!parseTiptapPayload(payload, &document)) {
+        return QString();
+    }
+    return htmlDocumentHead() + htmlBlock(document) + htmlDocumentTail();
+}
+
+QStringList TiptapDocumentExporter::voiceJsons(const QString &payload)
+{
+    QJsonObject document;
+    if (!parseTiptapPayload(payload, &document)) {
+        return {};
+    }
+    QStringList voices;
+    collectVoiceJsons(document, &voices);
+    return voices;
+}
+
+bool TiptapDocumentExporter::hasText(const QString &payload)
+{
+    return !toPlainText(payload).trimmed().isEmpty();
+}
+
+bool TiptapDocumentExporter::hasVoice(const QString &payload)
+{
+    return !voiceJsons(payload).isEmpty();
+}

--- a/src/common/tiptapdocumentexporter.h
+++ b/src/common/tiptapdocumentexporter.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TIPTAPDOCUMENTEXPORTER_H
+#define TIPTAPDOCUMENTEXPORTER_H
+
+#include <QString>
+#include <QStringList>
+
+class TiptapDocumentExporter
+{
+public:
+    static bool isTiptapEnvelope(const QString &payload);
+
+    // Export a Tiptap envelope to deterministic plain text. Images are emitted
+    // as explicit placeholders; voice blocks contribute persisted transcript
+    // text only so recording metadata does not pollute text export.
+    static QString toPlainText(const QString &payload);
+
+    // Export a Tiptap envelope to standalone HTML. Local AppData images are
+    // embedded as data URLs where possible; otherwise the persisted safe src is
+    // kept. Only persisted schema fields are rendered, runtime fields are
+    // intentionally ignored.
+    static QString toHtml(const QString &payload);
+
+    // Return legacy voice JSON objects compatible with MetaDataParser and the
+    // existing voice export worker. Runtime-only attrs are not emitted.
+    static QStringList voiceJsons(const QString &payload);
+
+    static bool hasText(const QString &payload);
+    static bool hasVoice(const QString &payload);
+};
+
+#endif // TIPTAPDOCUMENTEXPORTER_H

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -438,12 +438,16 @@ QString Utils::createRichText(const QString &title, const QString &key)
         return title.toHtmlEscaped();
     }
 
+    const DPalette palette = DGuiApplicationHelper::instance()->applicationPalette();
+    const QString highlightColor = palette.color(DPalette::Active, DPalette::Highlight).name();
+    const QString highlightOpen = QStringLiteral("<span style=\"color: %1;\">").arg(highlightColor);
+
     QString html;
     int pos = 0;
     int match = title.indexOf(key, pos, Qt::CaseInsensitive);
     while (match >= 0) {
         html += title.mid(pos, match - pos).toHtmlEscaped();
-        html += QStringLiteral("<span style=\"color: #0058de;\">")
+        html += highlightOpen
             + title.mid(match, key.size()).toHtmlEscaped()
             + QStringLiteral("</span>");
         pos = match + key.size();

--- a/src/common/vnoteitem.cpp
+++ b/src/common/vnoteitem.cpp
@@ -7,6 +7,7 @@
 #include "common/utils.h"
 #include "search/searchdocumentextractor.h"
 #include "search/searchtextnormalizer.h"
+#include "tiptapdocumentexporter.h"
 
 #include <DLog>
 #include <DGuiApplicationHelper>
@@ -260,6 +261,13 @@ void VNoteItem::delBlock(VNoteBlock *block)
 bool VNoteItem::haveVoice() const
 {
     qDebug() << "Checking for voice content in note ID:" << noteId;
+    const QString meta = metaDataConstRef().toString();
+    if (TiptapDocumentExporter::isTiptapEnvelope(meta)) {
+        const bool hasVoice = TiptapDocumentExporter::hasVoice(meta);
+        qInfo() << "Tiptap voice content check finished, result:" << hasVoice;
+        return hasVoice;
+    }
+
     if (htmlCode.isEmpty()) {
         bool hasVoice = datas.voiceBlocks.size() > 0;
         qInfo() << "Voice content check finished, result:" << hasVoice;
@@ -280,6 +288,13 @@ bool VNoteItem::haveVoice() const
 bool VNoteItem::haveText() const
 {
     qDebug() << "Checking for text content in note ID:" << noteId;
+    const QString meta = metaDataConstRef().toString();
+    if (TiptapDocumentExporter::isTiptapEnvelope(meta)) {
+        const bool hasText = TiptapDocumentExporter::hasText(meta);
+        qDebug() << "Tiptap format - Has text/exportable content:" << hasText;
+        return hasText;
+    }
+
     if (!htmlCode.isEmpty()) { //富文本文本内容判断
         bool hasText = (htmlCode != "<p><br></p>");
         qDebug() << "Rich text format - Has text:" << hasText;
@@ -304,6 +319,13 @@ bool VNoteItem::haveText() const
 qint32 VNoteItem::voiceCount() const
 {
     qDebug() << "Getting voice count for note ID:" << noteId;
+    const QString meta = metaDataConstRef().toString();
+    if (TiptapDocumentExporter::isTiptapEnvelope(meta)) {
+        const qint32 count = TiptapDocumentExporter::voiceJsons(meta).size();
+        qInfo() << "Tiptap voice count retrieval finished, count:" << count;
+        return count;
+    }
+
     //老版本
     if (htmlCode.isEmpty()) {
         qint32 count = datas.voiceBlocks.size();
@@ -324,6 +346,13 @@ qint32 VNoteItem::voiceCount() const
 QStringList VNoteItem::getVoiceJsons() const
 {
     qDebug() << "Getting voice JSONs for note ID:" << noteId;
+    const QString meta = metaDataConstRef().toString();
+    if (TiptapDocumentExporter::isTiptapEnvelope(meta)) {
+        const QStringList list = TiptapDocumentExporter::voiceJsons(meta);
+        qDebug() << "Found" << list.size() << "Tiptap voice JSONs";
+        return list;
+    }
+
     QRegularExpression rx("<div.+jsonkey.+>");
     QRegularExpression rxJson("\\{.*\\}");
     QStringList list;
@@ -348,6 +377,11 @@ QStringList VNoteItem::getVoiceJsons() const
 QString VNoteItem::getFullHtml() const
 {
     qDebug() << "Generating full HTML for note ID:" << noteId;
+    const QString meta = metaDataConstRef().toString();
+    if (TiptapDocumentExporter::isTiptapEnvelope(meta)) {
+        return TiptapDocumentExporter::toHtml(meta);
+    }
+
     //html字符串
     QString html = htmlHead;
 

--- a/src/search/searchindexmanager.cpp
+++ b/src/search/searchindexmanager.cpp
@@ -6,6 +6,7 @@
 
 #include "searchdocumentextractor.h"
 #include "searchtextnormalizer.h"
+#include "utils.h"
 #include "vnoteitem.h"
 
 #include <QCollator>
@@ -219,23 +220,7 @@ int SearchIndexManager::fieldWeight(SearchField field)
 
 QString SearchIndexManager::highlightedHtml(const QString &text, const QString &query)
 {
-    if (query.isEmpty() || text.isEmpty()) {
-        return text.toHtmlEscaped();
-    }
-
-    QString html;
-    int pos = 0;
-    int match = text.indexOf(query, pos, Qt::CaseInsensitive);
-    while (match >= 0) {
-        html += text.mid(pos, match - pos).toHtmlEscaped();
-        html += QStringLiteral("<span style=\"color: #0058de;\">")
-            + text.mid(match, query.size()).toHtmlEscaped()
-            + QStringLiteral("</span>");
-        pos = match + query.size();
-        match = text.indexOf(query, pos, Qt::CaseInsensitive);
-    }
-    html += text.mid(pos).toHtmlEscaped();
-    return html;
+    return Utils::createRichText(text, query);
 }
 
 QString SearchIndexManager::snippetHtml(const QString &text, const QString &query)

--- a/src/task/exportnoteworker.cpp
+++ b/src/task/exportnoteworker.cpp
@@ -9,6 +9,7 @@
 #include "common/metadataparser.h"
 #include "common/setting.h"
 #include "common/utils.h"
+#include "common/tiptapdocumentexporter.h"
 
 #include <DLog>
 
@@ -144,7 +145,11 @@ ExportNoteWorker::ExportError ExportNoteWorker::exportText()
                 return Savefailed; //保存失败
             }
             //富文本数据需要转换为纯文本
-            if (!noteData->htmlCode.isEmpty()) {
+            const QString meta = noteData->metaDataConstRef().toString();
+            if (TiptapDocumentExporter::isTiptapEnvelope(meta)) {
+                qDebug() << "Converting Tiptap envelope to plain text";
+                out.write(TiptapDocumentExporter::toPlainText(meta).toUtf8());
+            } else if (!noteData->htmlCode.isEmpty()) {
                 qDebug() << "Converting HTML content to plain text";
                 QTextDocument doc;
                 doc.setHtml(noteData->htmlCode);
@@ -186,7 +191,18 @@ ExportNoteWorker::ExportError ExportNoteWorker::exportAllVoice()
                 qDebug() << "Skipping note without voice content";
                 continue;
             }
-            if (noteData->htmlCode.isEmpty()) {
+            const QString meta = noteData->metaDataConstRef().toString();
+            if (TiptapDocumentExporter::isTiptapEnvelope(meta)) {
+                qDebug() << "Processing Tiptap note voice blocks";
+                for (const QString &voiceJson : TiptapDocumentExporter::voiceJsons(meta)) {
+                    error = exportOneVoice(voiceJson);
+                    //某一个保存失败则后续的不再进行保存操作
+                    if (Savefailed == error) {
+                        qWarning() << "Failed to export Tiptap voice block from JSON";
+                        return error;
+                    }
+                }
+            } else if (noteData->htmlCode.isEmpty()) {
                 qDebug() << "Processing plain text note voice blocks";
                 for (auto it : noteData->datas.datas) {
                     error = exportOneVoice(it);

--- a/tests/at/setup_voice_note_at.sh
+++ b/tests/at/setup_voice_note_at.sh
@@ -22,6 +22,21 @@ stop_app()
     killall -q "${APP_NAME}" 2>/dev/null || true
 }
 
+clean_qml_cache()
+{
+    # AT 每次安装/切换新包后，旧 QML 磁盘缓存可能继续引用旧组件名，
+    # 导致 QML 引擎加载失败并被 youqu 误报为“应用程序未启动”。
+    # 清理当前应用缓存并禁用本次进程的 QML disk cache，保证读取最新 qrc 资源。
+    local cache_dir="${HOME}/.cache/deepin/${APP_NAME}/qmlcache"
+
+    if [[ -d "${cache_dir}" ]]; then
+        echo "Clean QML cache: ${cache_dir}"
+        rm -rf -- "${cache_dir}"
+    fi
+
+    export QML_DISABLE_DISK_CACHE=1
+}
+
 wait_for_schema()
 {
     local table_count
@@ -62,6 +77,7 @@ if [[ ! -f "${FIXTURE_DB}" ]]; then
 fi
 
 stop_app
+clean_qml_cache
 rm -rf -- "${DATA_DIR}" "${CONFIG_DIR}"
 mkdir -p -- "${DATA_DIR}" "${CONFIG_DIR}"
 

--- a/tests/src/common/ut_misc_common_coverage.cpp
+++ b/tests/src/common/ut_misc_common_coverage.cpp
@@ -19,8 +19,10 @@
 #include <gtest/gtest.h>
 
 #include <QBuffer>
+#include <QEventLoop>
 #include <QImage>
 #include <QObject>
+#include <QTimer>
 #include <QVariant>
 
 #include <vlc/vlc.h>
@@ -69,7 +71,15 @@ TEST(MigrationViewControllerCoverage, start_withNullOrchestrator_rollBackCleanly
     ctrl->m_migrationActive = false;
     ctrl->m_orchestrator = nullptr;           // ensure early-return not taken
     ctrl->start();
-    // After rollback migrationActive must be false.
+
+    // start() schedules MigrationOrchestrator::startIfNeeded via
+    // QTimer::singleShot(0), so wait one event-loop turn before checking the
+    // rollback state.
+    QEventLoop loop;
+    QTimer::singleShot(0, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    // After queued rollback migrationActive must be false.
     EXPECT_FALSE(ctrl->m_migrationActive);
 
     qputenv("DVN_TIPTAP_DEBUG", oldDebugEnv);

--- a/tests/src/common/ut_tiptapdocumentexporter.cpp
+++ b/tests/src/common/ut_tiptapdocumentexporter.cpp
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "common/tiptapdocumentexporter.h"
+#include "common/vnoteitem.h"
+#include "task/exportnoteworker.h"
+
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFile>
+#include <QImage>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+namespace {
+
+QJsonObject textNode(const QString &text, const QJsonArray &marks = QJsonArray())
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("text"));
+    node.insert(QStringLiteral("text"), text);
+    if (!marks.isEmpty()) {
+        node.insert(QStringLiteral("marks"), marks);
+    }
+    return node;
+}
+
+QJsonObject mark(const QString &type, const QJsonObject &attrs = QJsonObject())
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), type);
+    if (!attrs.isEmpty()) {
+        node.insert(QStringLiteral("attrs"), attrs);
+    }
+    return node;
+}
+
+QJsonObject paragraph(const QJsonArray &content)
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("paragraph"));
+    node.insert(QStringLiteral("content"), content);
+    return node;
+}
+
+QJsonObject heading(int level, const QString &text)
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("level"), level);
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("heading"));
+    node.insert(QStringLiteral("attrs"), attrs);
+    node.insert(QStringLiteral("content"), QJsonArray { textNode(text) });
+    return node;
+}
+
+QJsonObject blockNode(const QString &type, const QJsonArray &content = QJsonArray(), const QJsonObject &attrs = QJsonObject())
+{
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), type);
+    if (!attrs.isEmpty()) {
+        node.insert(QStringLiteral("attrs"), attrs);
+    }
+    if (!content.isEmpty()) {
+        node.insert(QStringLiteral("content"), content);
+    }
+    return node;
+}
+
+QJsonObject listItem(const QJsonArray &content)
+{
+    return blockNode(QStringLiteral("listItem"), content);
+}
+
+QJsonObject taskItem(bool checked, const QString &text)
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("checked"), checked);
+    return blockNode(QStringLiteral("taskItem"), QJsonArray { paragraph(QJsonArray { textNode(text) }) }, attrs);
+}
+
+QJsonObject nestedBulletList()
+{
+    return blockNode(QStringLiteral("bulletList"), QJsonArray {
+        listItem(QJsonArray {
+            paragraph(QJsonArray { textNode(QStringLiteral("父项")) }),
+            blockNode(QStringLiteral("bulletList"), QJsonArray {
+                listItem(QJsonArray { paragraph(QJsonArray { textNode(QStringLiteral("子项")) }) }),
+            }),
+        }),
+    });
+}
+
+QJsonObject taskList()
+{
+    return blockNode(QStringLiteral("taskList"), QJsonArray {
+        taskItem(true, QStringLiteral("任务完成")),
+    });
+}
+
+QJsonObject imageNode(const QString &relPath, const QString &alt, const QString &title)
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("src"), relPath);
+    attrs.insert(QStringLiteral("relPath"), relPath);
+    attrs.insert(QStringLiteral("alt"), alt);
+    attrs.insert(QStringLiteral("title"), title);
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("image"));
+    node.insert(QStringLiteral("attrs"), attrs);
+    return node;
+}
+
+QJsonObject voiceNode()
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("voiceId"), QStringLiteral("voice-export-1"));
+    attrs.insert(QStringLiteral("voicePath"), QStringLiteral("voicenote/export.mp3"));
+    attrs.insert(QStringLiteral("voiceSize"), 1234);
+    attrs.insert(QStringLiteral("createTime"), QStringLiteral("2026-08-29 10:00:00"));
+    attrs.insert(QStringLiteral("title"), QStringLiteral("会议录音"));
+    attrs.insert(QStringLiteral("text"), QStringLiteral("语音转写结果\n第二行"));
+    attrs.insert(QStringLiteral("translateUnfold"), false);
+    attrs.insert(QStringLiteral("playing"), true);
+    attrs.insert(QStringLiteral("progress"), 99);
+    attrs.insert(QStringLiteral("translating"), true);
+    QJsonObject node;
+    node.insert(QStringLiteral("type"), QStringLiteral("voiceBlock"));
+    node.insert(QStringLiteral("attrs"), attrs);
+    return node;
+}
+
+QString sampleEnvelope()
+{
+    QJsonObject colorAttrs;
+    colorAttrs.insert(QStringLiteral("color"), QStringLiteral("#123456"));
+
+    QJsonObject doc;
+    doc.insert(QStringLiteral("type"), QStringLiteral("doc"));
+    doc.insert(QStringLiteral("content"), QJsonArray {
+                   heading(2, QStringLiteral("导出标题")),
+                   paragraph(QJsonArray { textNode(QStringLiteral("正文")),
+                                          textNode(QStringLiteral("加粗"), QJsonArray { mark(QStringLiteral("bold")) }),
+                                          textNode(QStringLiteral("彩色"), QJsonArray { mark(QStringLiteral("color"), colorAttrs) }) }),
+                   nestedBulletList(),
+                   taskList(),
+                   paragraph(QJsonArray { imageNode(QStringLiteral("images/export-test.png"), QStringLiteral("截图Alt"), QStringLiteral("截图标题")) }),
+                   voiceNode(),
+               });
+
+    QJsonObject envelope;
+    envelope.insert(QStringLiteral("format"), QStringLiteral("tiptap"));
+    envelope.insert(QStringLiteral("schemaVersion"), 1);
+    envelope.insert(QStringLiteral("content"), doc);
+    return QString::fromUtf8(QJsonDocument(envelope).toJson(QJsonDocument::Compact));
+}
+
+void prepareImageFixture()
+{
+    const QString dirPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                            + QStringLiteral("/images");
+    QDir().mkpath(dirPath);
+    QImage image(2, 2, QImage::Format_ARGB32);
+    image.fill(Qt::red);
+    image.save(dirPath + QStringLiteral("/export-test.png"), "PNG");
+}
+
+void prepareVoiceFixture()
+{
+    const QString dirPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                            + QStringLiteral("/voicenote");
+    QDir().mkpath(dirPath);
+    QFile file(dirPath + QStringLiteral("/export.mp3"));
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    ASSERT_EQ(file.write("voice-data"), qint64(10));
+}
+
+QList<VNoteItem *> tiptapNoteList(VNoteItem *note)
+{
+    note->noteTitle = QStringLiteral("tiptap-note");
+    note->metaDataRef() = sampleEnvelope();
+    return QList<VNoteItem *> { note };
+}
+
+} // namespace
+
+TEST(UT_TiptapDocumentExporter, plainTextExportsStructuredNodes)
+{
+    const QString text = TiptapDocumentExporter::toPlainText(sampleEnvelope());
+
+    EXPECT_TRUE(text.contains(QStringLiteral("导出标题")));
+    EXPECT_TRUE(text.contains(QStringLiteral("正文加粗彩色")));
+    EXPECT_TRUE(text.contains(QStringLiteral("- 父项\n  - 子项")));
+    EXPECT_TRUE(text.contains(QStringLiteral("[x] 任务完成")));
+    EXPECT_TRUE(text.contains(QStringLiteral("[图片: 截图标题]")));
+    EXPECT_TRUE(text.contains(QStringLiteral("语音转写结果\n第二行")));
+    EXPECT_FALSE(text.contains(QStringLiteral("[语音:")));
+    EXPECT_FALSE(text.contains(QStringLiteral("会议录音")));
+    EXPECT_FALSE(text.contains(QStringLiteral("playing")));
+    EXPECT_FALSE(text.contains(QStringLiteral("translateUnfold")));
+    EXPECT_FALSE(text.contains(QStringLiteral("translating")));
+}
+
+TEST(UT_TiptapDocumentExporter, htmlExportsImagesTranscriptAndMarks)
+{
+    prepareImageFixture();
+
+    const QString html = TiptapDocumentExporter::toHtml(sampleEnvelope());
+
+    EXPECT_TRUE(html.contains(QStringLiteral("<h2>导出标题</h2>")));
+    EXPECT_TRUE(html.contains(QStringLiteral("<strong>加粗</strong>")));
+    EXPECT_TRUE(html.contains(QStringLiteral("style=\"color:#123456\"")));
+    EXPECT_TRUE(html.contains(QStringLiteral("<ul><li><p>父项</p><ul><li><p>子项</p></li></ul></li></ul>")));
+    EXPECT_TRUE(html.contains(QStringLiteral("data-type=\"taskItem\" data-checked=\"true\"")));
+    EXPECT_TRUE(html.contains(QStringLiteral("<img")));
+    EXPECT_TRUE(html.contains(QStringLiteral("src=\"data:image/png;base64,")));
+    EXPECT_TRUE(html.contains(QStringLiteral("alt=\"截图Alt\"")));
+    EXPECT_TRUE(html.contains(QStringLiteral("class=\"voiceBox\"")));
+    EXPECT_TRUE(html.contains(QStringLiteral("语音转写结果<br>第二行")));
+    EXPECT_FALSE(html.contains(QStringLiteral("playing")));
+    EXPECT_FALSE(html.contains(QStringLiteral("progress")));
+    EXPECT_FALSE(html.contains(QStringLiteral("translateUnfold")));
+    EXPECT_FALSE(html.contains(QStringLiteral("translating")));
+}
+
+TEST(UT_TiptapDocumentExporter, voiceJsonsExportPersistedFieldsOnly)
+{
+    const QStringList voices = TiptapDocumentExporter::voiceJsons(sampleEnvelope());
+    ASSERT_EQ(voices.size(), 1);
+
+    const QJsonObject voice = QJsonDocument::fromJson(voices.first().toUtf8()).object();
+    EXPECT_EQ(voice.value(QStringLiteral("type")).toInt(), 2);
+    EXPECT_EQ(voice.value(QStringLiteral("voiceId")).toString(), QStringLiteral("voice-export-1"));
+    EXPECT_EQ(voice.value(QStringLiteral("voicePath")).toString(), QStringLiteral("voicenote/export.mp3"));
+    EXPECT_EQ(voice.value(QStringLiteral("title")).toString(), QStringLiteral("会议录音"));
+    EXPECT_EQ(voice.value(QStringLiteral("text")).toString(), QStringLiteral("语音转写结果\n第二行"));
+    EXPECT_TRUE(voice.value(QStringLiteral("state")).toBool());
+    EXPECT_FALSE(voice.contains(QStringLiteral("playing")));
+    EXPECT_FALSE(voice.contains(QStringLiteral("progress")));
+    EXPECT_FALSE(voice.contains(QStringLiteral("translateUnfold")));
+    EXPECT_FALSE(voice.contains(QStringLiteral("translating")));
+}
+
+TEST(UT_TiptapDocumentExporter, vnoteItemUsesTiptapExportSemantics)
+{
+    VNoteItem note;
+    note.metaDataRef() = sampleEnvelope();
+
+    EXPECT_TRUE(note.haveText());
+    EXPECT_TRUE(note.haveVoice());
+    EXPECT_EQ(note.voiceCount(), 1);
+    EXPECT_EQ(note.getVoiceJsons().size(), 1);
+    EXPECT_TRUE(note.getFullHtml().contains(QStringLiteral("语音转写结果<br>第二行")));
+}
+
+
+TEST(UT_TiptapDocumentExporter, exportWorkerWritesTiptapPlainText)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    VNoteItem note;
+    ExportNoteWorker worker(dir.path(), ExportNoteWorker::ExportText, tiptapNoteList(&note));
+
+    EXPECT_EQ(worker.exportText(), ExportNoteWorker::ExportOK);
+
+    QFile file(dir.filePath(QStringLiteral("tiptap-note.txt")));
+    ASSERT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString text = QString::fromUtf8(file.readAll());
+    EXPECT_TRUE(text.contains(QStringLiteral("正文加粗彩色")));
+    EXPECT_TRUE(text.contains(QStringLiteral("[图片: 截图标题]")));
+    EXPECT_TRUE(text.contains(QStringLiteral("语音转写结果")));
+    EXPECT_FALSE(text.contains(QStringLiteral("[语音:")));
+    EXPECT_FALSE(text.contains(QStringLiteral("会议录音")));
+    EXPECT_FALSE(text.contains(QStringLiteral("playing")));
+}
+
+TEST(UT_TiptapDocumentExporter, exportWorkerWritesTiptapStandaloneHtml)
+{
+    prepareImageFixture();
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    VNoteItem note;
+    ExportNoteWorker worker(dir.path(), ExportNoteWorker::ExportHtml, tiptapNoteList(&note));
+
+    EXPECT_EQ(worker.exportAsHtml(), ExportNoteWorker::ExportOK);
+
+    QFile file(dir.filePath(QStringLiteral("tiptap-note.html")));
+    ASSERT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString html = QString::fromUtf8(file.readAll());
+    EXPECT_TRUE(html.startsWith(QStringLiteral("<!DOCTYPE html>")));
+    EXPECT_TRUE(html.contains(QStringLiteral("src=\"data:image/png;base64,")));
+    EXPECT_TRUE(html.contains(QStringLiteral("class=\"voiceBox\"")));
+    EXPECT_TRUE(html.contains(QStringLiteral("语音转写结果<br>第二行")));
+    EXPECT_FALSE(html.contains(QStringLiteral("progress")));
+}
+
+TEST(UT_TiptapDocumentExporter, exportWorkerCopiesTiptapVoiceFile)
+{
+    prepareVoiceFixture();
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    VNoteItem note;
+    ExportNoteWorker worker(dir.path(), ExportNoteWorker::ExportVoice, tiptapNoteList(&note));
+
+    EXPECT_EQ(worker.exportAllVoice(), ExportNoteWorker::ExportOK);
+
+    QFile file(dir.filePath(QStringLiteral("会议录音.mp3")));
+    ASSERT_TRUE(file.open(QIODevice::ReadOnly));
+    EXPECT_EQ(file.readAll(), QByteArray("voice-data"));
+}
+
+TEST(UT_TiptapDocumentExporter, htmlDropsUnsafeImageSrcFallbacks)
+{
+    QJsonObject attrs;
+    attrs.insert(QStringLiteral("src"), QStringLiteral("java\nscript:alert(1)"));
+    attrs.insert(QStringLiteral("relPath"), QStringLiteral("../secret.png"));
+    attrs.insert(QStringLiteral("alt"), QStringLiteral("bad"));
+
+    QJsonObject image;
+    image.insert(QStringLiteral("type"), QStringLiteral("image"));
+    image.insert(QStringLiteral("attrs"), attrs);
+
+    QJsonObject doc;
+    doc.insert(QStringLiteral("type"), QStringLiteral("doc"));
+    doc.insert(QStringLiteral("content"), QJsonArray { paragraph(QJsonArray { image }) });
+
+    QJsonObject envelope;
+    envelope.insert(QStringLiteral("format"), QStringLiteral("tiptap"));
+    envelope.insert(QStringLiteral("schemaVersion"), 1);
+    envelope.insert(QStringLiteral("content"), doc);
+
+    const QString html = TiptapDocumentExporter::toHtml(QString::fromUtf8(QJsonDocument(envelope).toJson(QJsonDocument::Compact)));
+
+    EXPECT_FALSE(html.contains(QStringLiteral("javascript"), Qt::CaseInsensitive));
+    EXPECT_FALSE(html.contains(QStringLiteral("secret.png")));
+    EXPECT_FALSE(html.contains(QStringLiteral("<img")));
+}

--- a/tests/src/common/ut_utils_ext.cpp
+++ b/tests/src/common/ut_utils_ext.cpp
@@ -148,7 +148,9 @@ TEST(UtilsExt, filteredFileName)
 TEST(UtilsExt, richTextAndHtml)
 {
     QString rt = Utils::createRichText("title key", "key");
-    EXPECT_NE(-1, rt.indexOf("<span style=\"color: #0058de;\">key</span>"));
+    EXPECT_NE(-1, rt.indexOf("<span style=\"color: "));
+    EXPECT_NE(-1, rt.indexOf("key</span>"));
+    EXPECT_EQ("title key", Utils::stripHtmlTags(rt));
     EXPECT_EQ("hello", Utils::stripHtmlTags("<b>hello</b>"));
 }
 


### PR DESCRIPTION
feat(export): support Tiptap document export
Add a shared Tiptap exporter for text, HTML, images, and voice data.

新增统一的 Tiptap 导出转换器，支持文本、HTML、图片和语音数据。

Wire Tiptap export paths into note item and export worker flows.

将 Tiptap 导出路径接入笔记项和导出任务流程。

Log: 支持 Tiptap 文档导出

PMS: TASK-393985

Influence: Tiptap 笔记可正确导出文本、图片、语音转写和语音文件，并避免导出运行态字段。

## Summary by Sourcery

Enable reliable export of Tiptap notes across text, HTML, and voice formats while preserving user content and excluding runtime state.

New Features:
- Add shared Tiptap document export support for plain text, standalone HTML, images, transcripts, and voice files.
- Integrate Tiptap content detection and export handling into note items and export worker workflows.

Bug Fixes:
- Exclude runtime-only voice state fields from exported content and metadata.
- Reject unsafe image sources and prevent invalid local paths from being emitted in HTML exports.

Enhancements:
- Reuse theme highlight colors for search and rich-text result highlighting.

Tests:
- Add coverage for Tiptap text, HTML, image, voice metadata, and worker export behavior.
- Stabilize voice-note AT setup by clearing stale QML caches and update asynchronous migration coverage.