### PR TITLE
fix(audio): correct microphone availability detection

### DIFF
--- a/src/audio/audio_watcher.cpp
+++ b/src/audio/audio_watcher.cpp
@@ -141,14 +141,19 @@ void AudioWatcher::updateDeviceEnabled(const QString cardsStr, bool isEmitSig)
             }
         }
     }
+    const bool oldInIsEnable = m_inIsEnable;
+    const bool oldOutIsEnable = m_outIsEnable;
+
     m_inAudioPort = currentAuidoPort(m_inAuidoPorts,Micphone);
-    m_inIsEnable = (m_inAudioPort.availability == 2 || m_inAudioPort.availability == 0)? true : false;
-    if (isEmitSig)
+    // m_inAuidoPorts 只保存 CardsWithoutUnavailable 中 Enabled=true 的输入端口，
+    // 设备是否可用应直接以该列表为准，避免 ActivePort.availability 的 D-Bus 解析异常影响判断。
+    m_inIsEnable = !m_inAuidoPorts.isEmpty();
+    if (isEmitSig && oldInIsEnable != m_inIsEnable)
         sigDeviceEnableChanged(Micphone, m_inIsEnable);
     m_outAudioPort = currentAuidoPort(m_outAuidoPorts,Internal);
-    // 此时应该使用 m_outAudioPort.availability 来判断是否启用
-    m_outIsEnable = (m_outAudioPort.availability == 2 || m_outAudioPort.availability == 0)? true : false;
-    if (isEmitSig)
+    // m_outAuidoPorts 只保存 CardsWithoutUnavailable 中 Enabled=true 的输出端口。
+    m_outIsEnable = !m_outAuidoPorts.isEmpty();
+    if (isEmitSig && oldOutIsEnable != m_outIsEnable)
         sigDeviceEnableChanged(Internal, m_outIsEnable);
 
     qInfo() << "Audio device status updated:"
