### PR TITLE
fix(atspi): expose voice note controls for automation

### DIFF
--- a/src/gui/VNoteToolButton.qml
+++ b/src/gui/VNoteToolButton.qml
@@ -17,7 +17,9 @@ import org.deepin.dtk 1.0
  */
 ToolButton {
     id: root
-    Accessible.name: "VNoteToolButton"
+    // Base component template is not a runtime locator; concrete instances
+    // provide their own Accessible.name and opt back into accessibility.
+    Accessible.ignored: true
 
     activeFocusOnTab: true
     display: text.length > 0 ? AbstractButton.TextBesideIcon : AbstractButton.IconOnly
@@ -26,7 +28,7 @@ ToolButton {
 
     background: VNoteButtonBackground {
         Accessible.name: "VNoteToolButtonBackground"
-        Accessible.role: Accessible.Panel
+        Accessible.role: Accessible.Pane
         button: root
     }
 

--- a/src/gui/mainwindow/FolderListView.qml
+++ b/src/gui/mainwindow/FolderListView.qml
@@ -288,7 +288,7 @@ Item {
 
     DragControl {
         Accessible.name: "FolderDragControl"
-        Accessible.role: Accessible.Panel
+        Accessible.role: Accessible.Pane
         id: dragControl
 
     }

--- a/src/gui/mainwindow/InitialInterface.qml
+++ b/src/gui/mainwindow/InitialInterface.qml
@@ -31,7 +31,7 @@ Item {
 
         menu: TitleBarMenu {
             Accessible.name: "InitialInterfaceTitleBarMenu"
-            Accessible.role: Accessible.Menu
+            Accessible.role: Accessible.PopupMenu
             onOpenPrivacy: {
                 VNoteMainManager.showPrivacy();
             }

--- a/src/gui/mainwindow/ItemListView.qml
+++ b/src/gui/mainwindow/ItemListView.qml
@@ -387,7 +387,7 @@ Item {
 
     DragControl {
         Accessible.name: "ItemListDragControl"
-        Accessible.role: Accessible.Panel
+        Accessible.role: Accessible.Pane
 
         id: dragControl
 
@@ -624,7 +624,7 @@ Item {
 
     VNoteRightMenu {
         Accessible.name: "NoteContextMenu"
-        Accessible.role: Accessible.Menu
+        Accessible.role: Accessible.PopupMenu
 
         id: noteCtxMenu
 

--- a/src/gui/mainwindow/MainWindow.qml
+++ b/src/gui/mainwindow/MainWindow.qml
@@ -14,6 +14,8 @@ import org.deepin.dtk 1.0
 
 Item {
     id: rootWindow
+    Accessible.name: "VoiceNoteMainWindow"
+    Accessible.role: Accessible.Pane
 
     anchors.fill: parent
 
@@ -99,7 +101,7 @@ Item {
 
     Shortcuts {
         Accessible.name: "MainShortcuts"
-        Accessible.role: Accessible.Panel
+        Accessible.role: Accessible.Pane
 
         id: shortcuts
 
@@ -537,6 +539,7 @@ Item {
 
     VNoteComponents.VNoteToolButton {
         Accessible.name: "TwoColumnModeButton"
+        Accessible.ignored: false
         Accessible.role: Accessible.Button
 
         id: twoColumnModeBtn
@@ -563,7 +566,7 @@ Item {
     // 全窗级毛玻璃：左侧文件夹栏 + 笔记列表区域透明可见，列表项保持实色卡片
     VNoteComponents.SidebarBlurBackground {
         Accessible.name: "SidebarBlurBackground"
-        Accessible.role: Accessible.Panel
+        Accessible.role: Accessible.Pane
 
         anchors.fill: parent
         windowControl: Window.window
@@ -791,6 +794,7 @@ Item {
 
                 VNoteComponents.VNoteToolButton {
                     Accessible.name: "ToolBarMoreButton"
+                    Accessible.ignored: false
                     Accessible.role: Accessible.Button
 
                     Layout.alignment: Text.AlignRight
@@ -923,6 +927,7 @@ Item {
 
                     VNoteComponents.VNoteToolButton {
                         Accessible.name: "NewNoteButton"
+                        Accessible.ignored: false
                         Accessible.role: Accessible.Button
 
                         id: newNoteBtn
@@ -1063,7 +1068,7 @@ Item {
 
                 WebEngineView {
                     Accessible.name: "NoteContentWebView"
-                    Accessible.role: Accessible.Panel
+                    Accessible.role: Accessible.Pane
 
                     id: webEngineView
 
@@ -1219,7 +1224,7 @@ Item {
 
             InitialInterface {
                 Accessible.name: "InitialInterface"
-                Accessible.role: Accessible.Panel
+                Accessible.role: Accessible.Pane
 
                 id: initiaInterface
 

--- a/src/gui/mainwindow/MultipleChoices.qml
+++ b/src/gui/mainwindow/MultipleChoices.qml
@@ -67,6 +67,7 @@ Item {
 
                     VNoteComponents.VNoteToolButton {
                         Accessible.name: "MoveButton"
+                        Accessible.ignored: false
                         Accessible.role: Accessible.Button
                         icon.name: "move_note"
                         implicitHeight: 40
@@ -81,6 +82,7 @@ Item {
 
                     VNoteComponents.VNoteToolButton {
                         Accessible.name: "SaveNoteButton"
+                        Accessible.ignored: false
                         Accessible.role: Accessible.Button
                         icon.name: "save_note"
                         implicitHeight: 40
@@ -96,6 +98,7 @@ Item {
 
                     VNoteComponents.VNoteToolButton {
                         Accessible.name: "SaveVoiceButton"
+                        Accessible.ignored: false
                         Accessible.role: Accessible.Button
                         icon.name: "save_audio"
                         implicitHeight: 40
@@ -112,6 +115,7 @@ Item {
 
                     VNoteComponents.VNoteToolButton {
                         Accessible.name: "DeleteButton"
+                        Accessible.ignored: false
                         Accessible.role: Accessible.Button
                         icon.name: "delete"
                         implicitHeight: 40

--- a/src/gui/mainwindow/RecordingView.qml
+++ b/src/gui/mainwindow/RecordingView.qml
@@ -77,6 +77,7 @@ FocusScope {
 
         VNoteComponents.VNoteToolButton {
             Accessible.name: "PauseButton"
+            Accessible.ignored: false
             Accessible.role: Accessible.Button
             id: pauseBtn
 
@@ -113,6 +114,7 @@ FocusScope {
 
         VNoteComponents.VNoteToolButton {
             Accessible.name: "StopButton"
+            Accessible.ignored: false
             Accessible.role: Accessible.Button
             id: stopBtn
 

--- a/src/gui/mainwindow/TitleBarMenu.qml
+++ b/src/gui/mainwindow/TitleBarMenu.qml
@@ -4,6 +4,7 @@ import org.deepin.dtk 1.0
 
 Menu {
     Accessible.name: "TitleBarMenu"
+    Accessible.role: Accessible.PopupMenu
     signal openPrivacy
     signal openSetting
 
@@ -13,6 +14,7 @@ Menu {
 
     MenuItem {
         Accessible.name: "SettingsMenuItem"
+        Accessible.onPressAction: settingsControl.triggered()
         id: settingsControl
 
         text: qsTr("Settings")
@@ -28,6 +30,7 @@ Menu {
 
     MenuItem {
         Accessible.name: "PrivacyPolicyMenuItem"
+        Accessible.onPressAction: privacyBtn.triggered()
         id: privacyBtn
 
         text: qsTr("Privacy Policy")
@@ -68,6 +71,8 @@ Menu {
 
     MenuItem {
         Accessible.name: "ExitMenuItem"
+        Accessible.onPressAction: exitControl.triggered()
+        id: exitControl
         text: qsTr("Exit")
         onTriggered: {
             var win = ApplicationWindow.window;

--- a/src/gui/mainwindow/VNoteRightMenu.qml
+++ b/src/gui/mainwindow/VNoteRightMenu.qml
@@ -9,7 +9,6 @@ import org.deepin.dtk 1.0
 
 // 动态创建不同类型的右键菜单
 Menu {
-    Accessible.name: "NoteRightMenu"
     id: rightMenu
 
     // 菜单类型 ActionManager::MenuType
@@ -138,7 +137,6 @@ Menu {
         id: menuCreator
 
         Menu {
-            Accessible.name: "CtxSubMenu"
             property int menuId: 0
 
             height: visible ? implicitHeight : 0
@@ -149,7 +147,9 @@ Menu {
         id: menuItemCreator
 
         MenuItem {
-            Accessible.name: ActionManager.actionText(menuId)
+            id: menuItem
+            Accessible.name: ActionManager.actionText(menuItem.menuId)
+            Accessible.onPressAction: menuItem.triggered()
             property int menuId: 0
 
             height: visible ? implicitHeight : 0

--- a/src/gui/mainwindow/WebEngineView.qml
+++ b/src/gui/mainwindow/WebEngineView.qml
@@ -557,7 +557,7 @@ Item {
 
             WindowTitleBar {
                 Accessible.name: "WebViewTitleBar"
-                Accessible.role: Accessible.Panel
+                Accessible.role: Accessible.Pane
 
                 id: title
 
@@ -600,8 +600,7 @@ Item {
             color: DTK.themeType === ApplicationHelper.LightType ? "#FFFFFF" : "#242424"
 
             WebEngineView {
-                Accessible.name: "WebView"
-                Accessible.role: Accessible.Panel
+                Accessible.ignored: true
 
                 id: webView
 
@@ -762,12 +761,13 @@ Item {
             onYChanged: rootItem.scheduleTiptapToolbarSeparatorSync()
 
             sourceComponent: Item {
+                Accessible.name: "TiptapWebView"
+                Accessible.role: Accessible.Pane
                 property WebEngineView editor: tiptapWebView
                 anchors.fill: parent
 
                 WebEngineView {
-                    Accessible.name: "TiptapWebView"
-                    Accessible.role: Accessible.Panel
+                    Accessible.ignored: true
 
                     id: tiptapWebView
 
@@ -916,7 +916,7 @@ Item {
 
             sourceComponent: MultipleChoices {
                 Accessible.name: "MultipleChoicesView"
-                Accessible.role: Accessible.Panel
+                Accessible.role: Accessible.Pane
 
                 anchors.fill: parent
 
@@ -1005,7 +1005,7 @@ Item {
 
         VNoteRightMenu {
             Accessible.name: "PictureContextMenu"
-            Accessible.role: Accessible.Menu
+            Accessible.role: Accessible.PopupMenu
 
             id: picturCtxMenu
 
@@ -1034,7 +1034,7 @@ Item {
 
         VNoteRightMenu {
             Accessible.name: "VoiceContextMenu"
-            Accessible.role: Accessible.Menu
+            Accessible.role: Accessible.PopupMenu
 
             id: voiceCtxMenu
 
@@ -1067,7 +1067,7 @@ Item {
 
         VNoteRightMenu {
             Accessible.name: "TextContextMenu"
-            Accessible.role: Accessible.Menu
+            Accessible.role: Accessible.PopupMenu
 
             id: txtCtxMenu
 
@@ -1157,7 +1157,7 @@ Item {
 
         sourceComponent: RecordingView {
             Accessible.name: "RecordingBar"
-            Accessible.role: Accessible.Panel
+            Accessible.role: Accessible.Pane
 
             id: recordingBar
 

--- a/src/gui/mainwindow/WindowTitleBar.qml
+++ b/src/gui/mainwindow/WindowTitleBar.qml
@@ -37,7 +37,7 @@ TitleBar {
     }
     menu: TitleBarMenu {
         Accessible.name: "TitleBarMenu"
-        Accessible.role: Accessible.Menu
+        Accessible.role: Accessible.PopupMenu
         id: tMenu
 
         onOpenPrivacy: {

--- a/src/main.qml
+++ b/src/main.qml
@@ -15,9 +15,6 @@ import org.deepin.dtk 1.0
 ApplicationWindow {
     id: rootWindow
 
-    Accessible.name: "VoiceNoteMainWindow"
-    Accessible.role: Accessible.Window
-
     property bool workspaceActive: workspaceLoader.active
     property bool createFirstNotebook: false
     property bool isRecording: workspaceLoader.item ? workspaceLoader.item.isRecording : false


### PR DESCRIPTION
Add stable accessible names for QML controls used by AT suites.

为自动化用例补充QML控件的稳定可访问名称。

Log: 补充语音记事本AT-SPI控件名称

Influence: 提升YouQu通过AT-SPI定位控件的稳定性，不改变业务逻辑。

## Summary by Sourcery

Improve AT-SPI automation support by providing stable accessible controls, roles, and actions throughout the voice note interface.

New Features:
- Expose stable, automation-friendly accessible names for the voice note window, controls, menus, and menu items.
- Enable AT-SPI actions for menu items and dynamically generated context-menu items.

Bug Fixes:
- Improve AT-SPI control discovery by excluding non-interactive template and embedded web-view objects from the accessibility tree.

Enhancements:
- Normalize accessibility roles for panes and popup menus across the QML interface.
- Move accessible identification of embedded web content to its containing wrapper elements.