### PR TITLE
fix: 修复播放语音后Ctrl+C/X/V在Web编辑器中失效的问题

### DIFF
--- a/src/views/vnoterecordbar.cpp
+++ b/src/views/vnoterecordbar.cpp
@@ -184,8 +184,6 @@ void VNoteRecordBar::onClosePlayWidget(VNVoiceBlock *voiceData)
  */
 void VNoteRecordBar::playVoice(VNVoiceBlock *voiceData, bool bIsSame)
 {
-    //焦点切换到当前窗口，响应播放快捷键
-    setFocus();
     m_mainLayout->setCurrentWidget(m_playPanel);
     m_playPanel->playVoice(voiceData, bIsSame);
 }


### PR DESCRIPTION
fix: 修复播放语音后Ctrl+C/X/V在Web编辑器中失效的问题

Description: VNoteRecordBar::playVoice()中的setFocus()将焦点从WebRichTextEditor
转移到VNoteRecordBar，导致播放结束后键盘事件无法到达Web引擎，Ctrl+C/X/V失效。
空格播放快捷键已配置为Qt::ApplicationShortcut，不依赖VNoteRecordBar持有焦点，
因此setFocus()是冗余操作，删除即可恢复Web编辑器焦点。

Log: 删除VNoteRecordBar::playVoice()中不必要的setFocus()调用
Bug: https://pms.uniontech.com/bug-view-376089.html

## Summary by Sourcery

Bug Fixes:
- Restore Ctrl+C, Ctrl+X, and Ctrl+V functionality in the web editor after voice playback by preserving editor focus.