@@ -166,18 +171,16 @@ AudioPort AudioWatcher::currentAuidoPort(const QList<AudioPort> &auidoPorts,Audi
     AudioPort currentAudioPort;
     if(auidoPorts.count()){
         qInfo() << "auidoPorts is not empty";
-        foreach (AudioPort audioPort, auidoPorts) {
-            AudioPort defaultAudioPort;
-            if(audioMode == AudioMode::Internal){
-                defaultAudioPort = defaultSinkActivePort();
-            }else{
-                defaultAudioPort = defaultSourceActivePort();
-            }
+        AudioPort defaultAudioPort;
+        if(audioMode == AudioMode::Internal){
+            defaultAudioPort = defaultSinkActivePort();
+        }else{
+            defaultAudioPort = defaultSourceActivePort();
+        }
+        foreach (const AudioPort &audioPort, auidoPorts) {
+            currentAudioPort = audioPort;
             if(audioPort.name ==  defaultAudioPort.name){
-                currentAudioPort = defaultAudioPort;
                 break;
-            }else{
-                currentAudioPort = audioPort;
             }
         }
     }else{

--- a/src/handler/voice_recoder_handler.cpp
+++ b/src/handler/voice_recoder_handler.cpp
@@ -152,7 +152,8 @@ bool VoiceRecoderHandler::checkVolume()
     return (volume - 0.2 < 0.0) ? true : false;
 }
 
-// 通过脚本获取默认音源输入信息。只有获取的是所给的降噪字段的时候才使用，其他依然走dbus的方式
+// 通过 pactl 获取 PulseAudio/PipeWire 当前默认输入源。
+// 返回有效非 monitor source 时可作为 D-Bus 异常场景的兜底；降噪源 echo-cancel-source 优先使用。
 QString VoiceRecoderHandler::tryGetMicNameFromPactl() const
 {
     qInfo() << "Attempting to get default source via 'pactl get-default-source'";
@@ -186,8 +187,8 @@ QString VoiceRecoderHandler::tryGetMicNameFromPactl() const
         return QString();
     }
 
-    if (commandOutput.isEmpty()) {
-        qWarning() << "'pactl get-default-source' returned empty output.";
+    if (commandOutput.isEmpty() || commandOutput == "null") {
+        qWarning() << "'pactl get-default-source' returned invalid output:" << commandOutput;
         return QString();
     }
 
@@ -204,22 +205,28 @@ QString VoiceRecoderHandler::tryGetMicNameFromPactl() const
 QString VoiceRecoderHandler::getDefaultMicDeviceName() const
 {
     qInfo() << "Getting default mic device name";
-    QString defaultName;
 
-    // 只有当m_currentMode是麦克风模式时，才尝试使用pactl获取默认音源
-    if (static_cast<AudioWatcher::AudioMode>(m_currentMode) == AudioWatcher::Micphone) {
-        defaultName = tryGetMicNameFromPactl();
-        if (defaultName == "echo-cancel-source") {
-            // 如果pactl获取到有效且非降噪字段，则使用它
-            qInfo() << "Default mic device name retrieval finished";
-            return defaultName;
-        }
+    const auto mode = static_cast<AudioWatcher::AudioMode>(m_currentMode);
+    if (mode != AudioWatcher::Micphone) {
+        QString deviceName = m_audioWatcher->getDeviceName(mode);
+        qInfo() << "Default mic device name retrieval finished";
+        return deviceName;
     }
 
-    // 否则，回退到使用m_audioWatcher获取设备名称
-    defaultName = m_audioWatcher->getDeviceName(static_cast<AudioWatcher::AudioMode>(m_currentMode));
-    qInfo() << "Default mic device name retrieval finished";
-    return defaultName;
+    const QString pactlName = tryGetMicNameFromPactl();
+    if (pactlName == "echo-cancel-source") {
+        qInfo() << "Default mic device name retrieval finished";
+        return pactlName;
+    }
+
+    QString dbusName = m_audioWatcher->getDeviceName(mode);
+    if (!dbusName.isEmpty()) {
+        qInfo() << "Default mic device name retrieval finished";
+        return dbusName;
+    }
+
+    qInfo() << "Default mic device name retrieval finished with pactl fallback";
+    return pactlName;
 }
 
 void VoiceRecoderHandler::confirmStartRecoder()


### PR DESCRIPTION
Use the enabled ports parsed from CardsWithoutUnavailable as the source of truth when updating input/output availability, instead of relying on ActivePort.availability returned by D-Bus. This avoids marking an existing microphone as unavailable when ActivePort deserialization is unstable.

Keep ActivePort only for selecting the current port name and emit device-enable changes only when the computed availability actually changes, reducing redundant UI updates without delayed retry logic.

Preserve the original microphone-device selection intent: use pactl immediately for echo-cancel-source, prefer D-Bus for normal sources, and fall back to pactl only when D-Bus returns an empty device. Also ignore invalid null/monitor sources.

修复麦克风存在但被误判不可用：设备可用性以 CardsWithoutUnavailable 中 Enabled=true 的端口列表为准，不再使用不稳定的 ActivePort.availability 覆盖；仅在状态真实变化时通知界面，避免依赖延时防抖。

录音设备选择保留原有意图：降噪源 echo-cancel-source 优先使用 pactl，普通场景优先 D-Bus，D-Bus 返回空时再用 pactl 兜底，并过滤 null/monitor 源。

Log: 修复麦克风被误判不可用导致录音按钮异常

PMS: BUG-371001

Influence: 麦克风启用状态根据音频服务上报的 Enabled 端口稳定判断，避免有麦克风时录音按钮误禁用；录音输入源选择在 D-Bus 异常为空时可使用 pactl 兜底，降噪和普通录音场景保持正常。

## Summary by Sourcery

Correct audio device availability and recording-source resolution to prevent microphones from being incorrectly disabled.

Bug Fixes:
- Use enabled audio ports as the source of truth for microphone and internal audio availability, preventing valid microphones from being marked unavailable.
- Preserve reliable recording-source selection by prioritizing echo-cancel sources through pactl, preferring D-Bus for normal sources, and falling back to pactl when D-Bus is empty or invalid.
- Ignore null and monitor sources when resolving the default recording device.

Enhancements:
- Emit device availability updates only when the computed state changes, reducing redundant UI notifications.